### PR TITLE
Prevent cert creation failure on leap day

### DIFF
--- a/cups/tls-sspi.c
+++ b/cups/tls-sspi.c
@@ -1968,6 +1968,11 @@ http_sspi_make_credentials(
   GetSystemTime(&et);
   et.wYear += years;
 
+  // If today is February 29th, and the above addition operation results in a year that is *not* a leap year,
+  // then use February 28th instead.  Otherwise CertCreateSelfSignCertificate would fail.
+  BOOL isLeapYear = et.wYear % 4 == 0 && (et.wYear % 100 != 0 || et.wYear % 400 == 0);
+  et.wDay = et.wMonth == 2 && et.wDay == 29 && !isLeapYear ? 28 : et.wDay;
+
   ZeroMemory(&exts, sizeof(exts));
 
   createdContext = CertCreateSelfSignCertificate(hProv, &sib, 0, &kpi, NULL, NULL, &et, &exts);


### PR DESCRIPTION
The `http_sspi_make_credentials` function in `cups/tls-sspi.c` has a leap year bug.

https://github.com/apple/cups/blob/bc5060a1ddee63b524a3f61a939c24829f727fc7/cups/tls-sspi.c#L1968-L1973

This will fail if the code is executed on Feb 29th of a leap year (of which 2020 is the next one), unless the `years` being added also results in `et.wYear` being a leap year.  In other words, `2020-02-29` + `1 year` would result in `2021-02-29`, which does not exist.  In this case, `CertCreateSelfSignCertificate` will fail.

The attached PR checks for this condition, and adjusts such dates back one day to February 28th, which is a reasonable and common practice.

Please be sure this gets merged and highlighted in the release notes.  Those that rely on this code path will want to have fully deployed such code well before leap day 2020.  Thanks.