### PR TITLE
Abort job with multiple files when backend fails

### DIFF
--- a/backend/socket.c
+++ b/backend/socket.c
@@ -443,7 +443,7 @@ main(int  argc,				/* I - Number of command-line arguments (6 or 7) */
   if (print_fd != 0)
     close(print_fd);
 
-  return (CUPS_BACKEND_OK);
+  return (tbytes < 0 ? CUPS_BACKEND_FAILED : CUPS_BACKEND_OK);
 }
 
 

--- a/scheduler/main.c
+++ b/scheduler/main.c
@@ -1474,7 +1474,12 @@ process_children(void)
 	    if (job->filters[i])
 	      job->status = status;	/* Filter failed */
 	    else
+            {
 	      job->status = -status;	/* Backend failed */
+
+              if (job->num_files > 1)
+                cupsdSetJobState(job, IPP_JOB_ABORTED, CUPSD_JOB_FORCE, "Backend failed for job with multiple files, cancelling.");
+            }
           }
 
 	  if (job->state_value == IPP_JOB_PROCESSING &&


### PR DESCRIPTION
Hi,

there is the first shot, which gets multiple files job aborted when backend suddenly lost connection during data transfer as I wrote in email. I am lost in making such job retry - I think a recovery for retry is rather complicated - checking which file didn't print correctly and probably creating new job for the unfinished business.
This pull request is connected to issue #5359 , is it a right way to go?