### PR TITLE
Allow raw printing using 'file' backend

### DIFF
--- a/doc/help/man-cups-files.conf.html
+++ b/doc/help/man-cups-files.conf.html
@@ -162,7 +162,6 @@ The following directives are deprecated and will be removed from a future versio
 <dd style="margin-left: 5.0em"><dt><b>FileDevice No</b>
 <dd style="margin-left: 5.0em">Specifies whether the file pseudo-device can be used for new printer queues.
 The URI "file:///dev/null" is always allowed.
-File devices cannot be used with "raw" print queues - a PPD file is required.
 The specified file is overwritten for every print job.
 Writing to directories is not supported.
 <dt><a name="FontPath"></a><b>FontPath </b><i>directory[:...:directoryN]</i>

--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -746,7 +746,8 @@ cupsdContinueJob(cupsd_job_t *job)	/* I - Job */
   */
 
   if ((job->compressions[job->current_file] && (!job->printer->remote || job->num_files == 1)) ||
-      (!job->printer->remote && job->printer->raw && job->num_files > 1))
+      (!job->printer->remote && job->printer->raw &&
+       (job->num_files > 1 || !strncmp(job->printer->device_uri, "file:", 5))))
   {
    /*
     * Add gziptoany filter to the front of the list...


### PR DESCRIPTION
This makes it possible to do raw printing using the 'file'
backend, which was no longer working since commit
462b6e746cc2118e5e664fa95b5ee66cc702dc87.

While I am aware that this use case is not officially supported, it's still helpful to do troubleshooting in some cases without having to install any custom backend.