### PR TITLE
Fix call to usage which requires an int argument

### DIFF
--- a/scheduler/main.c
+++ b/scheduler/main.c
@@ -155,7 +155,7 @@ main(int  argc,				/* I - Number of command-line args */
   for (i = 1; i < argc; i ++)
   {
     if (!strcmp(argv[i], "--help"))
-      usage();
+      usage(1);
     else if (argv[i][0] == '-')
     {
       for (opt = argv[i] + 1; *opt != '\0'; opt ++)


### PR DESCRIPTION
Otherwise compilation fails:

```
main.c: In function ‘main’:
main.c:158:7: error: too few arguments to function ‘usage’
       usage();
       ^~~~~
main.c:73:14: note: declared here
 static void  usage(int status) _CUPS_NORETURN;
              ^~~~~
make[1]: *** [../Makedefs:270: main.o] Error 1
```