### PR TITLE
SIGSEGV in CUPS web ui when adding a printer

### DIFF
--- a/cgi-bin/var.c
+++ b/cgi-bin/var.c
@@ -170,6 +170,9 @@ cgiGetArray(const char *name,		/* I - Name of array variable */
   if (element < 0 || element >= var->nvalues)
     return (NULL);
 
+  if (var->values[element] == NULL)
+    return (NULL);
+
   return (strdup(var->values[element]));
 }
 


### PR DESCRIPTION
Hi,

I have a report in Fedora from ABRT tool https://bugzilla.redhat.com/show_bug.cgi?id=1720688 , which caught SIGSEGV in CUPS when user tried to add new printer by CUPS web ui.

It seems the element, which is tried to dup, is NULL. The check if it is NULL should cover it.

Does the patch look good? Please let me know if I can enhance something.