### PR TITLE
cc->ssl_options needs to be initialized

### DIFF
--- a/cups/usersys.c
+++ b/cups/usersys.c
@@ -1161,6 +1161,7 @@ cups_init_client_conf(
   memset(cc, 0, sizeof(_cups_client_conf_t));
 
 #ifdef HAVE_SSL
+  cc->ssl_options = _HTTP_TLS_NONE;
   cc->ssl_min_version = _HTTP_TLS_1_0;
   cc->ssl_max_version = _HTTP_TLS_MAX;
 #endif /* HAVE_SSL */


### PR DESCRIPTION
Hi Mike,
I was backporting MinTLS/MaxTLS functionality from 2.2.8 to 2.2.6 and I found out when you don't have any 'SSLOptions' directive in client.conf, then cc->ssl_options isn't initialized and has undefined value. And that undefined value is used in other functions and can cause troubles.
Would you mind merging this patch? It is just initialization and I and user who had troubles tested it and it worked.