### PR TITLE
Tests: error_log entries counting is off by two 'Unknown default SystemGroup' occurences

### DIFF
--- a/test/run-stp-tests.sh
+++ b/test/run-stp-tests.sh
@@ -996,7 +996,9 @@ else
 fi
 
 # Error log messages
-count=`$GREP '^E ' $BASE/log/error_log | wc -l | awk '{print $1}'`
+count=`$GREP '^E ' $BASE/log/error_log | \
+       $GREP -v 'Unknown default SystemGroup' | \
+       wc -l | awk '{print $1}'`
 if test $count != 33; then
 	echo "FAIL: $count error messages, expected 33."
 	$GREP '^E ' $BASE/log/error_log


### PR DESCRIPTION
This regression was introduced by the fix for https://github.com/apple/cups/issues/5041 which makes **builds** with `--with-system-groups=lpadmin` in environments where that same system group doesn't exist fail in the testsuite with the following error:

```
FAIL: 35 error messages, expected 33.
E [28/Aug/2017:13:46:06.572986 +0000] Unknown default SystemGroup "lpadmin".
…
```
The `error_log` error counting is off by two additionnal error messages as above.

This patch is how we fixed it in Debian, adressing specifically this problem only. There's certainly a better way to fix this than omitting that line in the `error_log` lines counting.

By the way; these are all the exceptions we take into account to only count '33' errors consistently:
```
count=`$GREP '^E ' $BASE/log/error_log | \
       $GREP -v '(usb) crashed on signal 11' | \
       $GREP -v '(dnssd) stopped with status 1' | \
       $GREP -v 'loadFile failed: temp file: not a PDF file' | \
       $GREP -v 'Failed to connect to system bus' | \
       $GREP -v -E 'Unable to open listen socket for address .* Address family not supported by protocol.' | \
       $GREP -v 'Unable to write uncompressed print data: Broken pipe' | \
       $GREP -v 'Unknown default SystemGroup' | \
       wc -l | awk '{print $1}'`
```
