### PR TITLE
Respect AccessLog configuration when compiled against journald.

### DIFF
--- a/scheduler/log.c
+++ b/scheduler/log.c
@@ -1153,7 +1153,7 @@ cupsdLogRequest(cupsd_client_t *con,	/* I - Request to log */
   }
 
 #ifdef HAVE_SYSTEMD_SD_JOURNAL_H
-  if (!strcmp(ErrorLog, "syslog"))
+  if (!strcmp(AccessLog, "syslog"))
   {
     sd_journal_print(LOG_INFO, "REQUEST %s - %s \"%s %s HTTP/%d.%d\" %d " CUPS_LLFMT " %s %s", con->http->hostname, con->username[0] != '\0' ? con->username : "-", states[con->operation], _httpEncodeURI(temp, con->uri, sizeof(temp)), con->http->version / 100, con->http->version % 100, code, CUPS_LLCAST con->bytes, con->request ? ippOpString(con->request->request.op.operation_id) : "-", con->response ? ippErrorString(con->response->request.status.status_code) : "-");
     return (1);


### PR DESCRIPTION
When cups is compiled against journald access log is written to journal if ErrorLog is set to syslog and the AccesLog settings is ignored.