### PR TITLE
Fix saving cupsJobPassword in PPD cache

### DIFF
--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -904,7 +904,7 @@ _ppdCacheCreateWithFile(
       pc->account_id = !_cups_strcasecmp(value, "true");
     else if (!_cups_strcasecmp(line, "JobAccountingUserId"))
       pc->accounting_user_id = !_cups_strcasecmp(value, "true");
-    else if (!_cups_strcasecmp(line, "JobPassword"))
+    else if (!_cups_strcasecmp(line, "cupsJobPassword"))
       pc->password = strdup(value);
     else if (!_cups_strcasecmp(line, "Mandatory"))
     {
@@ -3188,7 +3188,7 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
 
     pattern[maxlen] = '\0';
 
-    cupsFilePrintf(fp, "*cupsPassword: \"%s\"\n", pattern);
+    cupsFilePrintf(fp, "*cupsJobPassword: \"%s\"\n", pattern);
   }
 
  /*


### PR DESCRIPTION
It seems there are typos in saving/reading PPD cache file, therefore "job-password-supported" attribute can't be fetched correctly. 