### PR TITLE
Correct problem with UNKNOWN READ/SEGV for incorrect PPD file

### DIFF
--- a/cups/ppd-page.c
+++ b/cups/ppd-page.c
@@ -122,10 +122,12 @@ ppdPageSize(ppd_file_t *ppd,		/* I - PPD file record */
       if ((coption = ppdFindCustomOption(ppd, "PageSize")) != NULL)
       {
         if ((cparam = ppdFindCustomParam(coption, "Width")) != NULL)
-	  cparam->current.custom_points = (float)w;
+          if (cparam->type == PPD_CUSTOM_POINTS)
+            cparam->current.custom_points = (float)w;
 
         if ((cparam = ppdFindCustomParam(coption, "Height")) != NULL)
-	  cparam->current.custom_points = (float)l;
+          if (cparam->type == PPD_CUSTOM_POINTS)
+            cparam->current.custom_points = (float)l;
       }
 
      /*


### PR DESCRIPTION
The problem occurres when an input PPD file contains a specific combination of
*PageSize keywords with incorrect types. In this case the PPD parser may cause
memory violation when one of the type is PPD_CUSTOM_PASSCODE,
PPD_CUSTOM_PASSWORD or PPD_CUSTOM_STRING.