### PR TITLE
Correct typos in rastertolabel

### DIFF
--- a/filter/rastertolabel.c
+++ b/filter/rastertolabel.c
@@ -368,7 +368,7 @@ StartPage(ppd_file_t         *ppd,	/* I - PPD file */
 
           if (header->cupsCompression != ~0U)
 	  				/* inPrintDensity */
-	    printf("\033&d%uA", 30 * header->cupsCompression / 100 - 15);
+	    printf("\033&d%dA", 30 * header->cupsCompression / 100 - 15);
 
 	  if ((choice = ppdFindMarkedChoice(ppd, "inPrintMode")) != NULL)
 	  {


### PR DESCRIPTION
Whilst testing changes for #5092 I noticed a few typos in rastertolabel.

- Zebra CPCL output appears to specify the PAGE-HEIGHT as header->cupsWidth.
- Intellitech print density outputs an unsigned integer, where a signed integer is required
