### PR TITLE
Allow cupsd daemon to exit on idle

### DIFF
--- a/scheduler/org.cups.cupsd.service.in
+++ b/scheduler/org.cups.cupsd.service.in
@@ -5,7 +5,7 @@ Documentation=man:cupsd(8)
 [Service]
 ExecStart=@sbindir@/cupsd -l
 Type=simple
-Restart=always
+Restart=on-failure
 
 [Install]
 Also=org.cups.cupsd.socket org.cups.cupsd.path


### PR DESCRIPTION
When using socket activation cups daemon can safely exit on idle and be automatically started when it's needed. Using Restart=always prevent this behavior and causes cups daemon constantly restarting itself instead of exiting. Users reported[1] that Restart=on-failure was enough to fix issues[2] so Restart=always may be unnecessary and harmful.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=861470
[2] https://github.com/apple/cups/issues/5263