### PR TITLE
socket backend doesn't fail when printer is disconnected

### DIFF
--- a/backend/socket.c
+++ b/backend/socket.c
@@ -331,7 +331,8 @@ main(int  argc,				/* I - Number of command-line arguments (6 or 7) */
       fprintf(stderr, "DEBUG: Connection error: %s\n", strerror(error));
 
       if (error == ECONNREFUSED || error == EHOSTDOWN ||
-          error == EHOSTUNREACH)
+          error == EHOSTUNREACH || error == ENOTCONN ||
+          error == ETIMEDOUT)
       {
         if (contimeout && (time(NULL) - start_time) > contimeout)
 	{
@@ -353,6 +354,16 @@ main(int  argc,				/* I - Number of command-line arguments (6 or 7) */
 				   _("The printer is unreachable at this "
 				     "time."));
 	      break;
+
+    case ETIMEDOUT :
+        _cupsLangPrintFilter(stderr, "WARNING",
+           _("The printer connection timed out."));
+        break;
+
+    case ENOTCONN :
+        _cupsLangPrintFilter(stderr, "WARNING",
+            _("Unable to connect to the printer."));
+        break;
 
 	  case ECONNREFUSED :
 	  default :


### PR DESCRIPTION
Hi Mike,

we ran several test and found out that socket backend doesn't return failure if printer is disconnected or powered off. httpAddrConnect() function returns ETIMEDOUT or ENOTCONN in these cases and code doesn't catch them. Created patch catches them and returns failure.
Is it acceptable behavior for socket backend?