### PR TITLE
PPD parser: Calling cupsFileGetChar(...) after EOF

### DIFF
--- a/cups/ppd.c
+++ b/cups/ppd.c
@@ -3038,7 +3038,7 @@ ppd_read(cups_file_t    *fp,		/* I - File to read from */
       }
     }
 
-    if (endquote)
+    if (endquote && ch != EOF)
     {
      /*
       * Didn't finish this quoted string...
@@ -3093,7 +3093,7 @@ ppd_read(cups_file_t    *fp,		/* I - File to read from */
 	}
     }
 
-    if (ch != '\n')
+    if (ch != '\n' && ch != EOF)
     {
      /*
       * Didn't finish this line...


### PR DESCRIPTION
For some input data the function cupsFileGetChar(...) was incorrectly called
from the function ppd_read(...) after returning EOF in a previous call. This
causes incorrect state of cups_file and results in memory leak.