### PR TITLE
Fix some manpage formatting inconsistencies

### DIFF
--- a/man/backend.man
+++ b/man/backend.man
@@ -69,7 +69,7 @@ Back-channel data from the device should be relayed to the job filters using the
 Backends are responsible for reading side-channel requests using the
 .BR cupsSideChannelRead ()
 function and responding with the
-.BR cupsSideChannelWrite()
+.BR cupsSideChannelWrite ()
 function. The
 .B CUPS_SC_FD
 constant defines the file descriptor that should be monitored for incoming requests.

--- a/man/backend.man
+++ b/man/backend.man
@@ -170,7 +170,7 @@ The device URI associated with the printer.
 .SH FILES
 .I /etc/cups/cups-files.conf
 .SH NOTES
-CUPS backends are not generally design to be run directly by the user. Aside from the device URI issue (
+CUPS backends are not generally designed to be run directly by the user. Aside from the device URI issue (
 .I argv[0]
 and
 .B DEVICE_URI

--- a/man/client.conf.man.in
+++ b/man/client.conf.man.in
@@ -51,7 +51,7 @@ CUPS adds the remote hostname ("name@server.example.com") for you. The default n
 .TP 5
 \fBServerName \fI/domain/socket\fR
 Specifies the address and optionally the port to use when connecting to the server.
-\fBNote: This directive it not supported on macOS 10.7 or later.\fR
+\fBNote: This directive is not supported on macOS 10.7 or later.\fR
 .TP 5
 \fBServerName \fIhostname-or-ip-address\fR[\fI:port\fR]\fB/version=1.1\fR
 Specifies the address and optionally the port to use when connecting to a server running CUPS 1.3.12 and earlier.

--- a/man/cups-lpd.man.in
+++ b/man/cups-lpd.man.in
@@ -103,9 +103,7 @@ program to register the changes to the \fIinetd.conf\fR file.
 CUPS includes configuration files for
 .BR launchd (8),
 .BR systemd (8),
-and
-.BR xinetd(8).
-Simply enable the
+and \fBxinetd(8)\fR. Simply enable the
 .B cups-lpd
 service using the corresponding control program.
 .SH SEE ALSO

--- a/man/cups-lpd.man.in
+++ b/man/cups-lpd.man.in
@@ -103,7 +103,9 @@ program to register the changes to the \fIinetd.conf\fR file.
 CUPS includes configuration files for
 .BR launchd (8),
 .BR systemd (8),
-and \fBxinetd(8)\fR. Simply enable the
+and
+.BR xinetd (8).
+Simply enable the
 .B cups-lpd
 service using the corresponding control program.
 .SH SEE ALSO

--- a/man/cupsd.conf.man.in
+++ b/man/cupsd.conf.man.in
@@ -689,7 +689,7 @@ The resource for the named printer class
 The path for all jobs (hold-job, release-job, etc.)
 .TP 5
 /jobs/id
-The path for the specified job.
+The path for the specified job
 .TP 5
 /printers
 The path for all printers

--- a/man/cupsd.conf.man.in
+++ b/man/cupsd.conf.man.in
@@ -231,14 +231,14 @@ The default is "30".
 .\"#LimitIPP
 .TP 5
 \fB<Limit \fIoperation \fR...\fB> \fR... \fB</Limit>\fR
-Specifies the IPP operations that are being limited inside a Policy section. IPP operation names are listed below in the section "IPP OPERATIONS".
+Specifies the IPP operations that are being limited inside a Policy section. IPP operation names are listed below in the section "IPP OPERATION NAMES".
 .\"#Limit
 .TP 5
 \fB<Limit \fImethod \fR...\fB> \fR... \fB</Limit>\fR
 .\"#LimitExcept
 .TP 5
 \fB<LimitExcept \fImethod \fR...\fB> \fR... \fB</LimitExcept>\fR
-Specifies the HTTP methods that are being limited inside a Location section. HTTP method names are listed below in the section "HTTP METHODS".
+Specifies the HTTP methods that are being limited inside a Location section. HTTP method names are listed below in the section "HTTP METHOD NAMES".
 .\"#LimitRequestBody
 .TP 5
 \fBLimitRequestBody \fIsize\fR


### PR DESCRIPTION
On https://bugs.debian.org/838854, Helge Kreutzmann <debian@helgefjell.de> reported some manpage formatting inconsistencies, which I've hereby converted to the source groff format.