### PR TITLE
pstops: Avoid operating on uninitialized memory

### DIFF
--- a/filter/pstops.c
+++ b/filter/pstops.c
@@ -2229,7 +2229,7 @@ parse_text(const char *start,		/* I - Start of text value */
   bufptr = buffer;
   bufend = buffer + bufsize - 1;
 
-  while (bufptr < bufend)
+  while (*start && bufptr < bufend)
   {
     if (isspace(*start & 255) && !level)
       break;


### PR DESCRIPTION
The "parse_text" function would read beyond the input buffer if
a PostScript file contained a malformed "%%Page" line, i.e.

```
$ cat >malformed.ps <<'EOF'
%!PS-Adobe-0
0
%%Page: (
EOF
```

Valgrind report:
```
  Use of uninitialised value of size 8
     at 0x11C048: parse_text (pstops.c:2234)
     by 0x11F109: copy_page (pstops.c:1245)
     by 0x1201C2: copy_dsc (pstops.c:850)
     by 0x120FB7: filter_main (pstops.c:343)
     by 0x1210E2: main (fuzzfilter.c:48)
```

Fixed by checking whether the byte to be examined isn't NUL.