### PR TITLE
Remove mentions of non-implemented -U option from lpoptions manpage

### DIFF
--- a/doc/help/man-lpoptions.html
+++ b/doc/help/man-lpoptions.html
@@ -14,9 +14,6 @@ lpoptions - display or set printer options and defaults
 [
 <b>-E</b>
 ] [
-<b>-U</b>
-<i>username</i>
-] [
 <b>-h </b><i>server</i>[<b>:</b><i>port</i>]
 ]
 <b>-d </b><i>destination</i>[<b>/</b><i>instance</i>]
@@ -28,9 +25,6 @@ lpoptions - display or set printer options and defaults
 [
 <b>-E</b>
 ] [
-<b>-U</b>
-<i>username</i>
-] [
 <b>-h </b><i>server</i>[<b>:</b><i>port</i>]
 ] [
 <b>-p </b><i>destination</i>[<b>/</b><i>instance</i>]
@@ -40,9 +34,6 @@ lpoptions - display or set printer options and defaults
 <b>lpoptions</b>
 [
 <b>-E</b>
-] [
-<b>-U</b>
-<i>username</i>
 ] [
 <b>-h </b><i>server</i>[<b>:</b><i>port</i>]
 ] [
@@ -54,9 +45,6 @@ lpoptions - display or set printer options and defaults
 <b>lpoptions</b>
 [
 <b>-E</b>
-] [
-<b>-U</b>
-<i>username</i>
 ] [
 <b>-h </b><i>server</i>[<b>:</b><i>port</i>]
 ]
@@ -78,8 +66,6 @@ Otherwise, the per-user defaults are managed in the <i>~/.cups/lpoptions</i> fil
 <dl class="man">
 <dt><b>-E</b>
 <dd style="margin-left: 5.0em">Enables encryption when communicating with the CUPS server.
-<dt><b>-U </b><i>username</i>
-<dd style="margin-left: 5.0em">Uses an alternate username.
 <dt><b>-d </b><i>destination</i>[<b>/</b><i>instance</i>]
 <dd style="margin-left: 5.0em">Sets the user default printer to <i>destination</i>.
 If <i>instance</i> is supplied then that particular instance is used.

--- a/man/lpoptions.man.in
+++ b/man/lpoptions.man.in
@@ -14,9 +14,6 @@ lpoptions \- display or set printer options and defaults
 [
 .B \-E
 ] [
-.B \-U
-.I username
-] [
 \fB\-h \fIserver\fR[\fB:\fIport\fR]
 ]
 \fB\-d \fIdestination\fR[\fB/\fIinstance\fR]
@@ -28,9 +25,6 @@ lpoptions \- display or set printer options and defaults
 [
 .B \-E
 ] [
-.B \-U
-.I username
-] [
 \fB\-h \fIserver\fR[\fB:\fIport\fR]
 ] [
 \fB\-p \fIdestination\fR[\fB/\fIinstance\fR]
@@ -40,9 +34,6 @@ lpoptions \- display or set printer options and defaults
 .B lpoptions
 [
 .B \-E
-] [
-.B \-U
-.I username
 ] [
 \fB\-h \fIserver\fR[\fB:\fIport\fR]
 ] [
@@ -54,9 +45,6 @@ lpoptions \- display or set printer options and defaults
 .B lpoptions
 [
 .B \-E
-] [
-.B \-U
-.I username
 ] [
 \fB\-h \fIserver\fR[\fB:\fIport\fR]
 ]
@@ -81,9 +69,6 @@ Otherwise, the per-user defaults are managed in the \fI~/.cups/lpoptions\fR file
 .TP 5
 .B \-E
 Enables encryption when communicating with the CUPS server.
-.TP 5
-\fB\-U \fIusername\fR
-Uses an alternate username.
 .TP 5
 \fB\-d \fIdestination\fR[\fB/\fIinstance\fR]
 Sets the user default printer to \fIdestination\fR.


### PR DESCRIPTION
The [man page for lpoptions](https://github.com/apple/cups/blob/afad2da22d1e301c13472e365a58a5179acb9429/doc/help/man-lpoptions.html) mentions a -U username option, to set the username for a printer. This option does not exist in [lpoptions.c](https://github.com/apple/cups/blob/105b26dedeb9cbed2a247bd68167122f73389c87/systemv/lpoptions.c) proper.