### PR TITLE
cups-config: only CUPS libraries go in non-static `cups-config --libs`

### DIFF
--- a/cups-config.in
+++ b/cups-config.in
@@ -103,7 +103,7 @@ while test $# -gt 0; do
 	    ;;
 	--libs)
 	    if test $static = no; then
-	        libs="@EXTLINKCUPS@ $LIBS";
+	        libs="@EXTLINKCUPS@";
  	        if test $image = yes; then
  	            libs="@EXTLINKCUPSIMAGE@ $libs"
 		fi


### PR DESCRIPTION
We're including compression and crypto libraries in the linker flags
output, even when we're built as a shared library. This doesn't make
sense, because callers of cups-config are only looking for their direct
dependencies. If they plan to make any SSL or zlib calls of their own,
they should be managing those flags on their own.

This resolves problems seen in package management, where libcups users
end up inadvertently linking against (e.g.) gnutls directly, without the
package manager being aware. (And thus, it doesn't know to rebuild on
library upgrades.)