### PR TITLE
cupstestppd Buffer Overflow

### DIFF
--- a/systemv/cupstestppd.c
+++ b/systemv/cupstestppd.c
@@ -923,7 +923,7 @@ main(int  argc,				/* I - Number of command-line args */
 	int	junkint;			/* Temp integer */
 
 
-        if (sscanf(attr->value, "(%[^)])%d", junkstr, &junkint) != 2)
+        if (sscanf(attr->value, "(%254[^)\n])%d", junkstr, &junkint) != 2)
 	{
 	  if (verbose >= 0)
 	  {


### PR DESCRIPTION
Due to the lack of a length specifier in a `sscanf` used to read the PPD `PSVersion` field, a malicious PPD file can overflow the `junkstr` `char` array in a classic buffer overflow scenario. Since the `\n` character is also missing from the `sscanf`, it's possible to read multiple lines directly into the buffer.

This patch adds both a maximum length specifier, and stops the `sscanf` reading multiple lines, both of which alone will mitigate this overflow.

Since this is a helper tool and not the main CUPS server, and exploiting this (at least on my machines) is completely blocked by ASLR and Stack Canaries, so I felt OK with submitting this PR publicly. My apologies if this is not acceptable.