### PR TITLE
Fix authorization check for kerberos local connections

### DIFF
--- a/scheduler/auth.c
+++ b/scheduler/auth.c
@@ -1694,6 +1694,9 @@ cupsdIsAuthorized(cupsd_client_t *con,	/* I - Connection */
 
 
     if (con->type != type && type != CUPSD_AUTH_NONE &&
+#ifdef AF_LOCAL
+        (_httpAddrFamily(con->http.hostaddr) != AF_LOCAL) &&
+#endif /* AF_LOCAL */
 #ifdef HAVE_GSSAPI
         (type != CUPSD_AUTH_NEGOTIATE || con->gss_uid <= 0) &&
 #endif /* HAVE_GSSAPI */


### PR DESCRIPTION
When a client connects through local socket, it is always authenticated
using Basic and socket peer credentials regardless the authentication
method configured. The authorization function should take this into
account and skip the authentication method check for AF_LOCAL connections.

Signed-off-by: Samuel Cabrero <scabrero@suse.de>