### PR TITLE
Fix typo in cupsctl man webpage

### DIFF
--- a/doc/help/man-cupsctl.html
+++ b/doc/help/man-cupsctl.html
@@ -45,15 +45,15 @@ The following options are recognized:
 <dd style="margin-left: 5.0em">Specifies an alternate username to use when authenticating with the scheduler.
 <dt><b>-h </b><i>server</i>[<b>:</b><i>port</i>]
 <dd style="margin-left: 5.0em">Specifies the server address.
-<dt><b>--fR[fBno-fR]fBdebug-logging</b>
+<dt><b>--</b>[<b>no-</b>]<b>debug-logging</b>
 <dd style="margin-left: 5.0em">Enables (disables) debug logging to the <i>error_log</i> file.
-<dt><b>--fR[fBno-fR]fBremote-admin</b>
+<dt><b>--</b>[<b>no-</b>]<b>remote-admin</b>
 <dd style="margin-left: 5.0em">Enables (disables) remote administration.
-<dt><b>--fR[fBno-fR]fBremote-any</b>
+<dt><b>--</b>[<b>no-</b>]<b>remote-any</b>
 <dd style="margin-left: 5.0em">Enables (disables) printing from any address, e.g., the Internet.
-<dt><b>--fR[fBno-fR]fBshare-printers</b>
+<dt><b>--</b>[<b>no-</b>]<b>share-printers</b>
 <dd style="margin-left: 5.0em">Enables (disables) sharing of local printers with other computers.
-<dt><b>--fR[fBno-fR]fBuser-cancel-any</b>
+<dt><b>--</b>[<b>no-</b>]<b>user-cancel-any</b>
 <dd style="margin-left: 5.0em">Allows (prevents) users to cancel jobs owned by others.
 </dl>
 <h2 class="title"><a name="EXAMPLES">Examples</a></h2>


### PR DESCRIPTION
The typo / conversion error seems to have snuck in with CUPS 2.0