### PR TITLE
Increase size of max header length to accomodate token authentication

### DIFF
--- a/cups/http.h
+++ b/cups/http.h
@@ -96,7 +96,7 @@ extern "C" {
 #  define HTTP_MAX_URI		1024	/* Max length of URI string */
 #  define HTTP_MAX_HOST		256	/* Max length of hostname string */
 #  define HTTP_MAX_BUFFER	2048	/* Max length of data buffer */
-#  define HTTP_MAX_VALUE	256	/* Max header field value length */
+#  define HTTP_MAX_VALUE	2048	/* Max header field value length */
 
 
 /*


### PR DESCRIPTION
Some tokens are larger than the current max header value length allows for.