### PR TITLE
Increase the allocated buffer size for names of loaded PPDs (Issue #4860)

### DIFF
--- a/scheduler/cups-driverd.cxx
+++ b/scheduler/cups-driverd.cxx
@@ -2383,7 +2383,7 @@ load_ppds(const char *d,		/* I - Actual directory */
   char		filename[1024],		/* Name of PPD or directory */
 		line[256],		/* Line from file */
 		*ptr,			/* Pointer into name */
-		name[128];		/* Name of PPD file */
+		name[256];		/* Name of PPD file */
   ppd_info_t	*ppd,			/* New PPD file */
 		key;			/* Search key */
 


### PR DESCRIPTION
Having 128 characters is probably enough in most systems, but in Endless
we have a custom system in place to automatically download printer drivers
that will be accessible from long paths under /usr/share/ppd/eos-config-printer
(e.g. /usr/share/ppd/eos-config-printer/epson-inkjet-printer-201301w_ppds_Epson)

As this path will become part of the virtual path for the PPD, this limit
will cause trouble in cases where the full PPD name exceeds it, since the
path CUPS will try to open will not exist, as it will be truncated.