### PR TITLE
dump both of uri & securi if HAVE_SSL, dump uri only if not HAVE_SSL

### DIFF
--- a/tools/ippeveprinter.c
+++ b/tools/ippeveprinter.c
@@ -1556,9 +1556,9 @@ create_printer(
     fprintf(stderr, "printer-more-info=\"%s\"\n", adminurl);
     fprintf(stderr, "printer-supply-info-uri=\"%s\"\n", supplyurl);
 #ifdef HAVE_SSL
-    fprintf(stderr, "printer-uri=\"%s\"\n", uri);
-#else
     fprintf(stderr, "printer-uri=\"%s\",\"%s\"\n", uri, securi);
+#else
+    fprintf(stderr, "printer-uri=\"%s\"\n", uri);
 #endif /* HAVE_SSL */
   }
 


### PR DESCRIPTION
During compilation of the latest source, accidentally I found a failure in building without SSL. It seems that current source does not dump securi if SSL is available but tries to dump securi if SSL is unavailable. securi is not defined if SSL is unavailable, so I exchanged the debug messages for the cases with/without SSL.