### PR TITLE
Fix validation rejecting all NAME and TEXT attrs

### DIFF
--- a/cups/ipp.c
+++ b/cups/ipp.c
@@ -5030,15 +5030,13 @@ ippValidateAttribute(
 	    else if (*ptr & 0x80)
 	      break;
 	    else if ((*ptr < ' ' && *ptr != '\n' && *ptr != '\r' && *ptr != '\t') || *ptr == 0x7f)
-	      break;
+		{
+		  ipp_set_error(IPP_STATUS_ERROR_BAD_REQUEST, _("\"%s\": Bad text value \"%s\" - bad control character (PWG 5100.14 section 8.3)."), attr->name, attr->values[i].string.text);
+		  return (0);
+		}
 	  }
 
-	  if (*ptr < ' ' || *ptr == 0x7f)
-	  {
-	    ipp_set_error(IPP_STATUS_ERROR_BAD_REQUEST, _("\"%s\": Bad text value \"%s\" - bad control character (PWG 5100.14 section 8.3)."), attr->name, attr->values[i].string.text);
-	    return (0);
-	  }
-	  else if (*ptr)
+	  if (*ptr)
 	  {
 	    ipp_set_error(IPP_STATUS_ERROR_BAD_REQUEST, _("\"%s\": Bad text value \"%s\" - bad UTF-8 sequence (RFC 8011 section 5.1.2)."), attr->name, attr->values[i].string.text);
 	    return (0);
@@ -5088,15 +5086,13 @@ ippValidateAttribute(
 	    else if (*ptr & 0x80)
 	      break;
 	    else if (*ptr < ' ' || *ptr == 0x7f)
-	      break;
+		{
+		  ipp_set_error(IPP_STATUS_ERROR_BAD_REQUEST, _("\"%s\": Bad name value \"%s\" - bad control character (PWG 5100.14 section 8.1)."), attr->name, attr->values[i].string.text);
+		  return (0);
+		}
 	  }
 
-	  if (*ptr < ' ' || *ptr == 0x7f)
-	  {
-	    ipp_set_error(IPP_STATUS_ERROR_BAD_REQUEST, _("\"%s\": Bad name value \"%s\" - bad control character (PWG 5100.14 section 8.1)."), attr->name, attr->values[i].string.text);
-	    return (0);
-	  }
-	  else if (*ptr)
+	  if (*ptr)
 	  {
 	    ipp_set_error(IPP_STATUS_ERROR_BAD_REQUEST, _("\"%s\": Bad name value \"%s\" - bad UTF-8 sequence (RFC 8011 section 5.1.3)."), attr->name, attr->values[i].string.text);
 	    return (0);


### PR DESCRIPTION
When the UTF-8 validation loop finishes successfully, `*ptr` points at
the `'\0'` at the end of the string. The code misinterpreted this as a
control character (`*ptr < ' '`) and failed the validation.

Fixes https://github.com/apple/cups/issues/5325