### PR TITLE
insert explicit casts to calm compiler warnings for -Wsign-conversion

### DIFF
--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -1910,7 +1910,7 @@ add_job(cupsd_client_t  *con,		/* I - Client connection */
   ippAddInteger(con->response, IPP_TAG_JOB, IPP_TAG_INTEGER, "job-id", job->id);
 
   ippAddInteger(con->response, IPP_TAG_JOB, IPP_TAG_ENUM, "job-state",
-                job->state_value);
+                (int)job->state_value);
   ippAddString(con->response, IPP_TAG_JOB, IPP_TAG_TEXT, "job-state-message", NULL, "");
   ippAddString(con->response, IPP_TAG_JOB, IPP_TAG_KEYWORD, "job-state-reasons",
                NULL, job->reasons->values[0].string.text);
@@ -3283,7 +3283,7 @@ cancel_all_jobs(cupsd_client_t  *con,	/* I - Client connection */
       * Cancel all jobs on all printers...
       */
 
-      cupsdCancelJobs(NULL, username, purge);
+      cupsdCancelJobs(NULL, username, (int)purge);
 
       cupsdLogMessage(CUPSD_LOG_INFO, "All jobs were %s by \"%s\".",
 		      purge == CUPSD_JOB_PURGE ? "purged" : "canceled",
@@ -3342,7 +3342,7 @@ cancel_all_jobs(cupsd_client_t  *con,	/* I - Client connection */
       * Cancel all of the jobs on the named printer...
       */
 
-      cupsdCancelJobs(printer->name, username, purge);
+      cupsdCancelJobs(printer->name, username, (int)purge);
 
       cupsdLogMessage(CUPSD_LOG_INFO, "All jobs on \"%s\" were %s by \"%s\".",
 		      printer->name,
@@ -3999,7 +3999,7 @@ close_job(cupsd_client_t  *con,		/* I - Client connection */
   ippAddInteger(con->response, IPP_TAG_JOB, IPP_TAG_INTEGER, "job-id", job->id);
 
   ippAddInteger(con->response, IPP_TAG_JOB, IPP_TAG_ENUM, "job-state",
-                job->state_value);
+                (int)job->state_value);
 
   con->response->request.status.status_code = IPP_OK;
 
@@ -4965,7 +4965,7 @@ copy_printer_attrs(
     ippAddString(con->response, IPP_TAG_PRINTER, IPP_TAG_NAME, "printer-op-policy", NULL, printer->op_policy);
 
   if (!ra || cupsArrayFind(ra, "printer-state"))
-    ippAddInteger(con->response, IPP_TAG_PRINTER, IPP_TAG_ENUM, "printer-state", printer->state);
+    ippAddInteger(con->response, IPP_TAG_PRINTER, IPP_TAG_ENUM, "printer-state", (int)printer->state);
 
   if (!ra || cupsArrayFind(ra, "printer-state-change-date-time"))
     ippAddDate(con->response, IPP_TAG_PRINTER, "printer-state-change-date-time", ippTimeToDate(printer->state_time));
@@ -5510,7 +5510,7 @@ create_local_printer(
   add_printer_attributes:
 
   ippAddBoolean(con->response, IPP_TAG_PRINTER, "printer-is-accepting-jobs", (char)printer->accepting);
-  ippAddInteger(con->response, IPP_TAG_PRINTER, IPP_TAG_ENUM, "printer-state", printer->state);
+  ippAddInteger(con->response, IPP_TAG_PRINTER, IPP_TAG_ENUM, "printer-state", (int)printer->state);
   add_printer_state_reasons(con, printer);
 
   httpAssembleURIf(HTTP_URI_CODING_ALL, uri, sizeof(uri), httpIsEncrypted(con->http) ? "ipps" : "ipp", NULL, con->clientname, con->clientport, "/printers/%s", printer->name);
@@ -9955,7 +9955,7 @@ send_document(cupsd_client_t  *con,	/* I - Client connection */
   ippAddInteger(con->response, IPP_TAG_JOB, IPP_TAG_INTEGER, "job-id", jobid);
 
   ippAddInteger(con->response, IPP_TAG_JOB, IPP_TAG_ENUM, "job-state",
-                job->state_value);
+                (int)job->state_value);
   ippAddString(con->response, IPP_TAG_JOB, IPP_TAG_KEYWORD, "job-state-reasons",
                NULL, job->reasons->values[0].string.text);
 

--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -2577,7 +2577,7 @@ cupsdSetJobState(
   job->state_value = newstate;
 
   if (job->state)
-    job->state->values[0].integer = newstate;
+    job->state->values[0].integer = (int)newstate;
 
   switch (newstate)
   {

--- a/scheduler/printers.c
+++ b/scheduler/printers.c
@@ -4586,7 +4586,7 @@ load_ppd(cupsd_printer_t *p)		/* I - Printer */
       for (fin = (_pwg_finishings_t *)cupsArrayFirst(p->pc->finishings); fin; fin = (_pwg_finishings_t *)cupsArrayNext(p->pc->finishings))
       {
         if (num_finishings < (int)(sizeof(finishings) / sizeof(finishings[0])))
-          finishings[num_finishings++] = fin->value;
+          finishings[num_finishings++] = (int)fin->value;
 
         switch (fin->value)
         {

--- a/scheduler/subscriptions.c
+++ b/scheduler/subscriptions.c
@@ -170,7 +170,7 @@ cupsdAddEvent(
 	             "printer-name", NULL, dest->name);
 
 	ippAddInteger(temp->attrs, IPP_TAG_EVENT_NOTIFICATION, IPP_TAG_ENUM,
-	              "printer-state", dest->state);
+	              "printer-state", (int)dest->state);
 
 	if (dest->num_reasons == 0)
 	  ippAddString(temp->attrs, IPP_TAG_EVENT_NOTIFICATION,
@@ -195,7 +195,7 @@ cupsdAddEvent(
 	ippAddInteger(temp->attrs, IPP_TAG_EVENT_NOTIFICATION, IPP_TAG_INTEGER,
 	              "notify-job-id", job->id);
 	ippAddInteger(temp->attrs, IPP_TAG_EVENT_NOTIFICATION, IPP_TAG_ENUM,
-	              "job-state", job->state_value);
+	              "job-state", (int)job->state_value);
 
         if ((attr = ippFindAttribute(job->attrs, "job-name",
 	                             IPP_TAG_NAME)) != NULL)

--- a/tools/ippeveprinter.c
+++ b/tools/ippeveprinter.c
@@ -4861,13 +4861,13 @@ load_ppd_attributes(
   attr = ippAddIntegers(attrs, IPP_TAG_PRINTER, IPP_TAG_ENUM, "finishings-ready", cupsArrayCount(pc->finishings) + 1, NULL);
   ippSetInteger(attrs, &attr, 0, IPP_FINISHINGS_NONE);
   for (i = 1, finishings = (_pwg_finishings_t *)cupsArrayFirst(pc->finishings); finishings; i ++, finishings = (_pwg_finishings_t *)cupsArrayNext(pc->finishings))
-    ippSetInteger(attrs, &attr, i, finishings->value);
+    ippSetInteger(attrs, &attr, i, (int)finishings->value);
 
   /* finishings-supported */
   attr = ippAddIntegers(attrs, IPP_TAG_PRINTER, IPP_TAG_ENUM, "finishings-supported", cupsArrayCount(pc->finishings) + 1, NULL);
   ippSetInteger(attrs, &attr, 0, IPP_FINISHINGS_NONE);
   for (i = 1, finishings = (_pwg_finishings_t *)cupsArrayFirst(pc->finishings); finishings; i ++, finishings = (_pwg_finishings_t *)cupsArrayNext(pc->finishings))
-    ippSetInteger(attrs, &attr, i, finishings->value);
+    ippSetInteger(attrs, &attr, i, (int)finishings->value);
 
   /* media-bottom-margin-supported */
   for (i = 0, num_margins = 0, pwg_size = pc->sizes; i < pc->num_sizes && num_margins < (int)(sizeof(margins) / sizeof(margins[0])); i ++, pwg_size ++)


### PR DESCRIPTION
During compilation of the latest source, I received several warnings for -WSign-conversion. Here is a patch inserting explicit casts to calm them.