### PR TITLE
Swapped branches of HAVE_SSL condition

### DIFF
--- a/tools/ippeveprinter.c
+++ b/tools/ippeveprinter.c
@@ -1556,9 +1556,9 @@ create_printer(
     fprintf(stderr, "printer-more-info=\"%s\"\n", adminurl);
     fprintf(stderr, "printer-supply-info-uri=\"%s\"\n", supplyurl);
 #ifdef HAVE_SSL
-    fprintf(stderr, "printer-uri=\"%s\"\n", uri);
-#else
     fprintf(stderr, "printer-uri=\"%s\",\"%s\"\n", uri, securi);
+#else
+    fprintf(stderr, "printer-uri=\"%s\"\n", uri);
 #endif /* HAVE_SSL */
   }
 


### PR DESCRIPTION
Swapped branches of #ifdef HAVE_SSL conditional
Can not be built if HAVE_SSL is undefined because of missing "securi" identifier.