### PR TITLE
Show warning about logs in syslog in Web UI

### DIFF
--- a/scheduler/client.c
+++ b/scheduler/client.c
@@ -2814,7 +2814,7 @@ get_file(cupsd_client_t *con,		/* I  - Client connection */
       if (AccessLog[0] == '/')
         strlcpy(filename, AccessLog, len);
 #ifdef HAVE_SYSTEMD_SD_JOURNAL_H || defined(HAVE_VSYSLOG)
-      else if (!strcmp(AccessLog, "syslog"))
+      else if (!strcmp(AccessLog, "syslog") && WebInterface)
       {
         cupsdLogClient(con, CUPSD_LOG_DEBUG2, "Log is set to syslog, get syslog warning file \"%s\".", SyslogWarn);
         strlcpy(filename, SyslogWarn, len);
@@ -2828,7 +2828,7 @@ get_file(cupsd_client_t *con,		/* I  - Client connection */
       if (ErrorLog[0] == '/')
         strlcpy(filename, ErrorLog, len);
 #ifdef HAVE_SYSTEMD_SD_JOURNAL_H || defined(HAVE_VSYSLOG)
-      else if (!strcmp(ErrorLog, "syslog"))
+      else if (!strcmp(ErrorLog, "syslog") && WebInterface)
       {
         cupsdLogClient(con, CUPSD_LOG_DEBUG2, "Log is set to syslog, get syslog warning file \"%s\".", SyslogWarn);
         strlcpy(filename, SyslogWarn, len);
@@ -2842,7 +2842,7 @@ get_file(cupsd_client_t *con,		/* I  - Client connection */
       if (PageLog[0] == '/')
         strlcpy(filename, PageLog, len);
 #ifdef HAVE_SYSTEMD_SD_JOURNAL_H || defined(HAVE_VSYSLOG)
-      else if (!strcmp(PageLog, "syslog"))
+      else if (!strcmp(PageLog, "syslog") && WebInterface)
       {
         cupsdLogClient(con, CUPSD_LOG_DEBUG2, "Log is set to syslog, get syslog warning file \"%s\".", SyslogWarn);
         strlcpy(filename, SyslogWarn, len);

--- a/scheduler/client.c
+++ b/scheduler/client.c
@@ -2809,12 +2809,48 @@ get_file(cupsd_client_t *con,		/* I  - Client connection */
   }
   else if (!strncmp(con->uri, "/admin/log/", 11))
   {
-    if (!strncmp(con->uri + 11, "access_log", 10) && AccessLog[0] == '/')
-      strlcpy(filename, AccessLog, len);
-    else if (!strncmp(con->uri + 11, "error_log", 9) && ErrorLog[0] == '/')
-      strlcpy(filename, ErrorLog, len);
-    else if (!strncmp(con->uri + 11, "page_log", 8) && PageLog[0] == '/')
-      strlcpy(filename, PageLog, len);
+    if (!strncmp(con->uri + 11, "access_log", 10))
+    {
+      if (AccessLog[0] == '/')
+        strlcpy(filename, AccessLog, len);
+#ifdef HAVE_SYSTEMD_SD_JOURNAL_H || defined(HAVE_VSYSLOG)
+      else if (!strcmp(AccessLog, "syslog"))
+      {
+        cupsdLogClient(con, CUPSD_LOG_DEBUG2, "Log is set to syslog, get syslog warning file \"%s\".", SyslogWarn);
+        strlcpy(filename, SyslogWarn, len);
+      }
+#endif
+      else
+        return(NULL);
+    }
+    else if (!strncmp(con->uri + 11, "error_log", 9))
+    {
+      if (ErrorLog[0] == '/')
+        strlcpy(filename, ErrorLog, len);
+#ifdef HAVE_SYSTEMD_SD_JOURNAL_H || defined(HAVE_VSYSLOG)
+      else if (!strcmp(ErrorLog, "syslog"))
+      {
+        cupsdLogClient(con, CUPSD_LOG_DEBUG2, "Log is set to syslog, get syslog warning file \"%s\".", SyslogWarn);
+        strlcpy(filename, SyslogWarn, len);
+      }
+#endif
+      else
+        return(NULL);
+    }
+    else if (!strncmp(con->uri + 11, "page_log", 8))
+    {
+      if (PageLog[0] == '/')
+        strlcpy(filename, PageLog, len);
+#ifdef HAVE_SYSTEMD_SD_JOURNAL_H || defined(HAVE_VSYSLOG)
+      else if (!strcmp(PageLog, "syslog"))
+      {
+        cupsdLogClient(con, CUPSD_LOG_DEBUG2, "Log is set to syslog, get syslog warning file \"%s\".", SyslogWarn);
+        strlcpy(filename, SyslogWarn, len);
+      }
+#endif
+      else
+        return(NULL);
+    }
     else
       return (NULL);
 

--- a/scheduler/conf.c
+++ b/scheduler/conf.c
@@ -836,7 +836,8 @@ cupsdReadConfiguration(void)
     cupsdSetString(&ErrorLog, CUPS_LOGDIR "/error_log");
 
 #ifdef HAVE_SYSTEMD_SD_JOURNAL_H || defined(HAVE_VSYSLOG)
-  if (!strcmp(AccessLog, "syslog") || !strcmp(ErrorLog, "syslog") || !strcmp(PageLog, "syslog"))
+  if (WebInterface && 
+      (!strcmp(AccessLog, "syslog") || !strcmp(ErrorLog, "syslog") || !strcmp(PageLog, "syslog")))
     cupsdWriteSyslogWarn();
   else
     cupsdCleanFiles(CUPS_CACHEDIR, "*syslog_warn");

--- a/scheduler/conf.h
+++ b/scheduler/conf.h
@@ -127,6 +127,10 @@ VAR char		*AccessLog		VALUE(NULL),
 					/* Error log filename */
 			*PageLog		VALUE(NULL),
 					/* Page log filename */
+#ifdef HAVE_SYSTEMD_SD_JOURNAL_H || defined(HAVE_VSYSLOG)
+                        *SyslogWarn             VALUE(NULL),
+                                        /* Syslog warning filename */
+#endif
 			*CacheDir		VALUE(NULL),
 					/* Cache file directory */
 			*DataDir		VALUE(NULL),
@@ -227,6 +231,10 @@ VAR cups_file_t		*AccessFile		VALUE(NULL),
 					/* Error log file */
 			*PageFile		VALUE(NULL);
 					/* Page log file */
+#ifdef HAVE_SYSTEMD_SD_JOURNAL_H || defined(HAVE_VSYSLOG)
+                        *SyslogWarnFile         VALUE(NULL);
+                                        /* Syslog warning file */
+#endif
 VAR char		*PageLogFormat		VALUE(NULL);
 					/* Page log format */
 VAR mime_t		*MimeDatabase		VALUE(NULL);


### PR DESCRIPTION
Hi Mike!
I set all cupsd logs to be in system log (journal), but it breaks viewing logs in CUPS web ui - it ends with 'Not Found', which can be confusing for users.
I tried to focus on the issue and solve it in the pull request - I introduced new file in CUPS_CACHEDIR, which will contain warning message (file is created and the message is written there during reading configuration - if configuration changes in the way there is no logs in syslog, file is deleted):

'The log has been moved to system log. Please consult your logging system for logs.'

CGI binary then gets the file instead of original log file (if CUPS is built with correct features - systemd or vsyslog and the logging is set to syslog).

Viewing logs in web ui shows warning instead of 'Not Found'. Is it acceptable behavior and could it be added to the project?