### PR TITLE
Enabling CUPS to work with recent configuration from /etc/resolv.conf without restart

### DIFF
--- a/cups/auth.c
+++ b/cups/auth.c
@@ -516,6 +516,17 @@ cups_gss_getname(
   DEBUG_printf(("7cups_gss_getname(http=%p, service_name=\"%s\")", http,
                 service_name));
 
+#ifdef HAVE_RES_INIT
+ /*
+  * Check if /etc/resolv.conf is modified.
+  * If so, reload resolver.
+  */
+
+  http_resolv_check_t status;
+
+  status = httpCheckResolv();
+#endif /* HAVE_RES_INIT */
+
 
  /*
   * Get the hostname...

--- a/cups/http-addr.c
+++ b/cups/http-addr.c
@@ -357,6 +357,17 @@ httpAddrLookup(
 
 #ifdef HAVE_RES_INIT
  /*
+  * Check if /etc/resolv.conf is modified.
+  * If so, reload resolver and set need_res_init to 0.
+  */
+
+  http_resolv_check_t status;
+
+  status = httpCheckResolv();
+
+  if (status == HTTP_RESOLV_CHECK_RELOADED && cg->need_res_init == 1)
+    cg->need_res_init = 0;
+ /*
   * STR #2920: Initialize resolver after failure in cups-polld
   *
   * If the previous lookup failed, re-initialize the resolver to prevent

--- a/cups/http-addrlist.c
+++ b/cups/http-addrlist.c
@@ -483,6 +483,17 @@ httpAddrGetList(const char *hostname,	/* I - Hostname, IP address, or NULL for p
 
 #ifdef HAVE_RES_INIT
  /*
+  * Check if /etc/resolv.conf is modified.
+  * If so, reload resolver and set cg->need_res_init to 0
+  */
+
+  http_resolv_check_t status;
+
+  status = httpCheckResolv();
+
+  if (status == HTTP_RESOLV_CHECK_RELOADED && cg->need_res_init == 1)
+    cg->need_res_init = 0;
+ /*
   * STR #2920: Initialize resolver after failure in cups-polld
   *
   * If the previous lookup failed, re-initialize the resolver to prevent

--- a/cups/http-support.c
+++ b/cups/http-support.c
@@ -2258,6 +2258,16 @@ http_resolve_cb(
     http_addrlist_t	*addrlist,	/* List of addresses */
 			*addr;		/* Current address */
 
+#ifdef HAVE_RES_INIT
+   /*
+   * Check if resolv.conf is modified, if so, reload resolver
+   */
+
+    http_resolv_check_t status;
+
+   status = httpCheckResolv();
+#endif /* HAVE_RES_INIT */
+
     DEBUG_printf(("5http_resolve_cb: Looking up \"%s\".", hostTarget));
 
     snprintf(fqdn, sizeof(fqdn), "%d", ntohs(port));

--- a/cups/http.h
+++ b/cups/http.h
@@ -55,6 +55,12 @@ typedef off_t ssize_t;			/* @private@ */
 #      define SO_PEERCRED LOCAL_PEERCRED
 #    endif /* LOCAL_PEERCRED && !SO_PEERCRED */
 #  endif /* WIN32 */
+#  ifdef HAVE_RES_INIT
+#    include <sys/stat.h>
+#    include <unistd.h>
+#    include <arpa/nameser.h>
+#    include <resolv.h>
+#  endif /* HAVE_RES_INIT */
 
 
 /*
@@ -95,6 +101,13 @@ extern "C" {
 #endif /* AF_INET6 && !s6_addr32 */
 
 
+#ifdef HAVE_RES_INIT
+/*
+ * Global variable for storing old modification time of resolv.conf 
+ */
+  extern time_t resolv_conf_modtime;
+#endif /* HAVE_RES_INIT */
+
 /*
  * Limits...
  */
@@ -103,6 +116,9 @@ extern "C" {
 #  define HTTP_MAX_HOST		256	/* Max length of hostname string */
 #  define HTTP_MAX_BUFFER	2048	/* Max length of data buffer */
 #  define HTTP_MAX_VALUE	256	/* Max header field value length */
+#  ifdef HAVE_RES_INIT
+#    define HTTP_RESOLV_CONF_PATH  "/etc/resolv.conf" /* Path to resolv.conf */
+#  endif /* HAVE_RES_INIT */
 
 
 /*
@@ -406,6 +422,15 @@ typedef enum http_version_e		/**** HTTP version numbers ****/
 #  endif /* !_CUPS_NO_DEPRECATED */
 } http_version_t;
 
+#ifdef HAVE_RES_INIT
+typedef enum http_resolv_check_e
+{
+  HTTP_RESOLV_CHECK_ERROR = -1,
+  HTTP_RESOLV_CHECK_OK = 0,
+  HTTP_RESOLV_CHECK_RELOADED = 1
+} http_resolv_check_t;
+#endif /* HAVE_RES_INIT */
+
 typedef union _http_addr_u		/**** Socket address union, which
 					 **** makes using IPv6 and other
 					 **** address types easier and
@@ -643,6 +668,11 @@ extern void		httpSetKeepAlive(http_t *http, http_keepalive_t keep_alive) _CUPS_A
 extern void		httpShutdown(http_t *http) _CUPS_API_2_0;
 extern const char	*httpStateString(http_state_t state) _CUPS_API_2_0;
 extern const char	*httpURIStatusString(http_uri_status_t status) _CUPS_API_2_0;
+
+/**** Prototype of function to check modification time of /etc/resolv.conf ****/
+#ifdef HAVE_RES_INIT
+extern http_resolv_check_t httpCheckResolv();
+#endif /* HAVE_RES_INIT */
 
 /*
  * C++ magic...

--- a/scheduler/conf.c
+++ b/scheduler/conf.c
@@ -869,6 +869,12 @@ cupsdReadConfiguration(void)
   if (!RemotePort)
     BrowseLocalProtocols = 0;		/* Disable sharing - no remote access */
 
+#ifdef HAVE_RES_INIT
+  http_resolv_check_t res_status;  /* Return status of httpCheckResolv() */
+
+  res_status = httpCheckResolv();
+#endif /* HAVE_RES_INIT */
+
  /*
   * See if the ServerName is an IP address...
   */

--- a/scheduler/main.c
+++ b/scheduler/main.c
@@ -133,6 +133,17 @@ main(int  argc,				/* I - Number of command-line args */
 #endif /* HAVE_ONDEMAND */
 
 
+#ifdef HAVE_RES_INIT
+  http_resolv_check_t status;  /* Return status from httpCheckResolv() */
+
+  status = httpCheckResolv();
+  if (status == HTTP_RESOLV_CHECK_ERROR)
+  {
+    fputs("cupsd: Cannot get a status of /etc/resolv.conf\n", stderr);
+   return (1);
+  }
+#endif /* HAVE_RES_INIT */
+
 #ifdef HAVE_GETEUID
  /*
   * Check for setuid invocation, which we do not support!


### PR DESCRIPTION
Hi Mike,

Our customer reported problem with CUPS about it is not using recent configuration from /etc/resolv.conf without CUPS' restart. It is issue with glibc, but it is known issue for upstream and they are working on solution, but it will not be solved in near future. So I tried to create workaround for CUPS to make it use recent nameserver's IP from /etc/resolv.conf. 
This patch is based on comparing modification times (acquired by stat()) and if they differ, res_init() is called. All of these are encapsulated in function httpCheckResolv(), which is called before all functions, which works with nameservers.
 When I looked into code I saw you are using res_init() when hostname/IP resolution went wrong, so I am checking need_res_init value and if it is set to 1 and my function already reloaded resolver, it sets need_res_init to 0.
I know that using inotify will be probably more complex solution, but if it is glibc issue to begin with, I thought the stat() function will be sufficient as temporary workaround for CUPS.
 I tested this patch on RHEL7 with CUPS-1.6.3 and it worked. So do you want to add this workaround to CUPS, Mike? I know there are some imperfections in this patch (like not checking return status in some places - because I didn't get how you deal with errors there), but I am willing to help with correcting it by your advices. 