### PR TITLE
Add wheel to system groups

### DIFF
--- a/config-scripts/cups-defaults.m4
+++ b/config-scripts/cups-defaults.m4
@@ -245,7 +245,7 @@ AC_ARG_WITH(system_groups, [  --with-system-groups    set default system groups 
 		AC_MSG_CHECKING(for default system groups)
 		if test -f /etc/group; then
 			CUPS_SYSTEM_GROUPS=""
-			GROUP_LIST="lpadmin sys system root"
+			GROUP_LIST="lpadmin sys system root wheel"
 			for group in $GROUP_LIST; do
 				if test "`grep \^${group}: /etc/group`" != ""; then
 					if test "x$CUPS_SYSTEM_GROUPS" = x; then

--- a/configure
+++ b/configure
@@ -9601,7 +9601,7 @@ else
 $as_echo_n "checking for default system groups... " >&6; }
 		if test -f /etc/group; then
 			CUPS_SYSTEM_GROUPS=""
-			GROUP_LIST="lpadmin sys system root"
+			GROUP_LIST="lpadmin sys system root wheel"
 			for group in $GROUP_LIST; do
 				if test "`grep \^${group}: /etc/group`" != ""; then
 					if test "x$CUPS_SYSTEM_GROUPS" = x; then


### PR DESCRIPTION
Members of the wheel group are able to gain system privileges, so for intents and purposes of CUPS it can be considered a system group. This allows to use privileged operations in the web interface as the user instead of root for members of the wheel group. 

Fedora Linux applies this by default: https://unix.stackexchange.com/questions/235477/cups-add-printer-page-returns-forbidden-on-web-interface