### PR TITLE
Fix cupsCheckDestSupported() handling of "job-password" option

### DIFF
--- a/cups/dest-options.c
+++ b/cups/dest-options.c
@@ -264,6 +264,15 @@ cupsCheckDestSupported(
         pwg->length >= min_length && pwg->length <= max_length)
       return (1);
   }
+  else if (!strcmp(option, "job-password")) 
+  {
+   /*
+    * Check that the length of the password doesn't exceed the maximum supported length.
+    */
+    
+    size_t max_length = attr->values[0].integer;
+    return strlen(value) <= max_length;
+  }
   else
   {
    /*


### PR DESCRIPTION
CUPS doesn't handle correctly "job-password" option in cupsCheckDestSupported() function, since it expects the integer value when IPP tag of "X-supported" attribute is IPP_TAG_INTEGER, but in case of "job-password" we have string value.
This commit adds separate check for that and fixes it.