### PR TITLE
scheduler/org.cups.cupsd.service.in: ensure that sssd is up when cups starts

### DIFF
--- a/scheduler/org.cups.cupsd.service.in
+++ b/scheduler/org.cups.cupsd.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=CUPS Scheduler
 Documentation=man:cupsd(8)
+After=sssd.service
 
 [Service]
 ExecStart=@sbindir@/cupsd -l


### PR DESCRIPTION

When the group defined in the SystemGroup directive is provided via
sssd, and sssd is not available when cups starts, cups will crash. This
patch makes cups start after sssd when both are present in the machine.
(Issue #5550)