### PR TITLE
Fix spanish gerunds in index.html

### DIFF
--- a/doc/es/index.html.in
+++ b/doc/es/index.html.in
@@ -35,9 +35,9 @@
 	</div>
 	<div class="thirds">
 	  <h2>CUPS para administradores</h2>
-	  <p><a href="admin">A&ntilde;adiendo impresoras y clases</a></p>
-	  <p><a href="help/policies.html">Gestionando pol&iacute;ticas de funcionamiento</a></p>
-	  <p><a href="help/network.html">Usando impresoras de red</a></p>
+	  <p><a href="admin">A&ntilde;adir impresoras y clases</a></p>
+	  <p><a href="help/policies.html">Gesti&oacute;n de pol&iacute;ticas de funcionamiento</a></p>
+	  <p><a href="help/network.html">Uso de impresoras de red</a></p>
 	  <p><a href="help/man-cupsd.conf.html">Referencia de cupsd.conf</a></p>
 	</div>
 	<div class="thirds">


### PR DESCRIPTION
See the Debian bug: https://bugs.debian.org/821788 from Santiago Vila:

> The file doc/es/index.html.in is a translation of doc/index.html.in, but gerunds like "Using Network Printers" have been translated as "Usando [...]" (Spanish gerund, which is not the same as English gerund). English gerund is a noun, so it should be translated as such.
