### PR TITLE
Add option to have per-printer usernames in lpoptions.

### DIFF
--- a/cups/options.c
+++ b/cups/options.c
@@ -79,10 +79,7 @@ cupsAddOption(const char    *name,	/* I  - Name of option */
   else if (!_cups_strcasecmp(name, "print-quality"))
     num_options = cupsRemoveOption("cupsPrintQuality", num_options, options);
   else if (!_cups_strcasecmp(name, "User"))
-  {
     cupsSetUser(value);
-    num_options = cupsRemoveOption("User", num_options, options);
-  }
 
  /*
   * Look for an existing option with the same name...

--- a/cups/options.c
+++ b/cups/options.c
@@ -78,6 +78,11 @@ cupsAddOption(const char    *name,	/* I  - Name of option */
     num_options = cupsRemoveOption("print-quality", num_options, options);
   else if (!_cups_strcasecmp(name, "print-quality"))
     num_options = cupsRemoveOption("cupsPrintQuality", num_options, options);
+  else if (!_cups_strcasecmp(name, "User"))
+  {
+    cupsSetUser(value);
+    num_options = cupsRemoveOption("User", num_options, options);
+  }
 
  /*
   * Look for an existing option with the same name...

--- a/systemv/lpoptions.c
+++ b/systemv/lpoptions.c
@@ -150,6 +150,23 @@ main(int  argc,				/* I - Number of command-line arguments */
 	      changes = -1;
 	      break;
 
+	  case 'U': /* -U username */
+	      if (opt[1] != '\0')
+	      {
+		num_options = cupsAddOption("User", opt + 1, num_options, &options);
+		opt += strlen(opt) - 1;
+	      }
+	      else
+	      {
+		i ++;
+		if (i >= argc)
+		  usage();
+
+		num_options = cupsAddOption("User", argv[i], num_options, &options);
+	      }
+	      changes = 1;
+	      break;
+
 	  case 'o' : /* -o option[=value] */
 	      if (dest == NULL)
 	      {
@@ -516,11 +533,11 @@ static void
 usage(void)
 {
   _cupsLangPuts(stdout,
-                _("Usage: lpoptions [-h server] [-E] -d printer\n"
-		  "       lpoptions [-h server] [-E] [-p printer] -l\n"
-		  "       lpoptions [-h server] [-E] -p printer -o "
+                _("Usage: lpoptions [-U username ] [-h server] [-E] -d printer\n"
+		  "       lpoptions [-U username ] [-h server] [-E] [-p printer] -l\n"
+		  "       lpoptions [-U username ] [-h server] [-E] -p printer -o "
 		  "option[=value] ...\n"
-		  "       lpoptions [-h server] [-E] -x printer"));
+		  "       lpoptions [-U username ] [-h server] [-E] -x printer"));
 
   exit(1);
 }


### PR DESCRIPTION
This PR implements the option to allow per-printer usernames, set via lpoptions. I avoided breaking the spec for entries in ``lpoptions``, which are of the form ``Dest <name> [<options>]`` or ``Default <name> [<options>]``. I instead added a "special" option named ``User``, which will be used by the ``options.c`` to set the cups_user, and by ``lpoptions.c`` to put the username to.

I would have loved to create a more "clean" solution, witout (ab)using options for that, but that would have probably broken the aforementioned spec of ``lpoptions``. I'm interested in better ideas of how to handle this.