### PR TITLE
Raw TLS socket support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ backend/socket
 backend/test1284
 backend/testbackend
 backend/testsupplies
+backend/tlsraw
 backend/usb
 berkeley/lpc
 berkeley/lpq

--- a/Makedefs.in
+++ b/Makedefs.in
@@ -116,6 +116,12 @@ INSTALLSTATIC	=	@INSTALLSTATIC@
 IPPALIASES	=	@IPPALIASES@
 
 #
+# Socket backend aliases...
+#
+
+SOCKETALIASES	=	@SOCKETALIASES@
+
+#
 # Install XPC backends?
 #
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -80,7 +80,7 @@ unittests:	$(UNITTESTS)
 #
 
 clean:
-	$(RM) $(OBJS) $(TARGETS) $(UNITTESTS) $(LIBOBJS) http https ipps mdns socket-static
+	$(RM) $(OBJS) $(TARGETS) $(UNITTESTS) $(LIBOBJS) http https ipps mdns socket-static tlsraw tlsraw-static
 
 
 #
@@ -127,6 +127,10 @@ install-exec:	$(INSTALLXPC)
 		$(RM) $(SERVERBIN)/backend/$$file; \
 		$(LN) ipp $(SERVERBIN)/backend/$$file; \
 	done
+	for file in $(SOCKETALIASES); do \
+		$(RM) $(SERVERBIN)/backend/$$file; \
+		$(LN) socket $(SERVERBIN)/backend/$$file; \
+	done
 	if test "x$(DNSSD_BACKEND)" != x -a `uname` = Darwin; then \
 		$(RM) $(SERVERBIN)/backend/mdns; \
 		$(LN) $(DNSSD_BACKEND) $(SERVERBIN)/backend/mdns; \
@@ -146,6 +150,10 @@ install-xpc:	ipp
 	for file in $(IPPALIASES); do \
 		$(RM) $(SERVERBIN)/apple/$$file; \
 		$(LN) ipp $(SERVERBIN)/apple/$$file; \
+	done
+	for file in $(SOCKETALIASES); do \
+		$(RM) $(SERVERBIN)/apple/$$file; \
+		$(LN) socket $(SERVERBIN)/apple/$$file; \
 	done
 
 
@@ -181,14 +189,14 @@ install-libs:
 
 uninstall:
 	$(RM) $(SERVERBIN)/apple/ipp
-	for file in $(IPPALIASES); do \
+	for file in $(IPPALIASES) $(SOCKETALIASES); do \
 		$(RM) $(SERVERBIN)/apple/$$file; \
 	done
 	-$(RMDIR) $(SERVERBIN)/apple
 	for file in $(RBACKENDS) $(UBACKENDS) $(ULBACKENDS); do \
 		$(RM) $(SERVERBIN)/backend/$$file; \
 	done
-	for file in $(IPPALIASES); do \
+	for file in $(IPPALIASES) $(SOCKETALIASES); do \
 		$(RM) $(SERVERBIN)/backend/$$file; \
 	done
 	-$(RMDIR) $(SERVERBIN)/backend
@@ -296,6 +304,10 @@ socket:	socket.o ../cups/$(LIBCUPS) libbackend.a
 	echo Linking $@...
 	$(LD_CC) $(LDFLAGS) -o socket socket.o libbackend.a $(LIBS)
 	$(CODE_SIGN) -s "$(CODE_SIGN_IDENTITY)" $@
+	$(RM) tlsraw
+	for file in $(SOCKETALIASES); do \
+		$(LN) socket $$file; \
+	done
 
 socket-static:	socket.o  ../cups/$(LIBCUPSSTATIC) libbackend.a
 	echo Linking $@...
@@ -303,6 +315,10 @@ socket-static:	socket.o  ../cups/$(LIBCUPSSTATIC) libbackend.a
 		../cups/$(LIBCUPSSTATIC) $(LIBGSSAPI) $(SSLLIBS) $(DNSSDLIBS) \
 		$(COMMONLIBS) $(LIBZ)
 	$(CODE_SIGN) -s "$(CODE_SIGN_IDENTITY)" $@
+	$(RM) tlsraw-static
+	for file in $(SOCKETALIASES); do \
+		$(LN) socket-static $${file}-static; \
+	done
 
 
 #

--- a/backend/socket.c
+++ b/backend/socket.c
@@ -162,8 +162,17 @@ main(int  argc,				/* I - Number of command-line arguments (6 or 7) */
                   username, sizeof(username), hostname, sizeof(hostname), &port,
 		  resource, sizeof(resource));
 
-  if (port == 0)
-    port = 9100;	/* Default to HP JetDirect/Tektronix PhaserShare */
+  if (!strcmp(scheme, "tlsraw"))
+    cupsSetEncryption(HTTP_ENCRYPTION_ALWAYS);
+  else
+    cupsSetEncryption(HTTP_ENCRYPTION_NEVER);
+
+  if (port == 0) {
+    if (cupsEncryption())
+      port = 9143;	/* Default to Zebra TLSRAW */
+    else
+      port = 9100;	/* Default to HP JetDirect/Tektronix PhaserShare */
+  }
 
  /*
   * Get options, if any...
@@ -259,7 +268,7 @@ main(int  argc,				/* I - Number of command-line arguments (6 or 7) */
 
   addrlist = backendLookup(hostname, port, NULL);
 
-  http = httpConnect2(hostname, port, addrlist, AF_UNSPEC, HTTP_ENCRYPTION_NEVER, 1,
+  http = httpConnect2(hostname, port, addrlist, AF_UNSPEC, cupsEncryption(), 1,
 		      0, NULL);
 
  /*

--- a/config-scripts/cups-ssl.m4
+++ b/config-scripts/cups-ssl.m4
@@ -84,16 +84,19 @@ if test x$enable_ssl != xno; then
 fi
 
 IPPALIASES="http"
+SOCKETALIASES=""
 if test $have_ssl = 1; then
     AC_MSG_RESULT([    Using SSLLIBS="$SSLLIBS"])
     AC_MSG_RESULT([    Using SSLFLAGS="$SSLFLAGS"])
     IPPALIASES="http https ipps"
+    SOCKETALIASES="tlsraw"
 elif test x$enable_cdsa = xyes -o x$enable_gnutls = xyes; then
     AC_MSG_ERROR([Unable to enable SSL support.])
 fi
 
 AC_SUBST(CUPS_SERVERKEYCHAIN)
 AC_SUBST(IPPALIASES)
+AC_SUBST(SOCKETALIASES)
 AC_SUBST(SSLFLAGS)
 AC_SUBST(SSLLIBS)
 

--- a/configure
+++ b/configure
@@ -677,6 +677,7 @@ PAMDIR
 EXPORT_SSLLIBS
 SSLLIBS
 SSLFLAGS
+SOCKETALIASES
 IPPALIASES
 CUPS_SERVERKEYCHAIN
 LIBGNUTLSCONFIG
@@ -8532,15 +8533,18 @@ fi
 fi
 
 IPPALIASES="http"
+SOCKETALIASES=""
 if test $have_ssl = 1; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: result:     Using SSLLIBS=\"$SSLLIBS\"" >&5
 $as_echo "    Using SSLLIBS=\"$SSLLIBS\"" >&6; }
     { $as_echo "$as_me:${as_lineno-$LINENO}: result:     Using SSLFLAGS=\"$SSLFLAGS\"" >&5
 $as_echo "    Using SSLFLAGS=\"$SSLFLAGS\"" >&6; }
     IPPALIASES="http https ipps"
+    SOCKETALIASES="tlsraw"
 elif test x$enable_cdsa = xyes -o x$enable_gnutls = xyes; then
     as_fn_error $? "Unable to enable SSL support." "$LINENO" 5
 fi
+
 
 
 

--- a/doc/help/admin.html
+++ b/doc/help/admin.html
@@ -99,6 +99,7 @@ everywhere IPP Everywhere</pre>
       <li><code>ipps</code>: The Internet Printing Protocol with mandatory encryption.</li>
       <li><code>lpd</code>: The Line Printer Daemon protocol.</li>
       <li><code>socket</code>: The AppSocket (JetDirect) protocol.</li>
+      <li><code>tlsraw</code>: The AppSocket (JetDirect) protocol with encryption.</li>
       <li><code>usb</code>: The Universal Serial Bus (USB) printer class.</li>
     </ol>
 

--- a/doc/help/firewalls.html
+++ b/doc/help/firewalls.html
@@ -68,6 +68,7 @@
         <tr><td>631&nbsp;(IPP/IPPS)</td><td>TCP</td><td>Internet Printing Protocol requests and responses (print jobs, status monitoring, etc.)</td></tr>
         <tr><td>5353&nbsp;(mDNS)</td><td>UDP</td><td>Multicast DNS lookups.</td></tr>
         <tr><td>9100-9102</td><td>TCP</td><td>Raw print data stream (AppSocket/JetDirect).</td></tr>
+	<tr><td>9143</td><td>TCP</td><td>Encrypted raw print data stream (AppSocket/JetDirect).</td></tr>
       </tbody>
     </table></div>
   </body>

--- a/doc/help/network.html
+++ b/doc/help/network.html
@@ -73,7 +73,8 @@ Request timeout for icmp_seq 1
 socket://ip-address/?contimeout=30
 socket://ip-address/?waiteof=false
 socket://ip-address/?contimeout=30&amp;waiteof=false
-socket://ip-address:port-number/?...</pre>
+socket://ip-address:port-number/?...
+tlsraw://hostname:port-number</pre>
 
     <p>The "contimeout" option controls the number of seconds that the backend will wait to obtain a connection to the printer. The default is 1 week or 604800 seconds.</p>
 


### PR DESCRIPTION
This small patch series adds support for TLS to the socket backend.  This allows CUPS to communicate with printers such as the Zebra ZQ520, which can listen on port 9143 for TLS-encrypted AppSocket/JetDirect connections.