### PR TITLE
configure: improve interpreter detection

### DIFF
--- a/config-scripts/cups-scripting.m4
+++ b/config-scripts/cups-scripting.m4
@@ -16,6 +16,7 @@ AC_ARG_WITH(java, [  --with-java             set Java interpreter for web interf
 	CUPS_JAVA="$withval",
 	CUPS_JAVA="auto")
 
+AC_MSG_CHECKING([for Java interpreter])
 if test "x$CUPS_JAVA" = xauto; then
 	AC_PATH_PROG(JAVA,java)
 	CUPS_JAVA="$JAVA"
@@ -26,7 +27,10 @@ fi
 AC_DEFINE_UNQUOTED(CUPS_JAVA, "$CUPS_JAVA")
 
 if test "x$CUPS_JAVA" != x; then
+	AC_MSG_RESULT([$CUPS_JAVA])
 	AC_DEFINE(HAVE_JAVA)
+else
+	AC_MSG_RESULT([none])
 fi
 
 dnl Do we have Perl?
@@ -34,6 +38,7 @@ AC_ARG_WITH(perl, [  --with-perl             set Perl interpreter for web interf
 	CUPS_PERL="$withval",
 	CUPS_PERL="auto")
 
+AC_MSG_CHECKING([for Perl interpreter])
 if test "x$CUPS_PERL" = xauto; then
 	AC_PATH_PROG(PERL,perl)
 	CUPS_PERL="$PERL"
@@ -44,7 +49,10 @@ fi
 AC_DEFINE_UNQUOTED(CUPS_PERL, "$CUPS_PERL")
 
 if test "x$CUPS_PERL" != x; then
+	AC_MSG_RESULT([$CUPS_PERL])
 	AC_DEFINE(HAVE_PERL)
+else
+	AC_MSG_RESULT([none])
 fi
 
 dnl Do we have PHP?
@@ -52,6 +60,7 @@ AC_ARG_WITH(php, [  --with-php              set PHP interpreter for web interfac
 	CUPS_PHP="$withval",
 	CUPS_PHP="auto")
 
+AC_MSG_CHECKING([for PHP interpreter])
 if test "x$CUPS_PHP" = xauto; then
 	AC_PATH_PROG(PHPCGI,php-cgi)
 	if test "x$PHPCGI" = x; then
@@ -67,7 +76,10 @@ fi
 AC_DEFINE_UNQUOTED(CUPS_PHP, "$CUPS_PHP")
 
 if test "x$CUPS_PHP" != x; then
+	AC_MSG_RESULT([$CUPS_PHP])
 	AC_DEFINE(HAVE_PHP)
+else
+	AC_MSG_RESULT([none])
 fi
 
 dnl Do we have Python?
@@ -75,6 +87,7 @@ AC_ARG_WITH(python, [  --with-python           set Python interpreter for web in
 	CUPS_PYTHON="$withval",
 	CUPS_PYTHON="auto")
 
+AC_MSG_CHECKING([for Python interpreter])
 if test "x$CUPS_PYTHON" = xauto; then
 	AC_PATH_PROG(PYTHON,python)
 	CUPS_PYTHON="$PYTHON"
@@ -85,5 +98,8 @@ fi
 AC_DEFINE_UNQUOTED(CUPS_PYTHON, "$CUPS_PYTHON")
 
 if test "x$CUPS_PYTHON" != x; then
+	AC_MSG_RESULT([$CUPS_PYTHON])
 	AC_DEFINE(HAVE_PYTHON)
+else
+	AC_MSG_RESULT([none])
 fi

--- a/config-scripts/cups-scripting.m4
+++ b/config-scripts/cups-scripting.m4
@@ -14,11 +14,13 @@ dnl
 dnl Do we have Java?
 AC_ARG_WITH(java, [  --with-java             set Java interpreter for web interfaces ],
 	CUPS_JAVA="$withval",
-	CUPS_JAVA="")
+	CUPS_JAVA="auto")
 
-if test "x$CUPS_JAVA" = x; then
+if test "x$CUPS_JAVA" = xauto; then
 	AC_PATH_PROG(JAVA,java)
 	CUPS_JAVA="$JAVA"
+elif test "x$CUPS_JAVA" = xno; then
+	CUPS_JAVA=""
 fi
 
 AC_DEFINE_UNQUOTED(CUPS_JAVA, "$CUPS_JAVA")
@@ -30,11 +32,13 @@ fi
 dnl Do we have Perl?
 AC_ARG_WITH(perl, [  --with-perl             set Perl interpreter for web interfaces ],
 	CUPS_PERL="$withval",
-	CUPS_PERL="")
+	CUPS_PERL="auto")
 
-if test "x$CUPS_PERL" = x; then
+if test "x$CUPS_PERL" = xauto; then
 	AC_PATH_PROG(PERL,perl)
 	CUPS_PERL="$PERL"
+elif test "x$CUPS_PERL" = xno; then
+	CUPS_PERL=""
 fi
 
 AC_DEFINE_UNQUOTED(CUPS_PERL, "$CUPS_PERL")
@@ -46,9 +50,9 @@ fi
 dnl Do we have PHP?
 AC_ARG_WITH(php, [  --with-php              set PHP interpreter for web interfaces ],
 	CUPS_PHP="$withval",
-	CUPS_PHP="")
+	CUPS_PHP="auto")
 
-if test "x$CUPS_PHP" = x; then
+if test "x$CUPS_PHP" = xauto; then
 	AC_PATH_PROG(PHPCGI,php-cgi)
 	if test "x$PHPCGI" = x; then
 		AC_PATH_PROG(PHP,php)
@@ -56,6 +60,8 @@ if test "x$CUPS_PHP" = x; then
 	else
 		CUPS_PHP="$PHPCGI"
 	fi
+elif test "x$CUPS_PHP" = xno; then
+	CUPS_PHP=""
 fi
 
 AC_DEFINE_UNQUOTED(CUPS_PHP, "$CUPS_PHP")
@@ -67,11 +73,13 @@ fi
 dnl Do we have Python?
 AC_ARG_WITH(python, [  --with-python           set Python interpreter for web interfaces ],
 	CUPS_PYTHON="$withval",
-	CUPS_PYTHON="")
+	CUPS_PYTHON="auto")
 
-if test "x$CUPS_PYTHON" = x; then
+if test "x$CUPS_PYTHON" = xauto; then
 	AC_PATH_PROG(PYTHON,python)
 	CUPS_PYTHON="$PYTHON"
+elif test "x$CUPS_PYTHON" = xno; then
+	CUPS_PYTHON=""
 fi
 
 AC_DEFINE_UNQUOTED(CUPS_PYTHON, "$CUPS_PYTHON")

--- a/config-scripts/cups-scripting.m4
+++ b/config-scripts/cups-scripting.m4
@@ -60,9 +60,7 @@ fi
 
 AC_DEFINE_UNQUOTED(CUPS_PHP, "$CUPS_PHP")
 
-if test "x$CUPS_PHP" = x; then
-	CUPS_PHP="no"
-else
+if test "x$CUPS_PHP" != x; then
 	AC_DEFINE(HAVE_PHP)
 fi
 


### PR DESCRIPTION
Currently, when configure is called with `--with-java` or `--with-java=`, auto-detection is performed. When called with `--without-java`, `HAVE_JAVA` is still being defined. This is unfortunate when cross-compiling for embedded systems, we would end up with Java on the host being auto-detected (which is not what we have on the target), or with a wrong `HAVE_JAVA` define.

This implements a way to explicitely disable scripting support for all supported languages with ``without-java` (or the respective options for Perl, PHP and Python)

While we're at it, make the detection a bit more verbose, and do some cleanup.