### PR TITLE
Test: Fix *topdf filters to find the examples in the correct path

### DIFF
--- a/test/run-stp-tests.sh
+++ b/test/run-stp-tests.sh
@@ -430,10 +430,10 @@ trap "" PIPE
 gziptoany "$1" "$2" "$3" "$4" "$5" \$6 >/dev/null
 case "\$5" in
 	*media=a4* | *media=iso_a4* | *PageSize=A4*)
-		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/examples/onepage-a4-300-black-1.pwg.gz"
+		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/examples/onepage-a4-300-black-1.pwg"
 		;;
 	*)
-		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/examples/onepage-letter-300-black-1.pwg.gz"
+		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/examples/onepage-letter-300-black-1.pwg"
 		;;
 esac
 EOF

--- a/test/run-stp-tests.sh
+++ b/test/run-stp-tests.sh
@@ -396,10 +396,10 @@ trap "" PIPE
 gziptoany "$1" "$2" "$3" "$4" "$5" \$6 >/dev/null
 case "\$5" in
 	*media=a4* | *media=iso_a4* | *PageSize=A4*)
-		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/test/onepage-a4.pdf"
+		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/examples/onepage-a4.pdf"
 		;;
 	*)
-		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/test/onepage-letter.pdf"
+		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/examples/onepage-letter.pdf"
 		;;
 esac
 EOF
@@ -413,10 +413,10 @@ trap "" PIPE
 gziptoany "$1" "$2" "$3" "$4" "$5" \$6 >/dev/null
 case "\$5" in
 	*media=a4* | *media=iso_a4* | *PageSize=A4*)
-		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/test/onepage-a4.ps"
+		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/examples/onepage-a4.ps"
 		;;
 	*)
-		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/test/onepage-letter.ps"
+		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/examples/onepage-letter.ps"
 		;;
 esac
 EOF
@@ -430,10 +430,10 @@ trap "" PIPE
 gziptoany "$1" "$2" "$3" "$4" "$5" \$6 >/dev/null
 case "\$5" in
 	*media=a4* | *media=iso_a4* | *PageSize=A4*)
-		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/test/onepage-a4-300-black-1.pwg.gz"
+		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/examples/onepage-a4-300-black-1.pwg.gz"
 		;;
 	*)
-		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/test/onepage-letter-300-black-1.pwg.gz"
+		gziptoany "$1" "$2" "$3" "$4" "$5" "$root/examples/onepage-letter-300-black-1.pwg.gz"
 		;;
 esac
 EOF


### PR DESCRIPTION
As identified in https://github.com/apple/cups/issues/5576#issuecomment-490148791, some files cannot be found in tests.

Indeed, the generated filters look for some example files in `test/` while they moved to `examples/` between v2.3b7 and v2.3b8.