### PR TITLE
scheduler/main.c: support READY_FD protocol

### DIFF
--- a/man/cupsd.man.in
+++ b/man/cupsd.man.in
@@ -23,6 +23,8 @@ cupsd \- cups scheduler
 ] [
 .B \-l
 ] [
+.B \-r
+] [
 .B \-s
 .I cups-files.conf
 ] [
@@ -61,6 +63,10 @@ when it is run from
 .BR launchd (8)
 or
 .BR systemd (8).
+.TP 5
+.B \-r
+Writes a newline to the file descriptor described by the READY_FD environment
+variable to indicate readiness to a service supervisor.
 .TP 5
 .BI \-s \ cups-files.conf
 Uses the named cups-files.conf configuration file.


### PR DESCRIPTION
This pull request add supports for a lightweight service readiness protocol.

The specification and reference supervisor implementation of the protocol can be found [here](https://gitlab.com/chinstrap/ready).

The protocol is compatible with the s6 service supervision suite, and the reference implementation can be paired with many other service supervisors.