### PR TITLE
Make explicit cast from enum to integer

### DIFF
--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -2190,7 +2190,7 @@ _ppdCacheGetFinishingValues(
     {
       DEBUG_printf(("_ppdCacheGetFinishingValues: Adding %d (%s)", f->value, ippEnumString("finishings", f->value)));
 
-      values[num_values ++] = f->value;
+      values[num_values ++] = (int)f->value;
 
       if (num_values >= max_values)
         break;


### PR DESCRIPTION
Clang-7 complains that there is a cast from unsigned (ipp_finishing_t which is an enum) to signed (int).  Perform an explicit cast since this should always be safe as long as ipp_finsihing_t is not too large.