### PR TITLE
PPDs for driverless printing: Make jobs be printed in correct order for face-up/face-down

### DIFF
--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -3034,6 +3034,7 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
   cups_array_t		*sizes;		/* Media sizes supported by printer */
   cups_size_t		*size;		/* Current media size */
   ipp_attribute_t	*attr,		/* xxx-supported */
+			*attr2,
 			*defattr,	/* xxx-default */
                         *quality,	/* print-quality-supported */
 			*x_dim, *y_dim;	/* Media dimensions */
@@ -3071,7 +3072,12 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
 					/* Locale data */
   cups_array_t		*fin_options = NULL;
 					/* Finishing options */
-
+  char			*defaultoutbin = NULL;
+  const char		*outbin,
+			*outbin_properties;
+  int			outputorderinfofound = 0,
+			faceupdown = 1,
+			firsttolast = 1;
 
  /*
   * Range check input...
@@ -3137,6 +3143,51 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
   cupsFilePrintf(fp, "*Product: \"(%s)\"\n", model);
   cupsFilePrintf(fp, "*NickName: \"%s - IPP Everywhere\"\n", model);
   cupsFilePrintf(fp, "*ShortNickName: \"%s - IPP Everywhere\"\n", model);
+
+  /* Which is the default output bin? */
+  if ((attr = ippFindAttribute(response, "output-bin-default", IPP_TAG_MIMETYPE)) != NULL)
+    defaultoutbin = strdup(ippGetString(attr, 0, NULL));
+  /* Find out on which position of the list of output bins the default one is, if there
+     is no default bin, take the first of this list */
+  i = 0;
+  if ((attr = ippFindAttribute(response, "output-bin-supported", IPP_TAG_MIMETYPE)) != NULL)
+  {
+    count = ippGetCount(attr);
+    for (i = 0; i < count; i ++)
+    {
+      outbin = ippGetString(attr, i, NULL);
+      if (outbin == NULL)
+	continue;
+      if (defaultoutbin == NULL)
+      {
+	defaultoutbin = strdup(outbin);
+	break;
+      }
+      else if (strcasecmp(outbin, defaultoutbin) == 0)
+	break;
+    }
+  }
+  /* Look up the corresponding entry in the "printer-output-tray" attribute */
+  if ((attr = ippFindAttribute(response, "printer-output-tray", IPP_TAG_MIMETYPE)) != NULL &&
+      i < ippGetCount(attr))
+  {
+    outbin_properties = ippGetString(attr, i, NULL);
+    if (strcasestr(outbin_properties, "pagedelivery=faceUp"))
+    {
+      outputorderinfofound = 1;
+      faceupdown = -1;
+    }
+    if (strcasestr(outbin_properties, "stackingorder=lastToFirst"))
+      firsttolast = -1;
+  }
+  if (outputorderinfofound == 0 && defaultoutbin && strcasestr(defaultoutbin, "face-up"))
+    faceupdown = -1;
+  if (defaultoutbin)
+    free (defaultoutbin);
+  if (firsttolast * faceupdown < 0)
+    cupsFilePuts(fp, "*DefaultOutputOrder: Reverse\n");
+  else
+    cupsFilePuts(fp, "*DefaultOutputOrder: Normal\n");
 
   if ((attr = ippFindAttribute(response, "color-supported", IPP_TAG_BOOLEAN)) != NULL && ippGetBoolean(attr, 0))
     cupsFilePuts(fp, "*ColorDevice: True\n");
@@ -3916,6 +3967,7 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
     cupsFilePrintf(fp, "*OpenUI *OutputBin: PickOne\n"
                        "*OrderDependency: 10 AnySetup *OutputBin\n"
                        "*DefaultOutputBin: %s\n", ppdname);
+    attr2 = ippFindAttribute(response, "printer-output-tray", IPP_TAG_MIMETYPE);
     for (i = 0; i < count; i ++)
     {
       keyword = ippGetString(attr, i, NULL);
@@ -3928,6 +3980,50 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
 	  msgstr = keyword;
 
       cupsFilePrintf(fp, "*OutputBin %s/%s: \"\"\n", ppdname, msgstr);
+      outputorderinfofound = 0;
+      faceupdown = 1;
+      firsttolast = 1;
+      if (attr2 && i < ippGetCount(attr2))
+      {
+	outbin_properties = ippGetString(attr2, i, NULL);
+	if (strcasestr(outbin_properties, "pagedelivery=faceUp"))
+	{
+	  outputorderinfofound = 1;
+	  faceupdown = -1;
+	}
+	else if (strcasestr(outbin_properties, "pagedelivery=faceDown"))
+	{
+	  outputorderinfofound = 1;
+	  faceupdown = 1;
+	}
+	if (strcasestr(outbin_properties, "stackingorder=lastToFirst"))
+	{
+	  outputorderinfofound = 1;
+	  firsttolast = -1;
+	}
+	else if (strcasestr(outbin_properties, "stackingorder=firstToLast"))
+	{
+	  outputorderinfofound = 1;
+	  firsttolast = 1;
+	}
+      }
+      if (outputorderinfofound == 0)
+      {
+	if (strcasestr(keyword, "face-up"))
+	{
+	  outputorderinfofound = 1;
+	  faceupdown = -1;
+	}
+	if (strcasestr(keyword, "face-down"))
+	{
+	  outputorderinfofound = 1;
+	  faceupdown = 1;
+	}
+      }
+      if (outputorderinfofound)
+	cupsFilePrintf(fp, "*PageStackOrder %s: %s\n",
+		       ppdname,
+		       (firsttolast * faceupdown < 0 ? "Reverse" : "Normal"));
     }
     cupsFilePuts(fp, "*CloseUI: *OutputBin\n");
   }

--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -3073,8 +3073,10 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
   cups_array_t		*fin_options = NULL;
 					/* Finishing options */
   char			*defaultoutbin = NULL;
-  const char		*outbin,
-			*outbin_properties;
+  const char		*outbin;
+  char			outbin_properties[1024];
+  int			octet_str_len;
+  void			*outbin_properties_octet;
   int			outputorderinfofound = 0,
 			faceupdown = 1,
 			firsttolast = 1;
@@ -3168,10 +3170,14 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
     }
   }
   /* Look up the corresponding entry in the "printer-output-tray" attribute */
-  if ((attr = ippFindAttribute(response, "printer-output-tray", IPP_TAG_ZERO)) != NULL &&
+  if ((attr = ippFindAttribute(response, "printer-output-tray", IPP_TAG_STRING)) != NULL &&
       i < ippGetCount(attr))
   {
-    outbin_properties = ippGetString(attr, i, NULL);
+    outbin_properties_octet = ippGetOctetString(attr, i, &octet_str_len);
+    memset(outbin_properties, 0, sizeof(outbin_properties));
+    memcpy(outbin_properties, outbin_properties_octet,
+	   ((size_t)octet_str_len < sizeof(outbin_properties) - 1 ?
+	    (size_t)octet_str_len : sizeof(outbin_properties) - 1));
     if (strcasestr(outbin_properties, "pagedelivery=faceUp"))
     {
       outputorderinfofound = 1;
@@ -3967,7 +3973,7 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
     cupsFilePrintf(fp, "*OpenUI *OutputBin: PickOne\n"
                        "*OrderDependency: 10 AnySetup *OutputBin\n"
                        "*DefaultOutputBin: %s\n", ppdname);
-    attr2 = ippFindAttribute(response, "printer-output-tray", IPP_TAG_ZERO);
+    attr2 = ippFindAttribute(response, "printer-output-tray", IPP_TAG_STRING);
     for (i = 0; i < count; i ++)
     {
       keyword = ippGetString(attr, i, NULL);
@@ -3985,7 +3991,11 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
       firsttolast = 1;
       if (attr2 && i < ippGetCount(attr2))
       {
-	outbin_properties = ippGetString(attr2, i, NULL);
+	outbin_properties_octet = ippGetOctetString(attr2, i, &octet_str_len);
+	memset(outbin_properties, 0, sizeof(outbin_properties));
+	memcpy(outbin_properties, outbin_properties_octet,
+	       ((size_t)octet_str_len < sizeof(outbin_properties) - 1 ?
+		(size_t)octet_str_len : sizeof(outbin_properties) - 1));
 	if (strcasestr(outbin_properties, "pagedelivery=faceUp"))
 	{
 	  outputorderinfofound = 1;

--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -3145,12 +3145,12 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
   cupsFilePrintf(fp, "*ShortNickName: \"%s - IPP Everywhere\"\n", model);
 
   /* Which is the default output bin? */
-  if ((attr = ippFindAttribute(response, "output-bin-default", IPP_TAG_MIMETYPE)) != NULL)
+  if ((attr = ippFindAttribute(response, "output-bin-default", IPP_TAG_ZERO)) != NULL)
     defaultoutbin = strdup(ippGetString(attr, 0, NULL));
   /* Find out on which position of the list of output bins the default one is, if there
      is no default bin, take the first of this list */
   i = 0;
-  if ((attr = ippFindAttribute(response, "output-bin-supported", IPP_TAG_MIMETYPE)) != NULL)
+  if ((attr = ippFindAttribute(response, "output-bin-supported", IPP_TAG_ZERO)) != NULL)
   {
     count = ippGetCount(attr);
     for (i = 0; i < count; i ++)
@@ -3168,7 +3168,7 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
     }
   }
   /* Look up the corresponding entry in the "printer-output-tray" attribute */
-  if ((attr = ippFindAttribute(response, "printer-output-tray", IPP_TAG_MIMETYPE)) != NULL &&
+  if ((attr = ippFindAttribute(response, "printer-output-tray", IPP_TAG_ZERO)) != NULL &&
       i < ippGetCount(attr))
   {
     outbin_properties = ippGetString(attr, i, NULL);
@@ -3967,7 +3967,7 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
     cupsFilePrintf(fp, "*OpenUI *OutputBin: PickOne\n"
                        "*OrderDependency: 10 AnySetup *OutputBin\n"
                        "*DefaultOutputBin: %s\n", ppdname);
-    attr2 = ippFindAttribute(response, "printer-output-tray", IPP_TAG_MIMETYPE);
+    attr2 = ippFindAttribute(response, "printer-output-tray", IPP_TAG_ZERO);
     for (i = 0; i < count; i ++)
     {
       keyword = ippGetString(attr, i, NULL);


### PR DESCRIPTION
In https://github.com/apple/cups/issues/5315 and https://github.com/OpenPrinting/cups-filters/issues/47 a user complained about that on printers which stack up their output pages face-up the pages should get printed in reverse order.
I have investigated this and the main problem is that many PPD files are missing the appropriate information about how the paper gets stacked.
In case of driverless printing the answers to the get-printer-attributes request always contains the needed information. Either the names of the output-bins (attributes "output-bin-supported", "output-bin-default" are named "face-up" or "face-down" or there is an array named "printer-output-tray" with the same number of items as "output-bin-supported", describing the properties of each output bin, especially telling about the way the pages get stacked ([PWG 5100.13 – IPP: Job and Printer Extensions – Set 3](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext3v10-20120727-5100.13.pdf), section 5.6.36).
The patch (which I also have applied to the PPD generator of cups-filters) makes this information available in the generated PPD files for driverless printing. Once, the PPD file gets a "*DefaultOutputOrder: ..." line with either "Normal" or "Reverse" as value, the latter indicating that the pages get stackked face-up in the default tray and therefore the pages need to get printed in reverse order (which `pdftopdf` of cups-filters takes care of in this case). Second, if the PPD has an "OutputBin" option, I add a "*PageStackOrder ..." line to each choice of the "OutputBin" option telling whether this bin is face-up or face-down. Also this is taken care of by `pdftopdf` (see "*OutputOrder", p124, and "*PageStackOrder", p125, in Adobe's PPD specs).
This way printers set up with driverless printing of CUPS should print the jobs in the correct order with respect to the fact that they stack their output face-up or face-down.