### PR TITLE
Fix build for HAVE_LIBPAM=0

### DIFF
--- a/scheduler/auth.c
+++ b/scheduler/auth.c
@@ -28,6 +28,8 @@
 #  else
 #    include <security/pam_appl.h>
 #  endif /* HAVE_PAM_PAM_APPL_H */
+#else
+#  include <cups/md5-private.h>
 #endif /* HAVE_LIBPAM */
 #ifdef HAVE_MEMBERSHIP_H
 #  include <membership.h>


### PR DESCRIPTION
This adds a missing `#include`that fixes the build for the case where
'HAVE_LIBPAM' is 0.

The following error occurs without this:

~~~
[...]
Making all in scheduler...
Compiling auth.c...
auth.c:2017:5: error: unknown type name '_cups_md5_state_t'; did you mean '_cups_message_t'?
    _cups_md5_state_t   state;          /* Primary MD5 state info */
    ^~~~~~~~~~~~~~~~~
    _cups_message_t
../cups/language-private.h:52:3: note: '_cups_message_t' declared here
} _cups_message_t;
  ^
auth.c:2018:5: error: unknown type name '_cups_md5_state_t'; did you mean '_cups_message_t'?
    _cups_md5_state_t   state2;         /* Secondary MD5 state info */
    ^~~~~~~~~~~~~~~~~
    _cups_message_t
../cups/language-private.h:52:3: note: '_cups_message_t' declared here
} _cups_message_t;
  ^
auth.c:2038:5: warning: implicit declaration of function '_cupsMD5Init' is invalid in C99 [-Wimplicit-function-declaration]
    _cupsMD5Init(&state);
    ^
auth.c:2039:5: warning: implicit declaration of function '_cupsMD5Append' is invalid in C99 [-Wimplicit-function-declaration]
    _cupsMD5Append(&state, (unsigned char *)pw, pwlen);
    ^
auth.c:2046:5: warning: implicit declaration of function '_cupsMD5Finish' is invalid in C99 [-Wimplicit-function-declaration]
    _cupsMD5Finish(&state2, digest);
    ^
3 warnings and 2 errors generated.
../Makedefs:260: recipe for target 'auth.o' failed
make[1]: *** [auth.o] Error 1
Makefile:25: recipe for target 'all' failed
make: *** [all] Error 1

~~~