### PR TITLE
Fix "sides" option if using *Duplex* in lpoptions file

### DIFF
--- a/cups/options.c
+++ b/cups/options.c
@@ -80,6 +80,15 @@ cupsAddOption(const char    *name,	/* I  - Name of option */
   else if (!_cups_strcasecmp(name, "print-quality"))
     num_options = cupsRemoveOption("cupsPrintQuality", num_options, options);
 
+  /* remove *Duplex* option read from lpoptions file if "sides" is specified on command line */
+  if (!_cups_strcasecmp(name, "sides")) {
+    num_options = cupsRemoveOption("Duplex", num_options, options);
+    num_options = cupsRemoveOption("EFDuplex", num_options, options);
+    num_options = cupsRemoveOption("EFDuplexing", num_options, options);
+    num_options = cupsRemoveOption("KD03Duplex", num_options, options);
+    num_options = cupsRemoveOption("JCLDuplex", num_options, options);
+  }
+
  /*
   * Look for an existing option with the same name...
   */


### PR DESCRIPTION
Remove *Duplex* option read from lpoptions file if "sides" is
specified on command line. Otherwise both options would be
present and "sides" would not override Duplex.

Test case:
Have a ~/.cups/lpoptions file containing a Duplex option like this:
$ cat ~/.cups/lpoptions
Default myprinter Duplex=None PageSize=A4

Print a document with more than one page on a printer supporting
duplex:
$ lpr -P myprinter -o sides=two-sided-long-edge test.pdf

Without this patch the document is not printed two-sided,
with this patch applied it is printed two-sided.