### PR TITLE
Let the PPD Generator read color spaces and color depth correctly from IPP data

### DIFF
--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -3725,7 +3725,13 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
 	  cupsFilePrintf(fp, "*OpenUI *ColorModel/%s: PickOne\n"
 			     "*OrderDependency: 10 AnySetup *ColorModel\n", _cupsLangString(lang, _("Color Mode")));
 
-        cupsFilePrintf(fp, "*ColorModel Gray/%s: \"<</cupsColorSpace 18/cupsBitsPerColor %s/cupsColorOrder 0/cupsCompression 0>>setpagedevice\"\n", _cupsLangString(lang, _("Grayscale")), (strstr(keyword, "16") ? "16" : "8"));
+	if (strstr(keyword, "8"))
+	{
+	  cupsFilePrintf(fp, "*ColorModel Gray/%s: \"<</cupsColorSpace 18/cupsBitsPerColor 8/cupsColorOrder 0/cupsCompression 0>>setpagedevice\"\n", _cupsLangString(lang, _("Grayscale")));
+	  if (strstr(keyword, "16"))
+	    cupsFilePrintf(fp, "*ColorModel GrayHD/%s: \"<</cupsColorSpace 18/cupsBitsPerColor 16/cupsColorOrder 0/cupsCompression 0>>setpagedevice\"\n", _cupsLangString(lang, _("Grayscale High Definition")));
+	} else if (strstr(keyword, "16"))
+	  cupsFilePrintf(fp, "*ColorModel Gray/%s: \"<</cupsColorSpace 18/cupsBitsPerColor 16/cupsColorOrder 0/cupsCompression 0>>setpagedevice\"\n", _cupsLangString(lang, _("Grayscale")));
 
         if (!default_color || !strcmp(default_color, "FastGray"))
 	  default_color = "Gray";
@@ -3736,7 +3742,7 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
 	  cupsFilePrintf(fp, "*OpenUI *ColorModel/%s: PickOne\n"
 			     "*OrderDependency: 10 AnySetup *ColorModel\n", _cupsLangString(lang, _("Color Mode")));
 
-        cupsFilePrintf(fp, "*ColorModel RGB/%s: \"<</cupsColorSpace 19/cupsBitsPerColor %s/cupsColorOrder 0/cupsCompression 0>>setpagedevice\"\n", _cupsLangString(lang, _("Color")), (strstr(keyword, "16") || strstr(keyword, "48") ? "16" : "8"));
+        cupsFilePrintf(fp, "*ColorModel RGB/%s: \"<</cupsColorSpace 19/cupsBitsPerColor %s/cupsColorOrder 0/cupsCompression 0>>setpagedevice\"\n", _cupsLangString(lang, _("Color")), (strstr(keyword, "8") || strstr(keyword, "24") ? "8" : "16"));
 
 	default_color = "RGB";
       }

--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -3719,34 +3719,34 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
         if (!default_color)
 	  default_color = "FastGray";
       }
-      else if (!strcasecmp(keyword, "sgray_8") || !strcmp(keyword, "W8") || !strcmp(keyword, "monochrome") || !strcmp(keyword, "process-monochrome"))
+      else if (!strncasecmp(keyword, "sgray_", 6) || !strncmp(keyword, "W8", 2) || !strncmp(keyword, "W16", 3) || !strcmp(keyword, "monochrome") || !strcmp(keyword, "process-monochrome"))
       {
         if (!default_color)
 	  cupsFilePrintf(fp, "*OpenUI *ColorModel/%s: PickOne\n"
 			     "*OrderDependency: 10 AnySetup *ColorModel\n", _cupsLangString(lang, _("Color Mode")));
 
-        cupsFilePrintf(fp, "*ColorModel Gray/%s: \"<</cupsColorSpace 18/cupsBitsPerColor 8/cupsColorOrder 0/cupsCompression 0>>setpagedevice\"\n", _cupsLangString(lang, _("Grayscale")));
+        cupsFilePrintf(fp, "*ColorModel Gray/%s: \"<</cupsColorSpace 18/cupsBitsPerColor %s/cupsColorOrder 0/cupsCompression 0>>setpagedevice\"\n", _cupsLangString(lang, _("Grayscale")), (strstr(keyword, "16") ? "16" : "8"));
 
         if (!default_color || !strcmp(default_color, "FastGray"))
 	  default_color = "Gray";
       }
-      else if (!strcasecmp(keyword, "srgb_8") || !strcmp(keyword, "SRGB24") || !strcmp(keyword, "color"))
+      else if (!strncasecmp(keyword, "srgb_", 5) || !strncmp(keyword, "SRGB", 4) || !strcmp(keyword, "color"))
       {
         if (!default_color)
 	  cupsFilePrintf(fp, "*OpenUI *ColorModel/%s: PickOne\n"
 			     "*OrderDependency: 10 AnySetup *ColorModel\n", _cupsLangString(lang, _("Color Mode")));
 
-        cupsFilePrintf(fp, "*ColorModel RGB/%s: \"<</cupsColorSpace 19/cupsBitsPerColor 8/cupsColorOrder 0/cupsCompression 0>>setpagedevice\"\n", _cupsLangString(lang, _("Color")));
+        cupsFilePrintf(fp, "*ColorModel RGB/%s: \"<</cupsColorSpace 19/cupsBitsPerColor %s/cupsColorOrder 0/cupsCompression 0>>setpagedevice\"\n", _cupsLangString(lang, _("Color")), (strstr(keyword, "16") || strstr(keyword, "48") ? "16" : "8"));
 
 	default_color = "RGB";
       }
-      else if (!strcasecmp(keyword, "adobe-rgb_16") || !strcmp(keyword, "ADOBERGB48"))
+      else if (!strncasecmp(keyword, "adobe-rgb_", 10) || !strncmp(keyword, "ADOBERGB", 8))
       {
         if (!default_color)
 	  cupsFilePrintf(fp, "*OpenUI *ColorModel/%s: PickOne\n"
 			     "*OrderDependency: 10 AnySetup *ColorModel\n", _cupsLangString(lang, _("Color Mode")));
 
-        cupsFilePrintf(fp, "*ColorModel AdobeRGB/%s: \"<</cupsColorSpace 20/cupsBitsPerColor 16/cupsColorOrder 0/cupsCompression 0>>setpagedevice\"\n", _cupsLangString(lang, _("Deep Color")));
+        cupsFilePrintf(fp, "*ColorModel AdobeRGB/%s: \"<</cupsColorSpace 20/cupsBitsPerColor %s/cupsColorOrder 0/cupsCompression 0>>setpagedevice\"\n", _cupsLangString(lang, _("Deep Color")), (strstr(keyword, "16") || strstr(keyword, "48") ? "16" : "8"));
 
         if (!default_color)
 	  default_color = "AdobeRGB";


### PR DESCRIPTION
The PPD generator did not support all combinations of color spaces and color depths when reading the information from the answer to the get-printer-attributes IPP request. especially if in Apple Raster a range of color depths is given for a color space, like "W8-16", "ADOBERGB24-48", ... Now support for a color space in any color depth is recognized and the highest depth available chosen for each color space.
On my DeskJet 2540 this was especially leading to the fact that only the standard RGB color space appeared in the "ColorModel" option and not the also supported Gray and AdobeRGB color spaces. These two color spaces also print perfectly on the printer with 16 bit color depth (with CUPS 2.3b2).

[HP-DeskJet_2540-ipp-attr-ippserver.txt](https://github.com/apple/cups/files/1641166/HP-DeskJet_2540-ipp-attr-ippserver.txt)
