### PR TITLE
Fix handling of OctetString in get_options() function

### DIFF
--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -3629,7 +3629,7 @@ get_options(cupsd_job_t *job,		/* I - Job */
 	    char        *title,		/* I - Title buffer */
 	    size_t      title_size)	/* I - Size of title buffer */
 {
-  int			i;		/* Looping var */
+  int			i, j;		/* Looping vars */
   size_t		newlength;	/* New option buffer length */
   char			*optptr,	/* Pointer to options */
 			*valptr;	/* Pointer in value string */
@@ -4030,6 +4030,18 @@ get_options(cupsd_job_t *job,		/* I - Job */
 	      break;
 
           case IPP_TAG_STRING :
+              j = attr->values[i].unknown.length;
+	      for (valptr = attr->values[i].unknown.data; j > 0; j --)
+	      {
+	        if (strchr(" \t\n\\\'\"", *valptr))
+		  *optptr++ = '\\';
+		*optptr++ = *valptr++;
+	      }
+
+	      *optptr = '\0';
+              
+              break;
+              
 	  case IPP_TAG_TEXT :
 	  case IPP_TAG_NAME :
 	  case IPP_TAG_KEYWORD :


### PR DESCRIPTION
The OctetString option was handled as if they have IPP_TAG_NAME tag, though it stores its data in unknown.data instead of string.text and also stores length instead of '\0' end symbol.