### PR TITLE
Introduce cupsHashNoCryptoData and --enable-gnutls-relax-mode configu…

### DIFF
--- a/cgi-bin/var.c
+++ b/cgi-bin/var.c
@@ -1220,7 +1220,7 @@ cgi_set_sid(void)
 	   (unsigned)CUPS_RAND() & 255, (unsigned)CUPS_RAND() & 255,
 	   (unsigned)CUPS_RAND() & 255, (unsigned)CUPS_RAND() & 255,
 	   (unsigned)CUPS_RAND() & 255, (unsigned)CUPS_RAND() & 255);
-  cupsHashData("md5", (unsigned char *)buffer, strlen(buffer), sum, sizeof(sum));
+  cupsHashNoCryptoData((unsigned char *)buffer, strlen(buffer), sum, sizeof(sum));
 
   cgiSetCookie(CUPS_SID, cupsHashString(sum, sizeof(sum), sid, sizeof(sid)), "/", NULL, 0, 0);
 

--- a/config-scripts/cups-ssl.m4
+++ b/config-scripts/cups-ssl.m4
@@ -10,6 +10,7 @@ dnl
 AC_ARG_ENABLE(ssl, [  --disable-ssl           disable SSL/TLS support])
 AC_ARG_ENABLE(cdsassl, [  --enable-cdsassl        use CDSA for SSL/TLS support, default=first])
 AC_ARG_ENABLE(gnutls, [  --enable-gnutls         use GNU TLS for SSL/TLS support, default=second])
+AC_ARG_ENABLE(gnutls_relax_mode, [  --enable-gnutls-relax-mode         use GNU TLS in relax mode for MD5 hash function at non-crypto cases, default=disabled])
 
 SSLFLAGS=""
 SSLLIBS=""
@@ -61,6 +62,10 @@ if test x$enable_ssl != xno; then
 	    AC_CHECK_FUNC(gnutls_transport_set_pull_timeout_function, AC_DEFINE(HAVE_GNUTLS_TRANSPORT_SET_PULL_TIMEOUT_FUNCTION))
 	    AC_CHECK_FUNC(gnutls_priority_set_direct, AC_DEFINE(HAVE_GNUTLS_PRIORITY_SET_DIRECT))
 	    LIBS="$SAVELIBS"
+
+	    if "x$enable_gnutls_relax_mode" != "xno"; then 
+	        AC_DEFINE(HAVE_GNUTLS_RELAX_MODE) 
+	    fi 
 	fi
     fi
 fi

--- a/cups/hash.c
+++ b/cups/hash.c
@@ -54,6 +54,7 @@ cupsHashNoCryptoData(const void    *data,	/* I - Data to hash */
 
   return result_hashsize; 
 }
+
 /*
  * 'cupsHashData()' - Perform a hash function on the given data.
  *

--- a/cups/http-support.c
+++ b/cups/http-support.c
@@ -512,7 +512,7 @@ httpAssembleUUID(const char *server,	/* I - Server name */
            port, name ? name : server, number,
 	   (unsigned)CUPS_RAND() & 0xffff, (unsigned)CUPS_RAND() & 0xffff);
 
-  cupsHashData("md5", (unsigned char *)data, strlen(data), md5sum, sizeof(md5sum));
+  cupsHashNoCryptoData((unsigned char *)data, strlen(data), md5sum, sizeof(md5sum));
 
  /*
   * Generate the UUID from the MD5...

--- a/cups/tls-darwin.c
+++ b/cups/tls-darwin.c
@@ -904,7 +904,7 @@ httpCredentialsString(
 
     expiration = (time_t)(SecCertificateNotValidAfter(secCert) + kCFAbsoluteTimeIntervalSince1970);
 
-    cupsHashData("md5", first->data, first->datalen, md5_digest, sizeof(md5_digest));
+    cupsHashNoCryptoData(first->data, first->datalen, md5_digest, sizeof(md5_digest));
 
     snprintf(buffer, bufsize, "%s (issued by %s) / %s / %s / %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X", commonName, issuer, httpGetDateString(expiration), sigalg, md5_digest[0], md5_digest[1], md5_digest[2], md5_digest[3], md5_digest[4], md5_digest[5], md5_digest[6], md5_digest[7], md5_digest[8], md5_digest[9], md5_digest[10], md5_digest[11], md5_digest[12], md5_digest[13], md5_digest[14], md5_digest[15]);
 

--- a/cups/tls-gnutls.c
+++ b/cups/tls-gnutls.c
@@ -687,7 +687,7 @@ httpCredentialsString(
     expiration = gnutls_x509_crt_get_expiration_time(cert);
     sigalg     = gnutls_x509_crt_get_signature_algorithm(cert);
 
-    cupsHashData("md5", first->data, first->datalen, md5_digest, sizeof(md5_digest));
+    cupsHashNoCryptoData(first->data, first->datalen, md5_digest, sizeof(md5_digest));
 
     snprintf(buffer, bufsize, "%s (issued by %s) / %s / %s / %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X", name, issuer, httpGetDateString(expiration), gnutls_sign_get_name((gnutls_sign_algorithm_t)sigalg), md5_digest[0], md5_digest[1], md5_digest[2], md5_digest[3], md5_digest[4], md5_digest[5], md5_digest[6], md5_digest[7], md5_digest[8], md5_digest[9], md5_digest[10], md5_digest[11], md5_digest[12], md5_digest[13], md5_digest[14], md5_digest[15]);
 

--- a/cups/tls-sspi.c
+++ b/cups/tls-sspi.c
@@ -373,7 +373,7 @@ httpCredentialsString(
     else
       strlcpy(cert_name, "unknown", sizeof(cert_name));
 
-    cupsHashData("md5", first->data, first->datalen, md5_digest, sizeof(md5_digest));
+    cupsHashNoCryptoData(first->data, first->datalen, md5_digest, sizeof(md5_digest));
 
     snprintf(buffer, bufsize, "%s / %s / %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X", cert_name, httpGetDateString(expiration), md5_digest[0], md5_digest[1], md5_digest[2], md5_digest[3], md5_digest[4], md5_digest[5], md5_digest[6], md5_digest[7], md5_digest[8], md5_digest[9], md5_digest[10], md5_digest[11], md5_digest[12], md5_digest[13], md5_digest[14], md5_digest[15]);
 


### PR DESCRIPTION
…re option

The cupsHashNoCryptoData function is for hashing non cryptographic data by MD5
hash function. MD5 hash function can be disabled in GNU TLS on specific machines
so new --enable-gnutls-relax-mode enables GNU TLS relax mode for use cases of MD5
which are not considered as encryption.