### PR TITLE
Clean up implementation for SSLOptions

### DIFF
--- a/cups/http-private.h
+++ b/cups/http-private.h
@@ -179,13 +179,14 @@ extern "C" {
 #define _HTTP_RESOLVE_FQDN	2	/* Resolve to a FQDN */
 #define _HTTP_RESOLVE_FAXOUT	4	/* Resolve FaxOut service? */
 
-#define _HTTP_TLS_NONE		0	/* No TLS options */
-#define _HTTP_TLS_ALLOW_RC4	1	/* Allow RC4 cipher suites */
-#define _HTTP_TLS_ALLOW_SSL3	2	/* Allow SSL 3.0 */
-#define _HTTP_TLS_ALLOW_DH	4	/* Allow DH/DHE key negotiation */
-#define _HTTP_TLS_DENY_TLS10	16	/* Deny TLS 1.0 */
-#define _HTTP_TLS_DENY_CBC	32	/* Deny CBC cipher suites */
-#define _HTTP_TLS_ONLY_TLS10    64      /* Only use TLS 1.0 */
+#define _HTTP_TLS_UNCHANGED     0   /* Don't change TLS options */
+#define _HTTP_TLS_NONE          1   /* No TLS options */
+#define _HTTP_TLS_ALLOW_RC4     2   /* Allow RC4 cipher suites */
+#define _HTTP_TLS_ALLOW_SSL3    4   /* Allow SSL 3.0 */
+#define _HTTP_TLS_ALLOW_DH      8   /* Allow DH/DHE key negotiation */
+#define _HTTP_TLS_DENY_TLS10    16  /* Deny TLS 1.0 */
+#define _HTTP_TLS_DENY_CBC      32  /* Deny CBC cipher suites */
+#define _HTTP_TLS_ONLY_TLS10    64  /* Only use TLS 1.0 */
 
 
 /*
@@ -442,7 +443,7 @@ extern void		_httpTLSInitialize(void);
 extern size_t		_httpTLSPending(http_t *http);
 extern int		_httpTLSRead(http_t *http, char *buf, int len);
 extern int		_httpTLSSetCredentials(http_t *http);
-extern void		_httpTLSSetOptions(int options);
+extern void		_httpTLSSetOptions(unsigned int options);
 extern int		_httpTLSStart(http_t *http);
 extern void		_httpTLSStop(http_t *http);
 extern int		_httpTLSWrite(http_t *http, const char *buf, int len);

--- a/cups/tls-darwin.c
+++ b/cups/tls-darwin.c
@@ -36,24 +36,17 @@ extern char **environ; /* @private@ */
  * Local globals...
  */
 
-static int		tls_auto_create = 0;
-					/* Auto-create self-signed certs? */
-static char		*tls_common_name = NULL;
-					/* Default common name */
+static int            tls_auto_create = 0;                 /* Auto-create self-signed certs? */
+static char          *tls_common_name = NULL;              /* Default common name */
 #ifdef HAVE_SECKEYCHAINOPEN
-static int		tls_cups_keychain = 0;
-					/* Opened the CUPS keychain? */
-static SecKeychainRef	tls_keychain = NULL;
-					/* Server cert keychain */
+static int            tls_cups_keychain = 0;               /* Opened the CUPS keychain? */
+static SecKeychainRef tls_keychain = NULL;                 /* Server cert keychain */
 #else
-static SecIdentityRef	tls_selfsigned = NULL;
-					/* Temporary self-signed cert */
+static SecIdentityRef tls_selfsigned = NULL;               /* Temporary self-signed cert */
 #endif /* HAVE_SECKEYCHAINOPEN */
-static char		*tls_keypath = NULL;
-					/* Server cert keychain path */
-static _cups_mutex_t	tls_mutex = _CUPS_MUTEX_INITIALIZER;
-					/* Mutex for keychain/certs */
-static int		tls_options = -1;/* Options for TLS connections */
+static char          *tls_keypath = NULL;                  /* Server cert keychain path */
+static _cups_mutex_t  tls_mutex = _CUPS_MUTEX_INITIALIZER; /* Mutex for keychain/certs */
+static unsigned int   tls_options = _HTTP_TLS_NONE;        /* Options for TLS connections */
 
 
 /*
@@ -1139,7 +1132,7 @@ _httpTLSRead(http_t *http,		/* I - HTTP connection */
  */
 
 void
-_httpTLSSetOptions(int options)		/* I - Options */
+_httpTLSSetOptions(unsigned int options)		/* I - Options */
 {
   tls_options = options;
 }
@@ -1169,7 +1162,7 @@ _httpTLSStart(http_t *http)		/* I - HTTP connection */
 
   DEBUG_printf(("3_httpTLSStart(http=%p)", (void *)http));
 
-  if (tls_options < 0)
+  if ((tls_options == _HTTP_TLS_UNCHANGED) || (tls_options == _HTTP_TLS_NONE))
   {
     DEBUG_puts("4_httpTLSStart: Setting defaults.");
     _cupsSetDefaults();

--- a/cups/tls-gnutls.c
+++ b/cups/tls-gnutls.c
@@ -1499,7 +1499,7 @@ _httpTLSStart(http_t *http)		/* I - Connection to server */
     return (-1);
   }
 
-  strlcpy(priority_string, "NORMAL", sizeof(priority_string));
+  strlcpy(priority_string, "NORMAL:!ANON-ECDH:!ANON-DH", sizeof(priority_string));
 
   if (tls_options & _HTTP_TLS_DENY_TLS10)
     strlcat(priority_string, ":+VERS-TLS-ALL:!VERS-TLS1.0:!VERS-SSL3.0", sizeof(priority_string));
@@ -1515,10 +1515,7 @@ _httpTLSStart(http_t *http)		/* I - Connection to server */
   else
     strlcat(priority_string, ":!ARCFOUR-128", sizeof(priority_string));
 
-  if (tls_options & _HTTP_TLS_ALLOW_DH)
-    strlcat(priority_string, ":+ANON-DH", sizeof(priority_string));
-  else
-    strlcat(priority_string, ":!ANON-DH", sizeof(priority_string));
+  /* _HTTP_TLS_ALLOW_DH cannot be implemented with gnutls */
 
   if (tls_options & _HTTP_TLS_DENY_CBC)
     strlcat(priority_string, ":!AES-128-CBC:!AES-256-CBC:!CAMELLIA-128-CBC:!CAMELLIA-256-CBC:!3DES-CBC", sizeof(priority_string));

--- a/cups/tls-sspi.c
+++ b/cups/tls-sspi.c
@@ -52,7 +52,7 @@
  * Local globals...
  */
 
-static int		tls_options = -1;/* Options for TLS connections */
+static unsigned int tls_options = _HTTP_TLS_NONE; /* Options for TLS connections */
 
 
 /*
@@ -911,7 +911,7 @@ _httpTLSRead(http_t *http,		/* I - HTTP connection */
  */
 
 void
-_httpTLSSetOptions(int options)		/* I - Options */
+_httpTLSSetOptions(unsigned int options)		/* I - Options */
 {
   tls_options = options;
 }
@@ -930,7 +930,7 @@ _httpTLSStart(http_t *http)		/* I - HTTP connection */
 
   DEBUG_printf(("3_httpTLSStart(http=%p)", http));
 
-  if (tls_options < 0)
+  if ((tls_options == _HTTP_TLS_UNCHANGED) || (tls_options == _HTTP_TLS_NONE))
   {
     DEBUG_puts("4_httpTLSStart: Setting defaults.");
     _cupsSetDefaults();

--- a/cups/usersys.c
+++ b/cups/usersys.c
@@ -957,7 +957,10 @@ _cupsSetDefaults(void)
     cg->validate_certs = cc.validate_certs;
 
 #ifdef HAVE_SSL
-  _httpTLSSetOptions(cc.ssl_options);
+  if (cc.ssl_options != _HTTP_TLS_UNCHANGED)
+  {
+    _httpTLSSetOptions(cc.ssl_options);
+  }
 #endif /* HAVE_SSL */
 }
 
@@ -1336,10 +1339,10 @@ cups_set_ssl_options(
   * SSLOptions [AllowRC4] [AllowSSL3] [AllowDH] [DenyTLS1.0] [None]
   */
 
-  int	options = _HTTP_TLS_NONE;	/* SSL/TLS options */
-  char	temp[256],			/* Copy of value */
-	*start,				/* Start of option */
-	*end;				/* End of option */
+  unsigned int options = _HTTP_TLS_UNCHANGED; /* SSL/TLS options */
+  char         temp[256],                     /* Copy of value */
+              *start,                         /* Start of option */
+              *end;                           /* End of option */
 
 
   strlcpy(temp, value, sizeof(temp));

--- a/doc/help/man-cupsd.conf.html
+++ b/doc/help/man-cupsd.conf.html
@@ -283,10 +283,10 @@ The default is "Minimal".
 <dd style="margin-left: 5.0em"><dt><b>SSLOptions None</b>
 <dd style="margin-left: 5.0em">Sets encryption options.
 By default, CUPS only supports encryption using TLS v1.0 or higher using known secure cipher suites.
-The <i>AllowDH</i> option enables cipher suites using the horribly insecure anonymous Diffie-Hellman key negotiation which is vulnerable to man-in-the-middle attacks.
-The <i>AllowRC4</i> option enables the insecure 128-bit RC4 cipher suites, which are required for some older clients that do not implement newer ones.
-The <i>AllowSSL3</i> option enables the insecure SSL v3.0 protocol, which is required for some older clients that do not support TLS v1.0.
-The <i>DenyCBC</i> option disables all CBC cipher suites.
+The <i>AllowDH</i> option enables cipher suites using static Diffie-Hellman key negotiation. This option is currently only supported on macOS.
+The <i>AllowRC4</i> option enables the 128-bit RC4 cipher suites, which are required for some older clients that do not implement newer ones. This option is currently not supported on Windows.
+The <i>AllowSSL3</i> option enables the SSL v3.0 protocol, which is required for some older clients that do not support TLS v1.0.
+The <i>DenyCBC</i> option disables all CBC cipher suites. This option is currently not supported on Windows.
 The <i>DenyTLS1.0</i> option disables TLS v1.0 support - this sets the minimum protocol version to TLS v1.1.
 <dt><a name="SSLPort"></a><b>SSLPort </b><i>port</i>
 <dd style="margin-left: 5.0em">Listens on the specified port for encrypted connections.

--- a/doc/help/man-cupsd.conf.html
+++ b/doc/help/man-cupsd.conf.html
@@ -283,9 +283,9 @@ The default is "Minimal".
 <dd style="margin-left: 5.0em"><dt><b>SSLOptions None</b>
 <dd style="margin-left: 5.0em">Sets encryption options.
 By default, CUPS only supports encryption using TLS v1.0 or higher using known secure cipher suites.
-The <i>AllowDH</i> option enables cipher suites using plain Diffie-Hellman key negotiation.
-The <i>AllowRC4</i> option enables the 128-bit RC4 cipher suites, which are required for some older clients that do not implement newer ones.
-The <i>AllowSSL3</i> option enables SSL v3.0, which is required for some older clients that do not support TLS v1.0.
+The <i>AllowDH</i> option enables cipher suites using the horribly insecure anonymous Diffie-Hellman key negotiation which is vulnerable to man-in-the-middle attacks.
+The <i>AllowRC4</i> option enables the insecure 128-bit RC4 cipher suites, which are required for some older clients that do not implement newer ones.
+The <i>AllowSSL3</i> option enables the insecure SSL v3.0 protocol, which is required for some older clients that do not support TLS v1.0.
 The <i>DenyCBC</i> option disables all CBC cipher suites.
 The <i>DenyTLS1.0</i> option disables TLS v1.0 support - this sets the minimum protocol version to TLS v1.1.
 <dt><a name="SSLPort"></a><b>SSLPort </b><i>port</i>

--- a/man/cupsd.conf.man.in
+++ b/man/cupsd.conf.man.in
@@ -445,10 +445,10 @@ Listens on the specified address and port for encrypted connections.
 \fBSSLOptions None\fR
 Sets encryption options.
 By default, CUPS only supports encryption using TLS v1.0 or higher using known secure cipher suites.
-The \fIAllowDH\fR option enables cipher suites using the horribly insecure anonymous Diffie-Hellman key negotiation which is vulnerable to man-in-the-middle attacks.
-The \fIAllowRC4\fR option enables the insecure 128-bit RC4 cipher suites, which are required for some older clients that do not implement newer ones.
-The \fIAllowSSL3\fR option enables the insecure SSL v3.0 protocol, which is required for some older clients that do not support TLS v1.0.
-The \fIDenyCBC\fR option disables all CBC cipher suites.
+The \fIAllowDH\fR option enables cipher suites using static Diffie-Hellman key negotiation. This option is currently only supported on macOS.
+The \fIAllowRC4\fR option enables the 128-bit RC4 cipher suites, which are required for some older clients that do not implement newer ones. This option is currently not supported on Windows.
+The \fIAllowSSL3\fR option enables the SSL v3.0 protocol, which is required for some older clients that do not support TLS v1.0.
+The \fIDenyCBC\fR option disables all CBC cipher suites. This option is currently not supported on Windows.
 The \fIDenyTLS1.0\fR option disables TLS v1.0 support - this sets the minimum protocol version to TLS v1.1.
 .\"#SSLPort
 .TP 5

--- a/man/cupsd.conf.man.in
+++ b/man/cupsd.conf.man.in
@@ -445,9 +445,9 @@ Listens on the specified address and port for encrypted connections.
 \fBSSLOptions None\fR
 Sets encryption options.
 By default, CUPS only supports encryption using TLS v1.0 or higher using known secure cipher suites.
-The \fIAllowDH\fR option enables cipher suites using plain Diffie-Hellman key negotiation.
-The \fIAllowRC4\fR option enables the 128-bit RC4 cipher suites, which are required for some older clients that do not implement newer ones.
-The \fIAllowSSL3\fR option enables SSL v3.0, which is required for some older clients that do not support TLS v1.0.
+The \fIAllowDH\fR option enables cipher suites using the horribly insecure anonymous Diffie-Hellman key negotiation which is vulnerable to man-in-the-middle attacks.
+The \fIAllowRC4\fR option enables the insecure 128-bit RC4 cipher suites, which are required for some older clients that do not implement newer ones.
+The \fIAllowSSL3\fR option enables the insecure SSL v3.0 protocol, which is required for some older clients that do not support TLS v1.0.
 The \fIDenyCBC\fR option disables all CBC cipher suites.
 The \fIDenyTLS1.0\fR option disables TLS v1.0 support - this sets the minimum protocol version to TLS v1.1.
 .\"#SSLPort


### PR DESCRIPTION
This cleans up the implementation for the `SSLOptions` configuration directive:

- Fixed the logic for `DenyCBC` on Linux and other gnutls platforms.
- Fixed the logic for `_httpTLSSetOptions()` in `cups/usersys.c` to prevent unsolicited overwriting of the `SSLOptions` read from `cupsd.conf`.
- The `options` / `tls_options` variables got changed into unsigned integers since we are using them as bit maps and not as "normal" numbers.
- The `_HTTP_TLS_*` constants got shifted by one bit to accomodate the new constant `_HTTP_TLS_UNCHANGED`, which means that the values changed for all of these constants. This is needed so we can distinguish between "explicitly use the default settings" and "don't change/overwrite the existing configuration".
- In some places, numerical values were replaced with the corresponding `_HTTP_TLS_*` constants.
- Added explicit warnings about the `AllowDH`, `AllowRC4` and `AllowSSL3` parameters to the manual.