### PR TITLE
Avoid truncation when encoding Kerberos token

### DIFF
--- a/cups/auth.c
+++ b/cups/auth.c
@@ -442,7 +442,7 @@ _cupsSetNegotiateAuthString(
     */
 
     int authsize = 10 +			/* "Negotiate " */
-		   (int)output_token.length * 4 / 3 + 1 + 1;
+		   (int)(((4 * output_token.length / 3) + 3) & ~3) + 1;
 		   			/* Base64 + nul */
 
     httpSetAuthString(http, NULL, NULL);


### PR DESCRIPTION
The "httpEncode64_2" function appends padding (0-3x "="). The buffer
size calculation in "_cupsSetNegotiateAuthString" did the calculation
wrongly and would have a buffer overflow for tokens of size (N * 4)
\+ 1 and (N * 4) + 2. With this change the buffer size is computed
correctly.

See commit message for detailed calculation.