### PR TITLE
Fix service_idle_exit build issue with -Werror=maybe-unitialized

### DIFF
--- a/scheduler/main.c
+++ b/scheduler/main.c
@@ -129,7 +129,7 @@ main(int  argc,				/* I - Number of command-line args */
   time_t		netif_time = 0;	/* Time since last network update */
 #endif /* __APPLE__ */
 #if defined(HAVE_ONDEMAND)
-  int			service_idle_exit;
+  int			service_idle_exit = 0;
 					/* Idle exit on select timeout? */
 #endif /* HAVE_ONDEMAND */
 


### PR DESCRIPTION
There's only one line that makes the build fail under `-Werror=maybe-unitialized` :

```
Compiling listen.c...
cc  -fPIC -g -fstack-protector -D_GNU_SOURCE -I.. -D_CUPS_SOURCE -isystem /usr/include/mit-krb5 -Wdate-time -D_FORTIFY_SOURCE=2 -isystem /usr/include/mit-krb5 -g -O2 -fdebug-prefix-map=/tmp/reprotest.wwqjgR/const_build_path=. -specs=/usr/share/dpkg/no-pie-compile.specs -fstack-protector-strong -Wformat -Werror=format-security -I/usr/include/libusb-1.0 -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -DDBUS_API_SUBJECT_TO_CHANGE -D_FORTIFY_SOURCE=2 -D_REENTRANT -I/usr/include/p11-kit-1 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_THREAD_SAFE -D_REENTRANT  -Werror -Wno-error=deprecated-declarations -Wall -Wno-format-y2k -Wunused -Wno-unused-result -Wsign-conversion -Wno-format-truncation -Wno-tautological-compare -c -o listen.o listen.c
main.c: In function ‘main’:
main.c:942:14: error: ‘service_idle_exit’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     if (!fds && service_idle_exit)
              ^~
```

It should be initialized to `0`, right?