### PR TITLE
mailto: Wait for server opening message

### DIFF
--- a/notifier/mailto.c
+++ b/notifier/mailto.c
@@ -248,6 +248,10 @@ email_message(const char *to,		/* I - Recipient of message */
 
     fprintf(stderr, "DEBUG: Connected to \"%s\"...\n", mailtoSMTPServer);
 
+    if (!cupsFileGets(fp, response, sizeof(response)) || atoi(response) >= 500)
+      goto smtp_error;
+    fprintf(stderr, "DEBUG: <<< %s\n", response);
+
     cupsFilePrintf(fp, "HELO %s\r\n",
                    httpGetHostname(NULL, hostbuf, sizeof(hostbuf)));
     fprintf(stderr, "DEBUG: >>> HELO %s\n", hostbuf);


### PR DESCRIPTION
A subset of all mailserver configurations reject SMTP sessions where the
client sends anything before the server sent its opening message. This
is the case with Exim on Ubuntu Artful, for example:

>   SMTP protocol synchronization error (input sent without waiting for
>   greeting)

Not waiting for the opening message is a violation of the session
initiation described in RFC5321 (section 3.1). Update the mailto
notifier to wait for a non-error status code from the server before
proceeding to start the mail transaction.