### PR TITLE
Some fix about pt_BR translate

### DIFF
--- a/templates/pt_BR/header.tmpl.in
+++ b/templates/pt_BR/header.tmpl.in
@@ -31,7 +31,7 @@
       <ul>
 	<li><a href="http://www.cups.org/" target="_blank">CUPS.org</a></li>
 	<li><a href="/">In&iacute;cio</a></li>
-	<li><a {SECTION=admin?class="active" :}href="/admin">Administrar&ccedil;&atilde;o</a></li>
+	<li><a {SECTION=admin?class="active" :}href="/admin">Administra&ccedil;&atilde;o</a></li>
 	<li><a {SECTION=classes?class="active" :}href="/classes/">Classes</a></li>
 	<li><a {SECTION=help?class="active" :}href="/help/">Ajuda</a></li>
 	<li><a {SECTION=jobs?class="active" :}href="/jobs/">Trabalhos</a></li>

--- a/templates/pt_BR/jobs-header.tmpl
+++ b/templates/pt_BR/jobs-header.tmpl
@@ -1,5 +1,5 @@
 {?which_jobs=?:<FORM ACTION="{?printer_name=?/jobs:{printer_uri_supported}}" METHOD="GET"><INPUT TYPE="SUBMIT" VALUE="Mostrar trabalhos ativos"></FORM>}
-{?which_jobs=completed?:<FORM ACTION="{?printer_name=?/jobs:{printer_uri_supported}}" METHOD="GET"><INPUT TYPE="HIDDEN" NAME="which_jobs" VALUE="conclu&iacute;dos"><INPUT TYPE="SUBMIT" VALUE="Mostrar trabalhos conclu&iacute;dos"></FORM>}
+{?which_jobs=completed?:<FORM ACTION="{?printer_name=?/jobs:{printer_uri_supported}}" METHOD="GET"><INPUT TYPE="HIDDEN" NAME="which_jobs" VALUE="completed"><INPUT TYPE="SUBMIT" VALUE="Mostrar trabalhos conclu&iacute;dos"></FORM>}
 {?which_jobs=all?:<FORM ACTION="{?printer_name=?/jobs:{printer_uri_supported}}" METHOD="GET"><INPUT TYPE="HIDDEN" NAME="which_jobs" VALUE="all"><INPUT TYPE="SUBMIT" VALUE="Mostrar todos trabalhos"></FORM>}
 
 <P ALIGN="CENTER">{?which_jobs=?Jobs listed in print order; held jobs appear first.:{which_jobs=Jobs listed in ascending order.?:Jobs listed in descending order.}}</P>


### PR DESCRIPTION
I did a new deploy of cups (version 2.2.7) today in a fresh ubuntu 18.04 installation and found:
* one bug in templates/pt_BR/job-header.tmpl; and
> When someone click on button "Mostrar trabalhos concluídos", the value passed is wrong.

* one translate error in templates/pt_BR/header.tpml.
> At cups interface header the translanting of "Admin" is wrong.

So I'd like put my contributing here.