### PR TITLE
Fix typo in example (cupsCommand -> cupsCommands)

### DIFF
--- a/doc/help/spec-command.html
+++ b/doc/help/spec-command.html
@@ -40,7 +40,7 @@ files by checking the <code>printer-type</code> attribute for the
 commands separated by spaces, for example:</p>
 
 <pre class='command'>
-*cupsCommand: "AutoConfigure Clean PrintSelfTestPage ReportLevels ReportStatus"
+*cupsCommands: "AutoConfigure Clean PrintSelfTestPage ReportLevels ReportStatus"
 </pre>
 
 <p>If no <code>cupsCommands</code> keyword is provided, the command filter


### PR DESCRIPTION
Hey, this trivial patch fixes a typo in the CUPS Command File example.  I wasted several hours on this before realizing the example was wrong.