### PR TITLE
Fix closures and button in templates/es/jobs.tmpl

### DIFF
--- a/templates/es/jobs.tmpl
+++ b/templates/es/jobs.tmpl
@@ -18,6 +18,7 @@
 <TD>
 {job_preserved>0?{job_state>5?
 <FORM ACTION="/jobs/" METHOD="POST"><INPUT TYPE="HIDDEN" NAME="org.cups.sid" VALUE="{$org.cups.sid}"><INPUT TYPE="HIDDEN" NAME="OP" VALUE="restart-job"><INPUT TYPE="HIDDEN" NAME="job_id" VALUE="{job_id}"><INPUT TYPE="HIDDEN" NAME="job_printer_uri" VALUE="{job_printer_uri}">
+<INPUT TYPE="SUBMIT" VALUE="Reimprimir trabajo"></FORM>:}:}
 {job_state=4?
 <FORM ACTION="/jobs/" METHOD="POST"><INPUT TYPE="HIDDEN" NAME="org.cups.sid" VALUE="{$org.cups.sid}"><INPUT TYPE="HIDDEN" NAME="OP" VALUE="release-job"><INPUT TYPE="HIDDEN" NAME="job_id" VALUE="{job_id}"><INPUT TYPE="HIDDEN" NAME="job_printer_uri" VALUE="{job_printer_uri}">
 <INPUT TYPE="SUBMIT" VALUE="Liberar trabajo"></FORM>:}


### PR DESCRIPTION
Add missing closures and reprint button in templates/es/jobs.tmpl. Before this completed job list output was broken for Spanish language.