### PR TITLE
consider loop detected to be success

### DIFF
--- a/scheduler/cups-driverd.cxx
+++ b/scheduler/cups-driverd.cxx
@@ -2400,7 +2400,7 @@ load_ppds(const char *d,		/* I - Actual directory */
   {
     fprintf(stderr, "ERROR: [cups-driverd] Skipping \"%s\": loop detected!\n",
             d);
-    return (0);
+    return (1);
   }
 
  /*


### PR DESCRIPTION
if return 0, load_ppds won't continue to search other files in current directory.