### PR TITLE
log history for journal

### DIFF
--- a/scheduler/log.c
+++ b/scheduler/log.c
@@ -565,48 +565,17 @@ cupsdLogJob(cupsd_job_t *job,		/* I - Job */
     return (1);
 
 #ifdef HAVE_SYSTEMD_SD_JOURNAL_H
-  if (!strcmp(ErrorLog, "syslog"))
-  {
-    cupsd_printer_t *printer = job ? (job->printer ? job->printer : (job->dest ? cupsdFindDest(job->dest) : NULL)) : NULL;
-    static const char * const job_states[] =
-    {					/* job-state strings */
-      "Pending",
-      "PendingHeld",
-      "Processing",
-      "ProcessingStopped",
-      "Canceled",
-      "Aborted",
-      "Completed"
-    };
-
-    va_start(ap, message);
-
-    do
-    {
-      va_copy(ap2, ap);
-      status = format_log_line(message, ap2);
-      va_end(ap2);
-    }
-    while (status == 0);
-
-    va_end(ap);
-
-    if (job)
-      sd_journal_send("MESSAGE=%s", log_line,
-		      "PRIORITY=%i", log_levels[level],
-		      PWG_Event"=JobStateChanged",
-		      PWG_ServiceURI"=%s", printer ? printer->uri : "",
-		      PWG_JobID"=%d", job->id,
-		      PWG_JobState"=%s", job->state_value < IPP_JSTATE_PENDING ? "" : job_states[job->state_value - IPP_JSTATE_PENDING],
-		      PWG_JobImpressionsCompleted"=%d", ippGetInteger(job->impressions, 0),
-		      NULL);
-    else
-      sd_journal_send("MESSAGE=%s", log_line,
-		      "PRIORITY=%i", log_levels[level],
-		      NULL);
-
-    return (1);
-  }
+  cupsd_printer_t *printer = job ? (job->printer ? job->printer : (job->dest ? cupsdFindDest(job->dest) : NULL)) : NULL;
+  static const char * const job_states[] =
+  {					/* job-state strings */
+    "Pending",
+    "PendingHeld",
+    "Processing",
+    "ProcessingStopped",
+    "Canceled",
+    "Aborted",
+    "Completed"
+  };
 #endif /* HAVE_SYSTEMD_SD_JOURNAL_H */
 
  /*
@@ -672,7 +641,29 @@ cupsdLogJob(cupsd_job_t *job,		/* I - Job */
       return (1);
     }
     else if (level <= LogLevel)
+    {
+#ifdef HAVE_SYSTEMD_SD_JOURNAL_H
+      if (!strcmp(ErrorLog, "syslog"))
+      {
+        if (job)
+          sd_journal_send("MESSAGE=%s", log_line,
+    		      "PRIORITY=%i", log_levels[level],
+    		      PWG_Event"=JobStateChanged",
+    		      PWG_ServiceURI"=%s", printer ? printer->uri : "",
+    		      PWG_JobID"=%d", job->id,
+    		      PWG_JobState"=%s", job->state_value < IPP_JSTATE_PENDING ? "" : job_states[job->state_value - IPP_JSTATE_PENDING],
+    		      PWG_JobImpressionsCompleted"=%d", ippGetInteger(job->impressions, 0),
+    		      NULL);
+        else
+          sd_journal_send("MESSAGE=%s", log_line,
+    		      "PRIORITY=%i", log_levels[level],
+    		      NULL);
+    
+        return (1);
+      }
+#endif /* HAVE_SYSTEMD_SD_JOURNAL_H */
       return (cupsdWriteErrorLog(level, log_line));
+    }
     else
       return (1);
   }


### PR DESCRIPTION
Hi Mike,
when I was reproducing Fedora bug https://bugzilla.redhat.com/show_bug.cgi?id=1589593 , I found out the LogLevel directive is ignored when I have logging set to syslog (systemd-journald in Fedora) when LogDebugHistory is greater than 0 (I have it set to 200, according gdb).
To track the fix I looked more into cupsdLogJob function and found out there is job logs history tracked for no-systemd OS - so to solve 'ignoring issue' I implemented this patch, which now correctly respects the LogLevels (tested) and has job logs history for systemd OS (this one needs testing).
I tested it by changing where ErrorLog goes (syslog, /var/log/cups) and changing LogLevels (none, warn, debug2), but I don't know how to test job logs history feature.
Would CUPS benefit from this patch?