### PR TITLE
Fix ppdInstallableConflict conflict reporting

### DIFF
--- a/cups/ppd-conflicts.c
+++ b/cups/ppd-conflicts.c
@@ -993,7 +993,7 @@ ppd_test_constraints(
     if (!consts->installable && which == _PPD_INSTALLABLE_CONSTRAINTS)
       continue;				/* Skip non-installable option constraint */
 
-    if (which == _PPD_OPTION_CONSTRAINTS && option)
+    if ((which == _PPD_OPTION_CONSTRAINTS || which == _PPD_INSTALLABLE_CONSTRAINTS) && option)
     {
      /*
       * Skip constraints that do not involve the current option...


### PR DESCRIPTION
Without this patch it was taking all constraints into account, not only the ones
regarding the passed option so if you had a conflict somewhere else, every other
single option would be said to be conflicting which doesn't match what the
documentation says this function should do.