### PR TITLE
Cross-build fixes

### DIFF
--- a/Makedefs.in
+++ b/Makedefs.in
@@ -18,6 +18,7 @@
 AR		=	@AR@
 AWK		=	@AWK@
 CC		=	@LIBTOOL@ @CC@
+CC_FOR_BUILD	=	@CC_FOR_BUILD@
 CHMOD		=	@CHMOD@
 CXX		=	@LIBTOOL@ @CXX@
 DSO		=	@DSO@

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,15 @@ sinclude(config-scripts/cups-common.m4)
 sinclude(config-scripts/cups-directories.m4)
 sinclude(config-scripts/cups-manpages.m4)
 
+AC_MSG_CHECKING([for build system compiler])
+if test "$cross_compiling" = yes; then
+	CC_FOR_BUILD=${CC_FOR_BUILD-cc}
+else
+	CC_FOR_BUILD=${CC}
+fi
+AC_MSG_RESULT(${CC_FOR_BUILD})
+AC_SUBST(CC_FOR_BUILD)
+
 sinclude(config-scripts/cups-sharedlibs.m4)
 sinclude(config-scripts/cups-libtool.m4)
 sinclude(config-scripts/cups-compiler.m4)

--- a/man/Makefile
+++ b/man/Makefile
@@ -219,7 +219,5 @@ html:	$(MAN1) $(MAN5) $(MAN7) $(MAN8) mantohtml
 		./mantohtml `basename $$file .$(MAN8EXT)`.man >../doc/help/man-`basename $$file .$(MAN8EXT)`.html; \
 	done
 
-mantohtml:	mantohtml.o ../cups/$(LIBCUPSSTATIC)
-	$(CC) $(ARCHFLAGS) $(LDFLAGS) -o $@ mantohtml.o \
-		../cups/$(LIBCUPSSTATIC) $(LIBGSSAPI) $(SSLLIBS) \
-		$(DNSSDLIBS) $(COMMONLIBS) $(LIBZ)
+mantohtml:	mantohtml.c
+	$(CC_FOR_BUILD) -o $@ $<

--- a/man/mantohtml.c
+++ b/man/mantohtml.c
@@ -15,8 +15,10 @@
  * Include necessary headers.
  */
 
-#include <cups/string-private.h>
-#include <cups/array-private.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 
@@ -815,7 +817,8 @@ main(int  argc,				/* I - Number of command-line args */
         * Anchor for HTML output...
         */
 
-        strlcpy(anchor, line + 4, sizeof(anchor));
+        strncpy(anchor, line + 4, sizeof(anchor) - 1);
+        anchor[sizeof(anchor) - 1] = '\0';
       }
       else if (strncmp(line, ".\\\"", 3))
       {
@@ -944,7 +947,8 @@ html_alternate(const char *s,		/* I - String */
 		manfile[1024],		/* Man page filename */
 		manurl[1024];		/* Man page URL */
 
-        strlcpy(name, s, sizeof(name));
+        strncpy(name, s, sizeof(name) - 1);
+        name[sizeof(name) - 1] = '\0';
         if ((size_t)(end - s) < sizeof(name))
           name[end - s] = '\0';
 
@@ -1174,7 +1178,8 @@ html_fputs(const char *s,		/* I  - String */
       if (end[-1] == ',' || end[-1] == '.' || end[-1] == ')')
         end --;
 
-      strlcpy(temp, s, sizeof(temp));
+      strncpy(temp, s, sizeof(temp) - 1);
+      temp[sizeof(temp) - 1] = '\0';
       if ((size_t)(end -s) < sizeof(temp))
         temp[end - s] = '\0';
 

--- a/ppdc/Makefile
+++ b/ppdc/Makefile
@@ -221,9 +221,6 @@ genstrings:		genstrings.o libcupsppdc.a ../cups/$(LIBCUPSSTATIC) \
 	$(CXX) $(ARCHFLAGS) $(LDFLAGS) -o genstrings genstrings.o \
 		libcupsppdc.a ../cups/$(LIBCUPSSTATIC) $(LIBGSSAPI) $(SSLLIBS) \
 		$(DNSSDLIBS) $(COMMONLIBS) $(LIBZ)
-	echo Generating localization strings...
-	./genstrings >sample.c
-
 
 #
 # ppdc, the PPD compiler.


### PR DESCRIPTION
Helmut Grohne has reported in https://bugs.debian.org/837936 the only two missing pieces to allow CUPS cross-building. Here come the patches.

This addresses #4872.
