### PR TITLE
Lookup groups using group->gr_mem even if getgrouplist() failed

### DIFF
--- a/scheduler/auth.c
+++ b/scheduler/auth.c
@@ -1188,13 +1188,19 @@ cupsdCheckGroup(
 	  return (1);
     }
 
-#else
+#endif /* HAVE_GETGROUPLIST */
+    /*
+     * Searching group->gr_mem after getgrouplist failure may
+     * yield success because some NSS source have better
+     * success searching on group name instead of iterating 
+     * on user name. For instance, nss_ldap looking up an
+     * OpenLDAP dyngroup.
+     */
     for (i = 0; group->gr_mem[i]; i ++)
     {
       if (!_cups_strcasecmp(username, group->gr_mem[i]))
 	return (1);
     }
-#endif /* HAVE_GETGROUPLIST */
   }
   else
     groupid = (gid_t)-1;


### PR DESCRIPTION
getgrouplist() iterate on each group, searching if the user
is included, while group->gr_mem iterated on user list for
the target group. In some case the former method can miss
the result while the later will succeed. This is the case
for OpenLDAP dyngroup, where the group members are automatically
generated on group search. Searching by group member gives no
result, while searching the member of a given groups is fine.