### PR TITLE
Create untranslated cups.da.po

### DIFF
--- a/locale/cups.da.po
+++ b/locale/cups.da.po
@@ -1,0 +1,18927 @@
+# Danish translation for CUPS.
+# Copyright © 2007-2019 by Apple Inc.
+# Copyright © 2005-2007 by Easy Software Products.
+# Licensed under Apache License v2.0.  See the file "LICENSE" for more
+# information.
+# Notes for Translators:
+# The "checkpo" program located in the "locale" source directory can be used
+# to verify that your translations do not introduce formatting errors or other
+# problems.  Run with:
+# cd locale
+# ./checkpo cups_LL.po
+# where "LL" is your locale.
+# scootergrisen, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: CUPS 2.3.0\n"
+"Report-Msgid-Bugs-To: https://github.com/apple/cups/issues\n"
+"POT-Creation-Date: 2019-08-23 09:13-0400\n"
+"PO-Revision-Date: 2019-09-13 18:06+0200\n"
+"Last-Translator: scootergrisen\n"
+"Language-Team: Danish\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: systemv/lpstat.c:1871 systemv/lpstat.c:1990
+msgid "\t\t(all)"
+msgstr ""
+
+#: systemv/lpstat.c:1874 systemv/lpstat.c:1877 systemv/lpstat.c:1993
+#: systemv/lpstat.c:1996
+msgid "\t\t(none)"
+msgstr ""
+
+#: berkeley/lpc.c:416
+#, c-format
+msgid "\t%d entries"
+msgstr ""
+
+#: systemv/lpstat.c:812 systemv/lpstat.c:828
+#, c-format
+msgid "\t%s"
+msgstr ""
+
+#: systemv/lpstat.c:1852 systemv/lpstat.c:1971
+msgid "\tAfter fault: continue"
+msgstr ""
+
+#: systemv/lpstat.c:1488 systemv/lpstat.c:1825 systemv/lpstat.c:1945
+#, c-format
+msgid "\tAlerts: %s"
+msgstr ""
+
+#: systemv/lpstat.c:1875 systemv/lpstat.c:1994
+msgid "\tBanner required"
+msgstr ""
+
+#: systemv/lpstat.c:1876 systemv/lpstat.c:1995
+msgid "\tCharset sets:"
+msgstr ""
+
+#: systemv/lpstat.c:1844 systemv/lpstat.c:1963
+msgid "\tConnection: direct"
+msgstr ""
+
+#: systemv/lpstat.c:1835 systemv/lpstat.c:1955
+msgid "\tConnection: remote"
+msgstr ""
+
+#: systemv/lpstat.c:1801 systemv/lpstat.c:1921
+msgid "\tContent types: any"
+msgstr ""
+
+#: systemv/lpstat.c:1879 systemv/lpstat.c:1998
+msgid "\tDefault page size:"
+msgstr ""
+
+#: systemv/lpstat.c:1878 systemv/lpstat.c:1997
+msgid "\tDefault pitch:"
+msgstr ""
+
+#: systemv/lpstat.c:1880 systemv/lpstat.c:1999
+msgid "\tDefault port settings:"
+msgstr ""
+
+#: systemv/lpstat.c:1807 systemv/lpstat.c:1927
+#, c-format
+msgid "\tDescription: %s"
+msgstr ""
+
+#: systemv/lpstat.c:1800 systemv/lpstat.c:1920
+msgid "\tForm mounted:"
+msgstr ""
+
+#: systemv/lpstat.c:1873 systemv/lpstat.c:1992
+msgid "\tForms allowed:"
+msgstr ""
+
+#: systemv/lpstat.c:1839 systemv/lpstat.c:1959
+#, c-format
+msgid "\tInterface: %s.ppd"
+msgstr ""
+
+#: systemv/lpstat.c:1848 systemv/lpstat.c:1967
+#, c-format
+msgid "\tInterface: %s/ppd/%s.ppd"
+msgstr ""
+
+#: systemv/lpstat.c:1830 systemv/lpstat.c:1950
+#, c-format
+msgid "\tLocation: %s"
+msgstr ""
+
+#: systemv/lpstat.c:1851 systemv/lpstat.c:1970
+msgid "\tOn fault: no alert"
+msgstr ""
+
+#: systemv/lpstat.c:1802 systemv/lpstat.c:1922
+msgid "\tPrinter types: unknown"
+msgstr ""
+
+#: systemv/lpstat.c:1471
+#, c-format
+msgid "\tStatus: %s"
+msgstr ""
+
+#: systemv/lpstat.c:1856 systemv/lpstat.c:1870 systemv/lpstat.c:1975
+#: systemv/lpstat.c:1989
+msgid "\tUsers allowed:"
+msgstr ""
+
+#: systemv/lpstat.c:1863 systemv/lpstat.c:1982
+msgid "\tUsers denied:"
+msgstr ""
+
+#: berkeley/lpc.c:418
+msgid "\tdaemon present"
+msgstr ""
+
+#: berkeley/lpc.c:414
+msgid "\tno entries"
+msgstr ""
+
+#: berkeley/lpc.c:386 berkeley/lpc.c:398
+#, c-format
+msgid "\tprinter is on device '%s' speed -1"
+msgstr ""
+
+#: berkeley/lpc.c:411
+msgid "\tprinting is disabled"
+msgstr ""
+
+#: berkeley/lpc.c:409
+msgid "\tprinting is enabled"
+msgstr ""
+
+#: systemv/lpstat.c:1491
+#, c-format
+msgid "\tqueued for %s"
+msgstr ""
+
+#: berkeley/lpc.c:406
+msgid "\tqueuing is disabled"
+msgstr ""
+
+#: berkeley/lpc.c:404
+msgid "\tqueuing is enabled"
+msgstr ""
+
+#: systemv/lpstat.c:1793 systemv/lpstat.c:1913
+msgid "\treason unknown"
+msgstr ""
+
+#: systemv/cupstestppd.c:431
+msgid ""
+"\n"
+"    DETAILED CONFORMANCE TEST RESULTS"
+msgstr ""
+
+#: systemv/cupstestppd.c:387 systemv/cupstestppd.c:392
+msgid "                REF: Page 15, section 3.1."
+msgstr ""
+
+#: systemv/cupstestppd.c:382
+msgid "                REF: Page 15, section 3.2."
+msgstr ""
+
+#: systemv/cupstestppd.c:402
+msgid "                REF: Page 19, section 3.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:355
+msgid "                REF: Page 20, section 3.4."
+msgstr ""
+
+#: systemv/cupstestppd.c:407
+msgid "                REF: Page 27, section 3.5."
+msgstr ""
+
+#: systemv/cupstestppd.c:350
+msgid "                REF: Page 42, section 5.2."
+msgstr ""
+
+#: systemv/cupstestppd.c:397
+msgid "                REF: Pages 16-17, section 3.2."
+msgstr ""
+
+#: systemv/cupstestppd.c:367
+msgid "                REF: Pages 42-45, section 5.2."
+msgstr ""
+
+#: systemv/cupstestppd.c:361
+msgid "                REF: Pages 45-46, section 5.2."
+msgstr ""
+
+#: systemv/cupstestppd.c:372
+msgid "                REF: Pages 48-49, section 5.2."
+msgstr ""
+
+#: systemv/cupstestppd.c:377
+msgid "                REF: Pages 52-54, section 5.2."
+msgstr ""
+
+#: berkeley/lpq.c:533
+#, c-format
+msgid "        %-39.39s %.0f bytes"
+msgstr ""
+
+#: systemv/cupstestppd.c:566
+#, c-format
+msgid "        PASS    Default%s"
+msgstr ""
+
+#: systemv/cupstestppd.c:501
+msgid "        PASS    DefaultImageableArea"
+msgstr ""
+
+#: systemv/cupstestppd.c:535
+msgid "        PASS    DefaultPaperDimension"
+msgstr ""
+
+#: systemv/cupstestppd.c:608
+msgid "        PASS    FileVersion"
+msgstr ""
+
+#: systemv/cupstestppd.c:652
+msgid "        PASS    FormatVersion"
+msgstr ""
+
+#: systemv/cupstestppd.c:672
+msgid "        PASS    LanguageEncoding"
+msgstr ""
+
+#: systemv/cupstestppd.c:692
+msgid "        PASS    LanguageVersion"
+msgstr ""
+
+#: systemv/cupstestppd.c:746
+msgid "        PASS    Manufacturer"
+msgstr ""
+
+#: systemv/cupstestppd.c:786
+msgid "        PASS    ModelName"
+msgstr ""
+
+#: systemv/cupstestppd.c:806
+msgid "        PASS    NickName"
+msgstr ""
+
+#: systemv/cupstestppd.c:866
+msgid "        PASS    PCFileName"
+msgstr ""
+
+#: systemv/cupstestppd.c:941
+msgid "        PASS    PSVersion"
+msgstr ""
+
+#: systemv/cupstestppd.c:846
+msgid "        PASS    PageRegion"
+msgstr ""
+
+#: systemv/cupstestppd.c:826
+msgid "        PASS    PageSize"
+msgstr ""
+
+#: systemv/cupstestppd.c:901
+msgid "        PASS    Product"
+msgstr ""
+
+#: systemv/cupstestppd.c:976
+msgid "        PASS    ShortNickName"
+msgstr ""
+
+#: systemv/cupstestppd.c:1351
+#, c-format
+msgid "        WARN    %s has no corresponding options."
+msgstr ""
+
+#: systemv/cupstestppd.c:1463
+#, c-format
+msgid ""
+"        WARN    %s shares a common prefix with %s\n"
+"                REF: Page 15, section 3.2."
+msgstr ""
+
+#: systemv/cupstestppd.c:1322
+#, c-format
+msgid ""
+"        WARN    Duplex option keyword %s may not work as expected and should be named Duplex.\n"
+"                REF: Page 122, section 5.17"
+msgstr ""
+
+#: systemv/cupstestppd.c:1721
+msgid "        WARN    File contains a mix of CR, LF, and CR LF line endings."
+msgstr ""
+
+#: systemv/cupstestppd.c:1367
+msgid ""
+"        WARN    LanguageEncoding required by PPD 4.3 spec.\n"
+"                REF: Pages 56-57, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:1703
+#, c-format
+msgid "        WARN    Line %d only contains whitespace."
+msgstr ""
+
+#: systemv/cupstestppd.c:1375
+msgid ""
+"        WARN    Manufacturer required by PPD 4.3 spec.\n"
+"                REF: Pages 58-59, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:1726
+msgid "        WARN    Non-Windows PPD files should use lines ending with only LF, not CR LF."
+msgstr ""
+
+#: systemv/cupstestppd.c:1359
+#, c-format
+msgid ""
+"        WARN    Obsolete PPD version %.1f.\n"
+"                REF: Page 42, section 5.2."
+msgstr ""
+
+#: systemv/cupstestppd.c:1390
+msgid ""
+"        WARN    PCFileName longer than 8.3 in violation of PPD spec.\n"
+"                REF: Pages 61-62, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:1398
+msgid ""
+"        WARN    PCFileName should contain a unique filename.\n"
+"                REF: Pages 61-62, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:1433
+msgid ""
+"        WARN    Protocols contains PJL but JCL attributes are not set.\n"
+"                REF: Pages 78-79, section 5.7."
+msgstr ""
+
+#: systemv/cupstestppd.c:1424
+msgid ""
+"        WARN    Protocols contains both PJL and BCP; expected TBCP.\n"
+"                REF: Pages 78-79, section 5.7."
+msgstr ""
+
+#: systemv/cupstestppd.c:1407
+msgid ""
+"        WARN    ShortNickName required by PPD 4.3 spec.\n"
+"                REF: Pages 64-65, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:3788
+#, c-format
+msgid ""
+"      %s  \"%s %s\" conflicts with \"%s %s\"\n"
+"                (constraint=\"%s %s %s %s\")."
+msgstr ""
+
+#: systemv/cupstestppd.c:2225
+#, c-format
+msgid "      %s  %s %s does not exist."
+msgstr ""
+
+#: systemv/cupstestppd.c:3941
+#, c-format
+msgid "      %s  %s file \"%s\" has the wrong capitalization."
+msgstr ""
+
+#: systemv/cupstestppd.c:2295
+#, c-format
+msgid ""
+"      %s  Bad %s choice %s.\n"
+"                REF: Page 122, section 5.17"
+msgstr ""
+
+#: systemv/cupstestppd.c:3548 systemv/cupstestppd.c:3597
+#: systemv/cupstestppd.c:3636
+#, c-format
+msgid "      %s  Bad UTF-8 \"%s\" translation string for option %s, choice %s."
+msgstr ""
+
+#: systemv/cupstestppd.c:3502
+#, c-format
+msgid "      %s  Bad UTF-8 \"%s\" translation string for option %s."
+msgstr ""
+
+#: systemv/cupstestppd.c:2366 systemv/cupstestppd.c:2388
+#, c-format
+msgid "      %s  Bad cupsFilter value \"%s\"."
+msgstr ""
+
+#: systemv/cupstestppd.c:2484 systemv/cupstestppd.c:2506
+#, c-format
+msgid "      %s  Bad cupsFilter2 value \"%s\"."
+msgstr ""
+
+#: systemv/cupstestppd.c:3005
+#, c-format
+msgid "      %s  Bad cupsICCProfile %s."
+msgstr ""
+
+#: systemv/cupstestppd.c:2612
+#, c-format
+msgid "      %s  Bad cupsPreFilter value \"%s\"."
+msgstr ""
+
+#: systemv/cupstestppd.c:1799
+#, c-format
+msgid "      %s  Bad cupsUIConstraints %s: \"%s\""
+msgstr ""
+
+#: systemv/cupstestppd.c:3452
+#, c-format
+msgid "      %s  Bad language \"%s\"."
+msgstr ""
+
+#: systemv/cupstestppd.c:2442 systemv/cupstestppd.c:2570
+#: systemv/cupstestppd.c:2656 systemv/cupstestppd.c:2714
+#: systemv/cupstestppd.c:2769 systemv/cupstestppd.c:2824
+#: systemv/cupstestppd.c:2879 systemv/cupstestppd.c:2932
+#: systemv/cupstestppd.c:3054
+#, c-format
+msgid "      %s  Bad permissions on %s file \"%s\"."
+msgstr ""
+
+#: systemv/cupstestppd.c:2350 systemv/cupstestppd.c:2468
+#: systemv/cupstestppd.c:2596 systemv/cupstestppd.c:2683
+#: systemv/cupstestppd.c:2738 systemv/cupstestppd.c:2793
+#: systemv/cupstestppd.c:2848 systemv/cupstestppd.c:2903
+#, c-format
+msgid "      %s  Bad spelling of %s - should be %s."
+msgstr ""
+
+#: systemv/cupstestppd.c:2948
+#, c-format
+msgid "      %s  Cannot provide both APScanAppPath and APScanAppBundleID."
+msgstr ""
+
+#: systemv/cupstestppd.c:2182
+#, c-format
+msgid "      %s  Default choices conflicting."
+msgstr ""
+
+#: systemv/cupstestppd.c:1780
+#, c-format
+msgid "      %s  Empty cupsUIConstraints %s"
+msgstr ""
+
+#: systemv/cupstestppd.c:3580 systemv/cupstestppd.c:3620
+#, c-format
+msgid "      %s  Missing \"%s\" translation string for option %s, choice %s."
+msgstr ""
+
+#: systemv/cupstestppd.c:3488
+#, c-format
+msgid "      %s  Missing \"%s\" translation string for option %s."
+msgstr ""
+
+#: systemv/cupstestppd.c:2427 systemv/cupstestppd.c:2555
+#: systemv/cupstestppd.c:2641 systemv/cupstestppd.c:2699
+#: systemv/cupstestppd.c:2754 systemv/cupstestppd.c:2809
+#: systemv/cupstestppd.c:2864 systemv/cupstestppd.c:2916
+#: systemv/cupstestppd.c:3039
+#, c-format
+msgid "      %s  Missing %s file \"%s\"."
+msgstr ""
+
+#: systemv/cupstestppd.c:3162
+#, c-format
+msgid ""
+"      %s  Missing REQUIRED PageRegion option.\n"
+"                REF: Page 100, section 5.14."
+msgstr ""
+
+#: systemv/cupstestppd.c:3147
+#, c-format
+msgid ""
+"      %s  Missing REQUIRED PageSize option.\n"
+"                REF: Page 99, section 5.14."
+msgstr ""
+
+#: systemv/cupstestppd.c:1990 systemv/cupstestppd.c:2031
+#, c-format
+msgid "      %s  Missing choice *%s %s in UIConstraints \"*%s %s *%s %s\"."
+msgstr ""
+
+#: systemv/cupstestppd.c:1885
+#, c-format
+msgid "      %s  Missing choice *%s %s in cupsUIConstraints %s: \"%s\""
+msgstr ""
+
+#: systemv/cupstestppd.c:1817
+#, c-format
+msgid "      %s  Missing cupsUIResolver %s"
+msgstr ""
+
+#: systemv/cupstestppd.c:1976 systemv/cupstestppd.c:2017
+#, c-format
+msgid "      %s  Missing option %s in UIConstraints \"*%s %s *%s %s\"."
+msgstr ""
+
+#: systemv/cupstestppd.c:1869
+#, c-format
+msgid "      %s  Missing option %s in cupsUIConstraints %s: \"%s\""
+msgstr ""
+
+#: systemv/cupstestppd.c:3674
+#, c-format
+msgid "      %s  No base translation \"%s\" is included in file."
+msgstr ""
+
+#: systemv/cupstestppd.c:2271
+#, c-format
+msgid ""
+"      %s  REQUIRED %s does not define choice None.\n"
+"                REF: Page 122, section 5.17"
+msgstr ""
+
+#: systemv/cupstestppd.c:3221 systemv/cupstestppd.c:3235
+#, c-format
+msgid "      %s  Size \"%s\" defined for %s but not for %s."
+msgstr ""
+
+#: systemv/cupstestppd.c:3201
+#, c-format
+msgid "      %s  Size \"%s\" has unexpected dimensions (%gx%g)."
+msgstr ""
+
+#: systemv/cupstestppd.c:3392
+#, c-format
+msgid "      %s  Size \"%s\" should be \"%s\"."
+msgstr ""
+
+#: systemv/cupstestppd.c:3341
+#, c-format
+msgid "      %s  Size \"%s\" should be the Adobe standard name \"%s\"."
+msgstr ""
+
+#: systemv/cupstestppd.c:3082
+#, c-format
+msgid "      %s  cupsICCProfile %s hash value collides with %s."
+msgstr ""
+
+#: systemv/cupstestppd.c:1940
+#, c-format
+msgid "      %s  cupsUIResolver %s causes a loop."
+msgstr ""
+
+#: systemv/cupstestppd.c:1922
+#, c-format
+msgid "      %s  cupsUIResolver %s does not list at least two different options."
+msgstr ""
+
+#: systemv/cupstestppd.c:1145
+#, c-format
+msgid ""
+"      **FAIL**  %s must be 1284DeviceID\n"
+"                REF: Page 72, section 5.5"
+msgstr ""
+
+#: systemv/cupstestppd.c:557
+#, c-format
+msgid ""
+"      **FAIL**  Bad Default%s %s\n"
+"                REF: Page 40, section 4.5."
+msgstr ""
+
+#: systemv/cupstestppd.c:491
+#, c-format
+msgid ""
+"      **FAIL**  Bad DefaultImageableArea %s\n"
+"                REF: Page 102, section 5.15."
+msgstr ""
+
+#: systemv/cupstestppd.c:527
+#, c-format
+msgid ""
+"      **FAIL**  Bad DefaultPaperDimension %s\n"
+"                REF: Page 103, section 5.15."
+msgstr ""
+
+#: systemv/cupstestppd.c:600
+#, c-format
+msgid ""
+"      **FAIL**  Bad FileVersion \"%s\"\n"
+"                REF: Page 56, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:644
+#, c-format
+msgid ""
+"      **FAIL**  Bad FormatVersion \"%s\"\n"
+"                REF: Page 56, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:1002
+msgid ""
+"      **FAIL**  Bad JobPatchFile attribute in file\n"
+"                REF: Page 24, section 3.4."
+msgstr ""
+
+#: systemv/cupstestppd.c:1190
+#, c-format
+msgid "      **FAIL**  Bad LanguageEncoding %s - must be ISOLatin1."
+msgstr ""
+
+#: systemv/cupstestppd.c:1204
+#, c-format
+msgid "      **FAIL**  Bad LanguageVersion %s - must be English."
+msgstr ""
+
+#: systemv/cupstestppd.c:720 systemv/cupstestppd.c:737
+#, c-format
+msgid ""
+"      **FAIL**  Bad Manufacturer (should be \"%s\")\n"
+"                REF: Page 211, table D.1."
+msgstr ""
+
+#: systemv/cupstestppd.c:777
+#, c-format
+msgid ""
+"      **FAIL**  Bad ModelName - \"%c\" not allowed in string.\n"
+"                REF: Pages 59-60, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:933
+msgid ""
+"      **FAIL**  Bad PSVersion - not \"(string) int\".\n"
+"                REF: Pages 62-64, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:894
+msgid ""
+"      **FAIL**  Bad Product - not \"(string)\".\n"
+"                REF: Page 62, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:968
+msgid ""
+"      **FAIL**  Bad ShortNickName - longer than 31 chars.\n"
+"                REF: Pages 64-65, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:1126
+#, c-format
+msgid ""
+"      **FAIL**  Bad option %s choice %s\n"
+"                REF: Page 84, section 5.9"
+msgstr ""
+
+#: systemv/cupstestppd.c:3815 systemv/cupstestppd.c:3837
+#, c-format
+msgid "      **FAIL**  Default option code cannot be interpreted: %s"
+msgstr ""
+
+#: systemv/cupstestppd.c:1263
+#, c-format
+msgid "      **FAIL**  Default translation string for option %s choice %s contains 8-bit characters."
+msgstr ""
+
+#: systemv/cupstestppd.c:1236
+#, c-format
+msgid "      **FAIL**  Default translation string for option %s contains 8-bit characters."
+msgstr ""
+
+#: systemv/cupstestppd.c:2078
+#, c-format
+msgid "      **FAIL**  Group names %s and %s differ only by case."
+msgstr ""
+
+#: systemv/cupstestppd.c:2123
+#, c-format
+msgid "      **FAIL**  Multiple occurrences of option %s choice name %s."
+msgstr ""
+
+#: systemv/cupstestppd.c:2140
+#, c-format
+msgid "      **FAIL**  Option %s choice names %s and %s differ only by case."
+msgstr ""
+
+#: systemv/cupstestppd.c:2100
+#, c-format
+msgid "      **FAIL**  Option names %s and %s differ only by case."
+msgstr ""
+
+#: systemv/cupstestppd.c:577
+#, c-format
+msgid ""
+"      **FAIL**  REQUIRED Default%s\n"
+"                REF: Page 40, section 4.5."
+msgstr ""
+
+#: systemv/cupstestppd.c:476
+msgid ""
+"      **FAIL**  REQUIRED DefaultImageableArea\n"
+"                REF: Page 102, section 5.15."
+msgstr ""
+
+#: systemv/cupstestppd.c:512
+msgid ""
+"      **FAIL**  REQUIRED DefaultPaperDimension\n"
+"                REF: Page 103, section 5.15."
+msgstr ""
+
+#: systemv/cupstestppd.c:618
+msgid ""
+"      **FAIL**  REQUIRED FileVersion\n"
+"                REF: Page 56, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:662
+msgid ""
+"      **FAIL**  REQUIRED FormatVersion\n"
+"                REF: Page 56, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:1053
+#, c-format
+msgid ""
+"      **FAIL**  REQUIRED ImageableArea for PageSize %s\n"
+"                REF: Page 41, section 5.\n"
+"                REF: Page 102, section 5.15."
+msgstr ""
+
+#: systemv/cupstestppd.c:682
+msgid ""
+"      **FAIL**  REQUIRED LanguageEncoding\n"
+"                REF: Pages 56-57, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:702
+msgid ""
+"      **FAIL**  REQUIRED LanguageVersion\n"
+"                REF: Pages 57-58, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:756
+msgid ""
+"      **FAIL**  REQUIRED Manufacturer\n"
+"                REF: Pages 58-59, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:796
+msgid ""
+"      **FAIL**  REQUIRED ModelName\n"
+"                REF: Pages 59-60, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:816
+msgid ""
+"      **FAIL**  REQUIRED NickName\n"
+"                REF: Page 60, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:876
+msgid ""
+"      **FAIL**  REQUIRED PCFileName\n"
+"                REF: Pages 61-62, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:951
+msgid ""
+"      **FAIL**  REQUIRED PSVersion\n"
+"                REF: Pages 62-64, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:856
+msgid ""
+"      **FAIL**  REQUIRED PageRegion\n"
+"                REF: Page 100, section 5.14."
+msgstr ""
+
+#: systemv/cupstestppd.c:1022
+msgid ""
+"      **FAIL**  REQUIRED PageSize\n"
+"                REF: Page 41, section 5.\n"
+"                REF: Page 99, section 5.14."
+msgstr ""
+
+#: systemv/cupstestppd.c:836
+msgid ""
+"      **FAIL**  REQUIRED PageSize\n"
+"                REF: Pages 99-100, section 5.14."
+msgstr ""
+
+#: systemv/cupstestppd.c:1075
+#, c-format
+msgid ""
+"      **FAIL**  REQUIRED PaperDimension for PageSize %s\n"
+"                REF: Page 41, section 5.\n"
+"                REF: Page 103, section 5.15."
+msgstr ""
+
+#: systemv/cupstestppd.c:911
+msgid ""
+"      **FAIL**  REQUIRED Product\n"
+"                REF: Page 62, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:986
+msgid ""
+"      **FAIL**  REQUIRED ShortNickName\n"
+"                REF: Page 64-65, section 5.3."
+msgstr ""
+
+#: systemv/cupstestppd.c:311 systemv/cupstestppd.c:330
+#: systemv/cupstestppd.c:342
+#, c-format
+msgid "      **FAIL**  Unable to open PPD file - %s on line %d."
+msgstr ""
+
+#: systemv/cupstestppd.c:1475
+#, c-format
+msgid "    %d ERRORS FOUND"
+msgstr ""
+
+#: systemv/cupstestppd.c:1477
+msgid "    NO ERRORS FOUND"
+msgstr ""
+
+#: ppdc/ppdc.cxx:444
+msgid "  --cr                    End lines with CR (Mac OS 9)."
+msgstr ""
+
+#: ppdc/ppdc.cxx:446
+msgid "  --crlf                  End lines with CR + LF (Windows)."
+msgstr ""
+
+#: ppdc/ppdc.cxx:448
+msgid "  --lf                    End lines with LF (UNIX/Linux/macOS)."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1477
+msgid "  --list-filters          List filters that will be used."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1478
+msgid "  -D                      Remove the input file when finished."
+msgstr ""
+
+#: ppdc/ppdc.cxx:427 ppdc/ppdhtml.cxx:174 ppdc/ppdpo.cxx:244
+msgid "  -D name=value           Set named variable to value."
+msgstr ""
+
+#: ppdc/ppdc.cxx:429 ppdc/ppdhtml.cxx:176 ppdc/ppdi.cxx:120 ppdc/ppdpo.cxx:246
+msgid "  -I include-dir          Add include directory to search path."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1479
+msgid "  -P filename.ppd         Set PPD file."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1480
+msgid "  -U username             Specify username."
+msgstr ""
+
+#: ppdc/ppdc.cxx:431
+msgid "  -c catalog.po           Load the specified message catalog."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1481
+msgid "  -c cups-files.conf      Set cups-files.conf file to use."
+msgstr ""
+
+#: ppdc/ppdc.cxx:433
+msgid "  -d output-dir           Specify the output directory."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1482
+msgid "  -d printer              Use the named printer."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1483
+msgid "  -e                      Use every filter from the PPD file."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1484
+msgid "  -i mime/type            Set input MIME type (otherwise auto-typed)."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1485
+msgid "  -j job-id[,N]           Filter file N from the specified job (default is file 1)."
+msgstr ""
+
+#: ppdc/ppdc.cxx:435
+msgid "  -l lang[,lang,...]      Specify the output language(s) (locale)."
+msgstr ""
+
+#: ppdc/ppdc.cxx:437
+msgid "  -m                      Use the ModelName value as the filename."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1486
+msgid "  -m mime/type            Set output MIME type (otherwise application/pdf)."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1487
+msgid "  -n copies               Set number of copies."
+msgstr ""
+
+#: ppdc/ppdi.cxx:122
+msgid "  -o filename.drv         Set driver information file (otherwise ppdi.drv)."
+msgstr ""
+
+#: ppdc/ppdmerge.cxx:357
+msgid "  -o filename.ppd[.gz]    Set output file (otherwise stdout)."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1488
+msgid "  -o name=value           Set option(s)."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1489
+msgid "  -p filename.ppd         Set PPD file."
+msgstr ""
+
+#: ppdc/ppdc.cxx:439
+msgid "  -t                      Test PPDs instead of generating them."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1490
+msgid "  -t title                Set title."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1491
+msgid "  -u                      Remove the PPD file when finished."
+msgstr ""
+
+#: ppdc/ppdc.cxx:441 ppdc/ppdpo.cxx:248
+msgid "  -v                      Be verbose."
+msgstr ""
+
+#: ppdc/ppdc.cxx:442
+msgid "  -z                      Compress PPD files using GNU zip."
+msgstr ""
+
+#: systemv/cupstestppd.c:309 systemv/cupstestppd.c:328
+#: systemv/cupstestppd.c:340 systemv/cupstestppd.c:473
+#: systemv/cupstestppd.c:488 systemv/cupstestppd.c:509
+#: systemv/cupstestppd.c:524 systemv/cupstestppd.c:554
+#: systemv/cupstestppd.c:574 systemv/cupstestppd.c:597
+#: systemv/cupstestppd.c:615 systemv/cupstestppd.c:641
+#: systemv/cupstestppd.c:659 systemv/cupstestppd.c:679
+#: systemv/cupstestppd.c:699 systemv/cupstestppd.c:717
+#: systemv/cupstestppd.c:734 systemv/cupstestppd.c:753
+#: systemv/cupstestppd.c:774 systemv/cupstestppd.c:793
+#: systemv/cupstestppd.c:813 systemv/cupstestppd.c:833
+#: systemv/cupstestppd.c:853 systemv/cupstestppd.c:873
+#: systemv/cupstestppd.c:891 systemv/cupstestppd.c:908
+#: systemv/cupstestppd.c:930 systemv/cupstestppd.c:948
+#: systemv/cupstestppd.c:965 systemv/cupstestppd.c:983
+#: systemv/cupstestppd.c:999 systemv/cupstestppd.c:1019
+#: systemv/cupstestppd.c:1050 systemv/cupstestppd.c:1072
+#: systemv/cupstestppd.c:1123 systemv/cupstestppd.c:1142
+#: systemv/cupstestppd.c:1186 systemv/cupstestppd.c:1200
+#: systemv/cupstestppd.c:1232 systemv/cupstestppd.c:1259
+#: systemv/cupstestppd.c:1777 systemv/cupstestppd.c:1796
+#: systemv/cupstestppd.c:1814 systemv/cupstestppd.c:1866
+#: systemv/cupstestppd.c:1882 systemv/cupstestppd.c:1919
+#: systemv/cupstestppd.c:1937 systemv/cupstestppd.c:1973
+#: systemv/cupstestppd.c:1987 systemv/cupstestppd.c:2014
+#: systemv/cupstestppd.c:2028 systemv/cupstestppd.c:2074
+#: systemv/cupstestppd.c:2096 systemv/cupstestppd.c:2119
+#: systemv/cupstestppd.c:2136 systemv/cupstestppd.c:2178
+#: systemv/cupstestppd.c:2221 systemv/cupstestppd.c:2268
+#: systemv/cupstestppd.c:2292 systemv/cupstestppd.c:2346
+#: systemv/cupstestppd.c:2362 systemv/cupstestppd.c:2384
+#: systemv/cupstestppd.c:2424 systemv/cupstestppd.c:2438
+#: systemv/cupstestppd.c:2464 systemv/cupstestppd.c:2480
+#: systemv/cupstestppd.c:2502 systemv/cupstestppd.c:2552
+#: systemv/cupstestppd.c:2566 systemv/cupstestppd.c:2592
+#: systemv/cupstestppd.c:2608 systemv/cupstestppd.c:2638
+#: systemv/cupstestppd.c:2652 systemv/cupstestppd.c:2679
+#: systemv/cupstestppd.c:2696 systemv/cupstestppd.c:2710
+#: systemv/cupstestppd.c:2734 systemv/cupstestppd.c:2751
+#: systemv/cupstestppd.c:2765 systemv/cupstestppd.c:2789
+#: systemv/cupstestppd.c:2806 systemv/cupstestppd.c:2820
+#: systemv/cupstestppd.c:2844 systemv/cupstestppd.c:2861
+#: systemv/cupstestppd.c:2875 systemv/cupstestppd.c:2899
+#: systemv/cupstestppd.c:2913 systemv/cupstestppd.c:2928
+#: systemv/cupstestppd.c:2945 systemv/cupstestppd.c:3001
+#: systemv/cupstestppd.c:3036 systemv/cupstestppd.c:3050
+#: systemv/cupstestppd.c:3078 systemv/cupstestppd.c:3143
+#: systemv/cupstestppd.c:3158 systemv/cupstestppd.c:3197
+#: systemv/cupstestppd.c:3217 systemv/cupstestppd.c:3231
+#: systemv/cupstestppd.c:3448 systemv/cupstestppd.c:3484
+#: systemv/cupstestppd.c:3498 systemv/cupstestppd.c:3544
+#: systemv/cupstestppd.c:3576 systemv/cupstestppd.c:3593
+#: systemv/cupstestppd.c:3616 systemv/cupstestppd.c:3632
+#: systemv/cupstestppd.c:3670 systemv/cupstestppd.c:3811
+#: systemv/cupstestppd.c:3833 systemv/cupstestppd.c:3937
+msgid " FAIL"
+msgstr ""
+
+#: systemv/cupstestppd.c:1283
+msgid " PASS"
+msgstr ""
+
+#: tools/ippfind.c:2803
+msgid "! expression            Unary NOT of expression"
+msgstr ""
+
+#: cups/ipp.c:5045
+#, c-format
+msgid "\"%s\": Bad URI value \"%s\" - %s (RFC 8011 section 5.1.6)."
+msgstr ""
+
+#: cups/ipp.c:5051
+#, c-format
+msgid "\"%s\": Bad URI value \"%s\" - bad length %d (RFC 8011 section 5.1.6)."
+msgstr ""
+
+#: cups/ipp.c:4753
+#, c-format
+msgid "\"%s\": Bad attribute name - bad length %d (RFC 8011 section 5.1.4)."
+msgstr ""
+
+#: cups/ipp.c:4747
+#, c-format
+msgid "\"%s\": Bad attribute name - invalid character (RFC 8011 section 5.1.4)."
+msgstr ""
+
+#: cups/ipp.c:4768
+#, c-format
+msgid "\"%s\": Bad boolean value %d (RFC 8011 section 5.1.21)."
+msgstr ""
+
+#: cups/ipp.c:5096
+#, c-format
+msgid "\"%s\": Bad charset value \"%s\" - bad characters (RFC 8011 section 5.1.8)."
+msgstr ""
+
+#: cups/ipp.c:5102
+#, c-format
+msgid "\"%s\": Bad charset value \"%s\" - bad length %d (RFC 8011 section 5.1.8)."
+msgstr ""
+
+#: cups/ipp.c:4845
+#, c-format
+msgid "\"%s\": Bad dateTime UTC hours %u (RFC 8011 section 5.1.15)."
+msgstr ""
+
+#: cups/ipp.c:4851
+#, c-format
+msgid "\"%s\": Bad dateTime UTC minutes %u (RFC 8011 section 5.1.15)."
+msgstr ""
+
+#: cups/ipp.c:4839
+#, c-format
+msgid "\"%s\": Bad dateTime UTC sign '%c' (RFC 8011 section 5.1.15)."
+msgstr ""
+
+#: cups/ipp.c:4809
+#, c-format
+msgid "\"%s\": Bad dateTime day %u (RFC 8011 section 5.1.15)."
+msgstr ""
+
+#: cups/ipp.c:4833
+#, c-format
+msgid "\"%s\": Bad dateTime deciseconds %u (RFC 8011 section 5.1.15)."
+msgstr ""
+
+#: cups/ipp.c:4815
+#, c-format
+msgid "\"%s\": Bad dateTime hours %u (RFC 8011 section 5.1.15)."
+msgstr ""
+
+#: cups/ipp.c:4821
+#, c-format
+msgid "\"%s\": Bad dateTime minutes %u (RFC 8011 section 5.1.15)."
+msgstr ""
+
+#: cups/ipp.c:4803
+#, c-format
+msgid "\"%s\": Bad dateTime month %u (RFC 8011 section 5.1.15)."
+msgstr ""
+
+#: cups/ipp.c:4827
+#, c-format
+msgid "\"%s\": Bad dateTime seconds %u (RFC 8011 section 5.1.15)."
+msgstr ""
+
+#: cups/ipp.c:4779
+#, c-format
+msgid "\"%s\": Bad enum value %d - out of range (RFC 8011 section 5.1.5)."
+msgstr ""
+
+#: cups/ipp.c:5032
+#, c-format
+msgid "\"%s\": Bad keyword value \"%s\" - bad length %d (RFC 8011 section 5.1.4)."
+msgstr ""
+
+#: cups/ipp.c:5026
+#, c-format
+msgid "\"%s\": Bad keyword value \"%s\" - invalid character (RFC 8011 section 5.1.4)."
+msgstr ""
+
+#: cups/ipp.c:5187
+#, c-format
+msgid "\"%s\": Bad mimeMediaType value \"%s\" - bad characters (RFC 8011 section 5.1.10)."
+msgstr ""
+
+#: cups/ipp.c:5194
+#, c-format
+msgid "\"%s\": Bad mimeMediaType value \"%s\" - bad length %d (RFC 8011 section 5.1.10)."
+msgstr ""
+
+#: cups/ipp.c:5001
+#, c-format
+msgid "\"%s\": Bad name value \"%s\" - bad UTF-8 sequence (RFC 8011 section 5.1.3)."
+msgstr ""
+
+#: cups/ipp.c:4996
+#, c-format
+msgid "\"%s\": Bad name value \"%s\" - bad control character (PWG 5100.14 section 8.1)."
+msgstr ""
+
+#: cups/ipp.c:5008
+#, c-format
+msgid "\"%s\": Bad name value \"%s\" - bad length %d (RFC 8011 section 5.1.3)."
+msgstr ""
+
+#: cups/ipp.c:5142
+#, c-format
+msgid "\"%s\": Bad naturalLanguage value \"%s\" - bad characters (RFC 8011 section 5.1.9)."
+msgstr ""
+
+#: cups/ipp.c:5149
+#, c-format
+msgid "\"%s\": Bad naturalLanguage value \"%s\" - bad length %d (RFC 8011 section 5.1.9)."
+msgstr ""
+
+#: cups/ipp.c:4790
+#, c-format
+msgid "\"%s\": Bad octetString value - bad length %d (RFC 8011 section 5.1.20)."
+msgstr ""
+
+#: cups/ipp.c:4885
+#, c-format
+msgid "\"%s\": Bad rangeOfInteger value %d-%d - lower greater than upper (RFC 8011 section 5.1.14)."
+msgstr ""
+
+#: cups/ipp.c:4874
+#, c-format
+msgid "\"%s\": Bad resolution value %dx%d%s - bad units value (RFC 8011 section 5.1.16)."
+msgstr ""
+
+#: cups/ipp.c:4862
+#, c-format
+msgid "\"%s\": Bad resolution value %dx%d%s - cross feed resolution must be positive (RFC 8011 section 5.1.16)."
+msgstr ""
+
+#: cups/ipp.c:4868
+#, c-format
+msgid "\"%s\": Bad resolution value %dx%d%s - feed resolution must be positive (RFC 8011 section 5.1.16)."
+msgstr ""
+
+#: cups/ipp.c:4946
+#, c-format
+msgid "\"%s\": Bad text value \"%s\" - bad UTF-8 sequence (RFC 8011 section 5.1.2)."
+msgstr ""
+
+#: cups/ipp.c:4941
+#, c-format
+msgid "\"%s\": Bad text value \"%s\" - bad control character (PWG 5100.14 section 8.3)."
+msgstr ""
+
+#: cups/ipp.c:4953
+#, c-format
+msgid "\"%s\": Bad text value \"%s\" - bad length %d (RFC 8011 section 5.1.2)."
+msgstr ""
+
+#: cups/ipp.c:5072
+#, c-format
+msgid "\"%s\": Bad uriScheme value \"%s\" - bad characters (RFC 8011 section 5.1.7)."
+msgstr ""
+
+#: cups/ipp.c:5078
+#, c-format
+msgid "\"%s\": Bad uriScheme value \"%s\" - bad length %d (RFC 8011 section 5.1.7)."
+msgstr ""
+
+#: scheduler/ipp.c:365
+msgid "\"requesting-user-name\" attribute in wrong group."
+msgstr ""
+
+#: scheduler/ipp.c:371 scheduler/ipp.c:386
+msgid "\"requesting-user-name\" attribute with wrong syntax."
+msgstr ""
+
+#: berkeley/lpq.c:538
+#, c-format
+msgid "%-7s %-7.7s %-7d %-31.31s %.0f bytes"
+msgstr ""
+
+#: cups/dest-localization.c:156
+#, c-format
+msgid "%d x %d mm"
+msgstr ""
+
+#: cups/dest-localization.c:148
+#, c-format
+msgid "%g x %g \""
+msgstr ""
+
+#: cups/dest-localization.c:189 cups/dest-localization.c:196
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#: cups/dest-localization.c:203
+#, c-format
+msgid "%s (%s, %s)"
+msgstr ""
+
+#: cups/dest-localization.c:180
+#, c-format
+msgid "%s (Borderless)"
+msgstr ""
+
+#: cups/dest-localization.c:187 cups/dest-localization.c:194
+#, c-format
+msgid "%s (Borderless, %s)"
+msgstr ""
+
+#: cups/dest-localization.c:201
+#, c-format
+msgid "%s (Borderless, %s, %s)"
+msgstr ""
+
+#: systemv/lpstat.c:806
+#, c-format
+msgid "%s accepting requests since %s"
+msgstr ""
+
+#: scheduler/ipp.c:10327
+#, c-format
+msgid "%s cannot be changed."
+msgstr ""
+
+#: berkeley/lpc.c:175
+#, c-format
+msgid "%s is not implemented by the CUPS version of lpc."
+msgstr ""
+
+#: berkeley/lpq.c:623
+#, c-format
+msgid "%s is not ready"
+msgstr ""
+
+#: berkeley/lpq.c:616
+#, c-format
+msgid "%s is ready"
+msgstr ""
+
+#: berkeley/lpq.c:619
+#, c-format
+msgid "%s is ready and printing"
+msgstr ""
+
+#: filter/rastertoepson.c:999 filter/rastertohp.c:668
+#: filter/rastertolabel.c:1120
+#, c-format
+msgid "%s job-id user title copies options [file]"
+msgstr ""
+
+#: systemv/lpstat.c:810
+#, c-format
+msgid "%s not accepting requests since %s -"
+msgstr ""
+
+#: scheduler/ipp.c:608
+#, c-format
+msgid "%s not supported."
+msgstr ""
+
+#: systemv/lpstat.c:821
+#, c-format
+msgid "%s/%s accepting requests since %s"
+msgstr ""
+
+#: systemv/lpstat.c:826
+#, c-format
+msgid "%s/%s not accepting requests since %s -"
+msgstr ""
+
+#: berkeley/lpq.c:531
+#, c-format
+msgid "%s: %-33.33s [job %d localhost]"
+msgstr ""
+
+#. TRANSLATORS: Message is "subject: error"
+#: cups/langprintf.c:70 scheduler/cupsfilter.c:720 systemv/lpadmin.c:795
+#: systemv/lpadmin.c:844 systemv/lpadmin.c:892 systemv/lpadmin.c:945
+#: systemv/lpadmin.c:1043 systemv/lpadmin.c:1095 systemv/lpadmin.c:1136
+#: systemv/lpadmin.c:1150 systemv/lpadmin.c:1599
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: systemv/cancel.c:310 systemv/cancel.c:374
+#, c-format
+msgid "%s: %s failed: %s"
+msgstr ""
+
+#: systemv/lpadmin.c:1209
+#, c-format
+msgid "%s: Bad printer URI \"%s\"."
+msgstr ""
+
+#: tools/ippfind.c:768 tools/ipptool.c:412
+#, c-format
+msgid "%s: Bad version %s for \"-V\"."
+msgstr ""
+
+#: systemv/cupsaccept.c:67
+#, c-format
+msgid "%s: Don't know what to do."
+msgstr ""
+
+#: berkeley/lpr.c:354 systemv/lp.c:589
+#, c-format
+msgid "%s: Error - %s"
+msgstr ""
+
+#: berkeley/lpq.c:233
+#, c-format
+msgid "%s: Error - %s environment variable names non-existent destination \"%s\"."
+msgstr ""
+
+#: berkeley/lpq.c:138 berkeley/lpq.c:211 berkeley/lpr.c:234 berkeley/lpr.c:345
+#: systemv/lp.c:160 systemv/lp.c:580 systemv/lp.c:677 systemv/lp.c:727
+#: systemv/lpstat.c:190 systemv/lpstat.c:235 systemv/lpstat.c:368
+#: systemv/lpstat.c:395 systemv/lpstat.c:417 systemv/lpstat.c:477
+#: systemv/lpstat.c:543 systemv/lpstat.c:604 systemv/lpstat.c:727
+#: systemv/lpstat.c:907 systemv/lpstat.c:1164 systemv/lpstat.c:1356
+#: systemv/lpstat.c:1593
+#, c-format
+msgid "%s: Error - add '/version=1.1' to server name."
+msgstr ""
+
+#: systemv/lp.c:237
+#, c-format
+msgid "%s: Error - bad job ID."
+msgstr ""
+
+#: systemv/lp.c:226
+#, c-format
+msgid "%s: Error - cannot print files and alter jobs simultaneously."
+msgstr ""
+
+#: systemv/lp.c:517
+#, c-format
+msgid "%s: Error - cannot print from stdin if files or a job ID are provided."
+msgstr ""
+
+#: berkeley/lpr.c:259 systemv/lp.c:279
+#, c-format
+msgid "%s: Error - copies must be 1 or more."
+msgstr ""
+
+#: systemv/lp.c:469
+#, c-format
+msgid "%s: Error - expected character set after \"-S\" option."
+msgstr ""
+
+#: systemv/lp.c:488
+#, c-format
+msgid "%s: Error - expected content type after \"-T\" option."
+msgstr ""
+
+#: berkeley/lpr.c:250
+#, c-format
+msgid "%s: Error - expected copies after \"-#\" option."
+msgstr ""
+
+#: systemv/lp.c:270
+#, c-format
+msgid "%s: Error - expected copies after \"-n\" option."
+msgstr ""
+
+#: berkeley/lpr.c:212
+#, c-format
+msgid "%s: Error - expected destination after \"-P\" option."
+msgstr ""
+
+#: systemv/lp.c:136
+#, c-format
+msgid "%s: Error - expected destination after \"-d\" option."
+msgstr ""
+
+#: systemv/lp.c:177
+#, c-format
+msgid "%s: Error - expected form after \"-f\" option."
+msgstr ""
+
+#: systemv/lp.c:405
+#, c-format
+msgid "%s: Error - expected hold name after \"-H\" option."
+msgstr ""
+
+#: berkeley/lpr.c:109
+#, c-format
+msgid "%s: Error - expected hostname after \"-H\" option."
+msgstr ""
+
+#: berkeley/lpq.c:172 berkeley/lprm.c:130 systemv/cancel.c:130
+#: systemv/cupsaccept.c:133 systemv/lp.c:197 systemv/lpstat.c:304
+#, c-format
+msgid "%s: Error - expected hostname after \"-h\" option."
+msgstr ""
+
+#: systemv/lp.c:385
+#, c-format
+msgid "%s: Error - expected mode list after \"-y\" option."
+msgstr ""
+
+#: berkeley/lpr.c:280
+#, c-format
+msgid "%s: Error - expected name after \"-%c\" option."
+msgstr ""
+
+#: berkeley/lpr.c:161 systemv/lp.c:300
+#, c-format
+msgid "%s: Error - expected option=value after \"-o\" option."
+msgstr ""
+
+#: systemv/lp.c:448
+#, c-format
+msgid "%s: Error - expected page list after \"-P\" option."
+msgstr ""
+
+#: systemv/lp.c:321
+#, c-format
+msgid "%s: Error - expected priority after \"-%c\" option."
+msgstr ""
+
+#: systemv/cupsaccept.c:152
+#, c-format
+msgid "%s: Error - expected reason text after \"-r\" option."
+msgstr ""
+
+#: systemv/lp.c:366
+#, c-format
+msgid "%s: Error - expected title after \"-t\" option."
+msgstr ""
+
+#: berkeley/lpq.c:101 berkeley/lpr.c:89 berkeley/lprm.c:110
+#: systemv/cancel.c:100 systemv/cupsaccept.c:110 systemv/lp.c:113
+#: systemv/lpadmin.c:439 systemv/lpstat.c:129
+#, c-format
+msgid "%s: Error - expected username after \"-U\" option."
+msgstr ""
+
+#: systemv/cancel.c:152
+#, c-format
+msgid "%s: Error - expected username after \"-u\" option."
+msgstr ""
+
+#: berkeley/lpr.c:134
+#, c-format
+msgid "%s: Error - expected value after \"-%c\" option."
+msgstr ""
+
+#: systemv/lpstat.c:149 systemv/lpstat.c:158
+#, c-format
+msgid "%s: Error - need \"completed\", \"not-completed\", or \"all\" after \"-W\" option."
+msgstr ""
+
+#: berkeley/lpq.c:238
+#, c-format
+msgid "%s: Error - no default destination available."
+msgstr ""
+
+#: systemv/lp.c:341
+#, c-format
+msgid "%s: Error - priority must be between 1 and 100."
+msgstr ""
+
+#: berkeley/lpr.c:356 systemv/lp.c:591
+#, c-format
+msgid "%s: Error - scheduler not responding."
+msgstr ""
+
+#: berkeley/lpr.c:321 systemv/lp.c:549
+#, c-format
+msgid "%s: Error - too many files - \"%s\"."
+msgstr ""
+
+#: berkeley/lpr.c:303 systemv/lp.c:532
+#, c-format
+msgid "%s: Error - unable to access \"%s\" - %s"
+msgstr ""
+
+#: berkeley/lpr.c:398 systemv/lp.c:621
+#, c-format
+msgid "%s: Error - unable to queue from stdin - %s."
+msgstr ""
+
+#: berkeley/lprm.c:92 berkeley/lprm.c:179 systemv/cancel.c:227
+#, c-format
+msgid "%s: Error - unknown destination \"%s\"."
+msgstr ""
+
+#: berkeley/lpq.c:140
+#, c-format
+msgid "%s: Error - unknown destination \"%s/%s\"."
+msgstr ""
+
+#: berkeley/lpr.c:289 berkeley/lprm.c:145 systemv/cancel.c:168
+#: systemv/cupsaccept.c:161 systemv/lp.c:507 systemv/lpstat.c:487
+#, c-format
+msgid "%s: Error - unknown option \"%c\"."
+msgstr ""
+
+#: systemv/lp.c:499
+#, c-format
+msgid "%s: Error - unknown option \"%s\"."
+msgstr ""
+
+#: systemv/lp.c:217
+#, c-format
+msgid "%s: Expected job ID after \"-i\" option."
+msgstr ""
+
+#: systemv/lpstat.c:547 systemv/lpstat.c:587
+#, c-format
+msgid "%s: Invalid destination name in list \"%s\"."
+msgstr ""
+
+#: scheduler/cupsfilter.c:573
+#, c-format
+msgid "%s: Invalid filter string \"%s\"."
+msgstr ""
+
+#: tools/ipptool.c:334
+#, c-format
+msgid "%s: Missing filename for \"-P\"."
+msgstr ""
+
+#: tools/ippfind.c:740 tools/ipptool.c:371
+#, c-format
+msgid "%s: Missing timeout for \"-T\"."
+msgstr ""
+
+#: tools/ippfind.c:753 tools/ipptool.c:385
+#, c-format
+msgid "%s: Missing version for \"-V\"."
+msgstr ""
+
+#: systemv/lp.c:425
+#, c-format
+msgid "%s: Need job ID (\"-i jobid\") before \"-H restart\"."
+msgstr ""
+
+#: scheduler/cupsfilter.c:445
+#, c-format
+msgid "%s: No filter to convert from %s/%s to %s/%s."
+msgstr ""
+
+#: systemv/cupsaccept.c:195
+#, c-format
+msgid "%s: Operation failed: %s"
+msgstr ""
+
+#: berkeley/lpq.c:86 berkeley/lpr.c:74 berkeley/lprm.c:71 systemv/cancel.c:85
+#: systemv/cupsaccept.c:95 systemv/lp.c:98 systemv/lpadmin.c:249
+#: systemv/lpinfo.c:192 systemv/lpmove.c:69 systemv/lpstat.c:91
+#: tools/ipptool.c:316 tools/ipptool.c:360
+#, c-format
+msgid "%s: Sorry, no encryption support."
+msgstr ""
+
+#: systemv/lpadmin.c:1216
+#, c-format
+msgid "%s: Unable to connect to \"%s:%d\": %s"
+msgstr ""
+
+#: berkeley/lpq.c:292 scheduler/cupsfilter.c:1269 systemv/cancel.c:250
+#, c-format
+msgid "%s: Unable to connect to server."
+msgstr ""
+
+#: systemv/cancel.c:334
+#, c-format
+msgid "%s: Unable to contact server."
+msgstr ""
+
+#: systemv/lpadmin.c:1246
+#, c-format
+msgid "%s: Unable to create PPD file: %s"
+msgstr ""
+
+#: scheduler/cupsfilter.c:410
+#, c-format
+msgid "%s: Unable to determine MIME type of \"%s\"."
+msgstr ""
+
+#: tools/ipptool.c:277 tools/ipptool.c:343
+#, c-format
+msgid "%s: Unable to open \"%s\": %s"
+msgstr ""
+
+#: ppdc/ppdmerge.cxx:86
+#, c-format
+msgid "%s: Unable to open %s: %s"
+msgstr ""
+
+#: scheduler/cupsfilter.c:668 ppdc/ppdmerge.cxx:102
+#, c-format
+msgid "%s: Unable to open PPD file: %s on line %d."
+msgstr ""
+
+#: systemv/lpadmin.c:1231
+#, c-format
+msgid "%s: Unable to query printer: %s"
+msgstr ""
+
+#: scheduler/cupsfilter.c:377
+#, c-format
+msgid "%s: Unable to read MIME database from \"%s\" or \"%s\"."
+msgstr ""
+
+#: systemv/lpadmin.c:1200
+#, c-format
+msgid "%s: Unable to resolve \"%s\"."
+msgstr ""
+
+#: systemv/lpinfo.c:238
+#, c-format
+msgid "%s: Unknown argument \"%s\"."
+msgstr ""
+
+#: berkeley/lpq.c:142 systemv/lpstat.c:608
+#, c-format
+msgid "%s: Unknown destination \"%s\"."
+msgstr ""
+
+#: scheduler/cupsfilter.c:422
+#, c-format
+msgid "%s: Unknown destination MIME type %s/%s."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1473 systemv/lpinfo.c:231 systemv/lpmove.c:94
+#, c-format
+msgid "%s: Unknown option \"%c\"."
+msgstr ""
+
+#: tools/ippeveprinter.c:381 tools/ippeveprinter.c:566 tools/ippfind.c:627
+#, c-format
+msgid "%s: Unknown option \"%s\"."
+msgstr ""
+
+#: tools/ippeveprinter.c:555 tools/ippfind.c:919 tools/ipptool.c:606
+#, c-format
+msgid "%s: Unknown option \"-%c\"."
+msgstr ""
+
+#: scheduler/cupsfilter.c:402
+#, c-format
+msgid "%s: Unknown source MIME type %s/%s."
+msgstr ""
+
+#: berkeley/lpr.c:147
+#, c-format
+msgid "%s: Warning - \"%c\" format modifier not supported - output may not be correct."
+msgstr ""
+
+#: systemv/lp.c:474
+#, c-format
+msgid "%s: Warning - character set option ignored."
+msgstr ""
+
+#: systemv/lp.c:493
+#, c-format
+msgid "%s: Warning - content type option ignored."
+msgstr ""
+
+#: systemv/lp.c:182
+#, c-format
+msgid "%s: Warning - form option ignored."
+msgstr ""
+
+#: systemv/lp.c:390
+#, c-format
+msgid "%s: Warning - mode option ignored."
+msgstr ""
+
+#: tools/ippfind.c:2802
+msgid "( expressions )         Group expressions"
+msgstr ""
+
+#: berkeley/lprm.c:233
+msgid "-                       Cancel all jobs"
+msgstr ""
+
+#: berkeley/lpr.c:432
+msgid "-# num-copies           Specify the number of copies to print"
+msgstr ""
+
+#: systemv/cupsctl.c:236
+msgid "--[no-]debug-logging    Turn debug logging on/off"
+msgstr ""
+
+#: systemv/cupsctl.c:237
+msgid "--[no-]remote-admin     Turn remote administration on/off"
+msgstr ""
+
+#: systemv/cupsctl.c:238
+msgid "--[no-]remote-any       Allow/prevent access from the Internet"
+msgstr ""
+
+#: systemv/cupsctl.c:239
+msgid "--[no-]share-printers   Turn printer sharing on/off"
+msgstr ""
+
+#: systemv/cupsctl.c:240
+msgid "--[no-]user-cancel-any  Allow/prevent users to cancel any job"
+msgstr ""
+
+#: systemv/lpinfo.c:504
+msgid "--device-id device-id   Show models matching the given IEEE 1284 device ID"
+msgstr ""
+
+#: tools/ippfind.c:2785
+msgid "--domain regex          Match domain to regular expression"
+msgstr ""
+
+#: systemv/lpinfo.c:505
+msgid ""
+"--exclude-schemes scheme-list\n"
+"                        Exclude the specified URI schemes"
+msgstr ""
+
+#: tools/ippfind.c:2786
+msgid ""
+"--exec utility [argument ...] ;\n"
+"                        Execute program if true"
+msgstr ""
+
+#: tools/ippfind.c:2805
+msgid "--false                 Always false"
+msgstr ""
+
+#: tools/ippeveprinter.c:7665
+msgid "--help                  Show program help"
+msgstr ""
+
+#: systemv/cupsaccept.c:249
+msgid "--hold                  Hold new jobs"
+msgstr ""
+
+#: tools/ippfind.c:2788
+msgid "--host regex            Match hostname to regular expression"
+msgstr ""
+
+#: systemv/lpinfo.c:507
+msgid ""
+"--include-schemes scheme-list\n"
+"                        Include only the specified URI schemes"
+msgstr ""
+
+#: tools/ipptool.c:4308
+msgid "--ippserver filename    Produce ippserver attribute file"
+msgstr ""
+
+#: systemv/lpinfo.c:509
+msgid "--language locale       Show models matching the given locale"
+msgstr ""
+
+#: tools/ippfind.c:2790
+msgid "--local                 True if service is local"
+msgstr ""
+
+#: tools/ippfind.c:2789
+msgid "--ls                    List attributes"
+msgstr ""
+
+#: systemv/lpinfo.c:510
+msgid "--make-and-model name   Show models matching the given make and model name"
+msgstr ""
+
+#: tools/ippfind.c:2791
+msgid "--name regex            Match service name to regular expression"
+msgstr ""
+
+#: tools/ippeveprinter.c:7666
+msgid "--no-web-forms          Disable web forms for media and supplies"
+msgstr ""
+
+#: tools/ippfind.c:2804
+msgid "--not expression        Unary NOT of expression"
+msgstr ""
+
+#: tools/ippfind.c:2792
+msgid "--path regex            Match resource path to regular expression"
+msgstr ""
+
+#: tools/ippfind.c:2793
+msgid "--port number[-number]  Match port to number or range"
+msgstr ""
+
+#: tools/ippfind.c:2794
+msgid "--print                 Print URI if true"
+msgstr ""
+
+#: tools/ippfind.c:2795
+msgid "--print-name            Print service name if true"
+msgstr ""
+
+#: systemv/lpinfo.c:511
+msgid "--product name          Show models matching the given PostScript product"
+msgstr ""
+
+#: tools/ippfind.c:2796
+msgid "--quiet                 Quietly report match via exit code"
+msgstr ""
+
+#: systemv/cupsaccept.c:251
+msgid "--release               Release previously held jobs"
+msgstr ""
+
+#: tools/ippfind.c:2797
+msgid "--remote                True if service is remote"
+msgstr ""
+
+#: tools/ipptool.c:4309
+msgid ""
+"--stop-after-include-error\n"
+"                        Stop tests after a failed INCLUDE"
+msgstr ""
+
+#: systemv/lpinfo.c:512
+msgid "--timeout seconds       Specify the maximum number of seconds to discover devices"
+msgstr ""
+
+#: tools/ippfind.c:2806
+msgid "--true                  Always true"
+msgstr ""
+
+#: tools/ippfind.c:2798
+msgid "--txt key               True if the TXT record contains the key"
+msgstr ""
+
+#: tools/ippfind.c:2799
+msgid "--txt-* regex           Match TXT record key to regular expression"
+msgstr ""
+
+#: tools/ippfind.c:2800
+msgid "--uri regex             Match URI to regular expression"
+msgstr ""
+
+#: tools/ippeveprinter.c:7667 tools/ippfind.c:2770
+msgid "--version               Show program version"
+msgstr ""
+
+#: tools/ipptool.c:4311
+msgid "--version               Show version"
+msgstr ""
+
+#: ppdc/sample.c:305
+msgid "-1"
+msgstr ""
+
+#: ppdc/sample.c:296
+msgid "-10"
+msgstr ""
+
+#: ppdc/sample.c:388
+msgid "-100"
+msgstr ""
+
+#: ppdc/sample.c:387
+msgid "-105"
+msgstr ""
+
+#: ppdc/sample.c:295
+msgid "-11"
+msgstr ""
+
+#: ppdc/sample.c:386
+msgid "-110"
+msgstr ""
+
+#: ppdc/sample.c:385
+msgid "-115"
+msgstr ""
+
+#: ppdc/sample.c:294
+msgid "-12"
+msgstr ""
+
+#: ppdc/sample.c:384
+msgid "-120"
+msgstr ""
+
+#: ppdc/sample.c:293
+msgid "-13"
+msgstr ""
+
+#: ppdc/sample.c:292
+msgid "-14"
+msgstr ""
+
+#: ppdc/sample.c:291
+msgid "-15"
+msgstr ""
+
+#: ppdc/sample.c:304
+msgid "-2"
+msgstr ""
+
+#: tools/ippeveprinter.c:7668
+msgid "-2                      Set 2-sided printing support (default=1-sided)"
+msgstr ""
+
+#: ppdc/sample.c:404
+msgid "-20"
+msgstr ""
+
+#: ppdc/sample.c:403
+msgid "-25"
+msgstr ""
+
+#: ppdc/sample.c:303
+msgid "-3"
+msgstr ""
+
+#: ppdc/sample.c:402
+msgid "-30"
+msgstr ""
+
+#: ppdc/sample.c:401
+msgid "-35"
+msgstr ""
+
+#: ppdc/sample.c:302
+msgid "-4"
+msgstr ""
+
+#: tools/ippfind.c:2766 tools/ipptool.c:4312
+msgid "-4                      Connect using IPv4"
+msgstr ""
+
+#: ppdc/sample.c:400
+msgid "-40"
+msgstr ""
+
+#: ppdc/sample.c:399
+msgid "-45"
+msgstr ""
+
+#: ppdc/sample.c:301
+msgid "-5"
+msgstr ""
+
+#: ppdc/sample.c:398
+msgid "-50"
+msgstr ""
+
+#: ppdc/sample.c:397
+msgid "-55"
+msgstr ""
+
+#: ppdc/sample.c:300
+msgid "-6"
+msgstr ""
+
+#: tools/ippfind.c:2767 tools/ipptool.c:4313
+msgid "-6                      Connect using IPv6"
+msgstr ""
+
+#: ppdc/sample.c:396
+msgid "-60"
+msgstr ""
+
+#: ppdc/sample.c:395
+msgid "-65"
+msgstr ""
+
+#: ppdc/sample.c:299
+msgid "-7"
+msgstr ""
+
+#: ppdc/sample.c:394
+msgid "-70"
+msgstr ""
+
+#: ppdc/sample.c:393
+msgid "-75"
+msgstr ""
+
+#: ppdc/sample.c:298
+msgid "-8"
+msgstr ""
+
+#: ppdc/sample.c:392
+msgid "-80"
+msgstr ""
+
+#: ppdc/sample.c:391
+msgid "-85"
+msgstr ""
+
+#: ppdc/sample.c:297
+msgid "-9"
+msgstr ""
+
+#: ppdc/sample.c:390
+msgid "-90"
+msgstr ""
+
+#: ppdc/sample.c:389
+msgid "-95"
+msgstr ""
+
+#: tools/ipptool.c:4314
+msgid "-C                      Send requests using chunking (default)"
+msgstr ""
+
+#: systemv/lpadmin.c:1623
+msgid "-D description          Specify the textual description of the printer"
+msgstr ""
+
+#: tools/ippeveprinter.c:7669
+msgid "-D device-uri           Set the device URI for the printer"
+msgstr ""
+
+#: systemv/lpadmin.c:1625
+msgid "-E                      Enable and accept jobs on the printer (after -p)"
+msgstr ""
+
+#: berkeley/lpq.c:644 berkeley/lpr.c:433 berkeley/lprm.c:234
+#: systemv/cancel.c:403 systemv/cupsaccept.c:244 systemv/cupsctl.c:233
+#: systemv/lp.c:752 systemv/lpadmin.c:1624 systemv/lpinfo.c:498
+#: systemv/lpmove.c:217 systemv/lpoptions.c:540 systemv/lpstat.c:2045
+msgid "-E                      Encrypt the connection to the server"
+msgstr ""
+
+#: tools/ipptool.c:4315
+msgid "-E                      Test with encryption using HTTP Upgrade to TLS"
+msgstr ""
+
+#: scheduler/main.c:2136
+msgid "-F                      Run in the foreground but detach from console."
+msgstr ""
+
+#: tools/ippeveprinter.c:7670
+msgid "-F output-type/subtype  Set the output format for the printer"
+msgstr ""
+
+#: systemv/lpstat.c:2050
+msgid "-H                      Show the default server and port"
+msgstr ""
+
+#: systemv/lp.c:754
+msgid "-H HH:MM                Hold the job until the specified UTC time"
+msgstr ""
+
+#: systemv/lp.c:755
+msgid "-H hold                 Hold the job until released/resumed"
+msgstr ""
+
+#: systemv/lp.c:756
+msgid "-H immediate            Print the job as soon as possible"
+msgstr ""
+
+#: systemv/lp.c:757
+msgid "-H restart              Reprint the job"
+msgstr ""
+
+#: systemv/lp.c:758
+msgid "-H resume               Resume a held job"
+msgstr ""
+
+#: berkeley/lpr.c:434
+msgid "-H server[:port]        Connect to the named server and port"
+msgstr ""
+
+#: tools/ipptool.c:4316
+msgid "-I                      Ignore errors"
+msgstr ""
+
+#: systemv/cupstestppd.c:3858
+msgid ""
+"-I {filename,filters,none,profiles}\n"
+"                          Ignore specific warnings"
+msgstr ""
+
+#: tools/ippeveprinter.c:7672
+msgid "-K keypath              Set location of server X.509 certificates and keys."
+msgstr ""
+
+#: tools/ipptool.c:4317
+msgid "-L                      Send requests using content-length"
+msgstr ""
+
+#: systemv/lpadmin.c:1628
+msgid "-L location             Specify the textual location of the printer"
+msgstr ""
+
+#: tools/ippeveprinter.c:7674
+msgid "-M manufacturer         Set manufacturer name (default=Test)"
+msgstr ""
+
+#: berkeley/lpq.c:647
+msgid "-P destination          Show status for the specified destination"
+msgstr ""
+
+#: berkeley/lpr.c:450 berkeley/lprm.c:236
+msgid "-P destination          Specify the destination"
+msgstr ""
+
+#: tools/ipptool.c:4318
+msgid "-P filename.plist       Produce XML plist to a file and test report to standard output"
+msgstr ""
+
+#: tools/ippeveprinter.c:7675
+msgid "-P filename.ppd         Load printer attributes from PPD file"
+msgstr ""
+
+#: tools/ippfind.c:2772
+msgid "-P number[-number]      Match port to number or range"
+msgstr ""
+
+#: systemv/lp.c:774
+msgid "-P page-list            Specify a list of pages to print"
+msgstr ""
+
+#: systemv/lpstat.c:2060
+msgid "-R                      Show the ranking of jobs"
+msgstr ""
+
+#: systemv/lpadmin.c:1648
+msgid "-R name-default         Remove the default value for the named option"
+msgstr ""
+
+#: systemv/cupstestppd.c:3860
+msgid "-R root-directory       Set alternate root"
+msgstr ""
+
+#: tools/ipptool.c:4319
+msgid "-S                      Test with encryption using HTTPS"
+msgstr ""
+
+#: tools/ippfind.c:2768
+msgid "-T seconds              Set the browse timeout in seconds"
+msgstr ""
+
+#: tools/ipptool.c:4320
+msgid "-T seconds              Set the receive/send timeout in seconds"
+msgstr ""
+
+#: berkeley/lpr.c:451
+msgid "-T title                Specify the job title"
+msgstr ""
+
+#: berkeley/lpq.c:648 berkeley/lpr.c:452 berkeley/lprm.c:237
+#: systemv/cancel.c:406 systemv/cupsaccept.c:247 systemv/lp.c:778
+#: systemv/lpadmin.c:1652 systemv/lpinfo.c:502 systemv/lpmove.c:219
+#: systemv/lpoptions.c:545 systemv/lpstat.c:2048
+msgid "-U username             Specify the username to use for authentication"
+msgstr ""
+
+#: systemv/cupsctl.c:235
+msgid "-U username             Specify username to use for authentication"
+msgstr ""
+
+#: tools/ippeveprinter.c:7676 tools/ippfind.c:2769 tools/ipptool.c:4321
+msgid "-V version              Set default IPP version"
+msgstr ""
+
+#: systemv/lpstat.c:2051
+msgid "-W completed            Show completed jobs"
+msgstr ""
+
+#: systemv/lpstat.c:2052
+msgid "-W not-completed        Show pending jobs"
+msgstr ""
+
+#: systemv/cupstestppd.c:3861
+msgid ""
+"-W {all,none,constraints,defaults,duplex,filters,profiles,sizes,translations}\n"
+"                          Issue warnings instead of errors"
+msgstr ""
+
+#: tools/ipptool.c:4322
+msgid "-X                      Produce XML plist instead of plain text"
+msgstr ""
+
+#: systemv/cancel.c:402
+msgid "-a                      Cancel all jobs"
+msgstr ""
+
+#: berkeley/lpq.c:643
+msgid "-a                      Show jobs on all destinations"
+msgstr ""
+
+#: systemv/lpstat.c:2053
+msgid "-a [destination(s)]     Show the accepting state of destinations"
+msgstr ""
+
+#: tools/ippeveprinter.c:7677
+msgid "-a filename.conf        Load printer attributes from conf file"
+msgstr ""
+
+#: systemv/lp.c:751
+msgid "-c                      Make a copy of the print file(s)"
+msgstr ""
+
+#: tools/ipptool.c:4323
+msgid "-c                      Produce CSV output"
+msgstr ""
+
+#: systemv/lpstat.c:2054
+msgid "-c [class(es)]          Show classes and their member printers"
+msgstr ""
+
+#: systemv/lpadmin.c:1621
+msgid "-c class                Add the named destination to a class"
+msgstr ""
+
+#: tools/ippeveprinter.c:7678
+msgid "-c command              Set print command"
+msgstr ""
+
+#: scheduler/main.c:2134
+msgid "-c cupsd.conf           Set cupsd.conf file to use."
+msgstr ""
+
+#: systemv/lpstat.c:2055
+msgid "-d                      Show the default destination"
+msgstr ""
+
+#: systemv/lpoptions.c:539
+msgid "-d destination          Set default destination"
+msgstr ""
+
+#: systemv/lpadmin.c:1622
+msgid "-d destination          Set the named destination as the server default"
+msgstr ""
+
+#: tools/ipptool.c:4324
+msgid "-d name=value           Set named variable to value"
+msgstr ""
+
+#: tools/ippfind.c:2773
+msgid "-d regex                Match domain to regular expression"
+msgstr ""
+
+#: tools/ippeveprinter.c:7679
+msgid "-d spool-directory      Set spool directory"
+msgstr ""
+
+#: systemv/lpstat.c:2056
+msgid "-e                      Show available destinations on the network"
+msgstr ""
+
+#: scheduler/main.c:2135
+msgid "-f                      Run in the foreground."
+msgstr ""
+
+#: tools/ipptool.c:4325
+msgid "-f filename             Set default request filename"
+msgstr ""
+
+#: tools/ippeveprinter.c:7680
+msgid "-f type/subtype[,...]   Set supported file types"
+msgstr ""
+
+#: scheduler/main.c:2137
+msgid "-h                      Show this usage message."
+msgstr ""
+
+#: tools/ipptool.c:4326
+msgid "-h                      Validate HTTP response headers"
+msgstr ""
+
+#: tools/ippfind.c:2774
+msgid "-h regex                Match hostname to regular expression"
+msgstr ""
+
+#: berkeley/lpq.c:645 berkeley/lprm.c:235 systemv/cancel.c:404
+#: systemv/cupsaccept.c:245 systemv/cupsctl.c:234 systemv/lp.c:753
+#: systemv/lpadmin.c:1626 systemv/lpinfo.c:499 systemv/lpmove.c:218
+#: systemv/lpoptions.c:541 systemv/lpstat.c:2046
+msgid "-h server[:port]        Connect to the named server and port"
+msgstr ""
+
+#: tools/ippeveprinter.c:7681
+msgid "-i iconfile.png         Set icon file"
+msgstr ""
+
+#: systemv/lp.c:759
+msgid "-i id                   Specify an existing job ID to modify"
+msgstr ""
+
+#: systemv/lpadmin.c:1627
+msgid "-i ppd-file             Specify a PPD file for the printer"
+msgstr ""
+
+#: tools/ipptool.c:4327
+msgid "-i seconds              Repeat the last file with the given time interval"
+msgstr ""
+
+#: tools/ippeveprinter.c:7682
+msgid "-k                      Keep job spool files"
+msgstr ""
+
+#: tools/ippfind.c:2775
+msgid "-l                      List attributes"
+msgstr ""
+
+#: tools/ipptool.c:4328
+msgid "-l                      Produce plain text output"
+msgstr ""
+
+#: scheduler/main.c:2139
+msgid "-l                      Run cupsd on demand."
+msgstr ""
+
+#: systemv/lpoptions.c:542
+msgid "-l                      Show supported options and values"
+msgstr ""
+
+#: berkeley/lpq.c:646 systemv/lpinfo.c:500 systemv/lpstat.c:2047
+msgid "-l                      Show verbose (long) output"
+msgstr ""
+
+#: tools/ippeveprinter.c:7683
+msgid "-l location             Set location of printer"
+msgstr ""
+
+#: berkeley/lpr.c:435 systemv/lp.c:760
+msgid "-m                      Send an email notification when the job completes"
+msgstr ""
+
+#: systemv/lpinfo.c:501
+msgid "-m                      Show models"
+msgstr ""
+
+#: systemv/lpadmin.c:1630
+msgid "-m everywhere           Specify the printer is compatible with IPP Everywhere"
+msgstr ""
+
+#: tools/ippeveprinter.c:7684
+msgid "-m model                Set model name (default=Printer)"
+msgstr ""
+
+#: systemv/lpadmin.c:1629
+msgid "-m model                Specify a standard model/PPD file for the printer"
+msgstr ""
+
+#: tools/ipptool.c:4329
+msgid "-n count                Repeat the last file the given number of times"
+msgstr ""
+
+#: tools/ippeveprinter.c:7685
+msgid "-n hostname             Set hostname for printer"
+msgstr ""
+
+#: systemv/lp.c:761
+msgid "-n num-copies           Specify the number of copies to print"
+msgstr ""
+
+#: tools/ippfind.c:2776
+msgid "-n regex                Match service name to regular expression"
+msgstr ""
+
+#: systemv/lpadmin.c:1632
+msgid "-o Name=Value           Specify the default value for the named PPD option "
+msgstr ""
+
+#: systemv/lpstat.c:2057
+msgid "-o [destination(s)]     Show jobs"
+msgstr ""
+
+#: systemv/lpadmin.c:1633
+msgid ""
+"-o cupsIPPSupplies=false\n"
+"                        Disable supply level reporting via IPP"
+msgstr ""
+
+#: systemv/lpadmin.c:1635
+msgid ""
+"-o cupsSNMPSupplies=false\n"
+"                        Disable supply level reporting via SNMP"
+msgstr ""
+
+#: systemv/lpadmin.c:1637
+msgid "-o job-k-limit=N        Specify the kilobyte limit for per-user quotas"
+msgstr ""
+
+#: systemv/lpadmin.c:1638
+msgid "-o job-page-limit=N     Specify the page limit for per-user quotas"
+msgstr ""
+
+#: systemv/lpadmin.c:1639
+msgid "-o job-quota-period=N   Specify the per-user quota period in seconds"
+msgstr ""
+
+#: berkeley/lpr.c:437 systemv/lp.c:763
+msgid "-o job-sheets=standard  Print a banner page with the job"
+msgstr ""
+
+#: berkeley/lpr.c:438 systemv/lp.c:764
+msgid "-o media=size           Specify the media size to use"
+msgstr ""
+
+#: systemv/lpadmin.c:1631
+msgid "-o name-default=value   Specify the default value for the named option"
+msgstr ""
+
+#: systemv/lpoptions.c:543
+msgid "-o name[=value]         Set default option and value"
+msgstr ""
+
+#: berkeley/lpr.c:439 systemv/lp.c:765
+msgid "-o number-up=N          Specify that input pages should be printed N-up (1, 2, 4, 6, 9, and 16 are supported)"
+msgstr ""
+
+#: berkeley/lpr.c:436 systemv/lp.c:762
+msgid "-o option[=value]       Specify a printer-specific option"
+msgstr ""
+
+#: berkeley/lpr.c:440 systemv/lp.c:766
+msgid ""
+"-o orientation-requested=N\n"
+"                        Specify portrait (3) or landscape (4) orientation"
+msgstr ""
+
+#: berkeley/lpr.c:442 systemv/lp.c:768
+msgid "-o print-quality=N      Specify the print quality - draft (3), normal (4), or best (5)"
+msgstr ""
+
+#: systemv/lpadmin.c:1640
+msgid ""
+"-o printer-error-policy=name\n"
+"                        Specify the printer error policy"
+msgstr ""
+
+#: systemv/lpadmin.c:1642
+msgid ""
+"-o printer-is-shared=true\n"
+"                        Share the printer"
+msgstr ""
+
+#: systemv/lpadmin.c:1644
+msgid ""
+"-o printer-op-policy=name\n"
+"                        Specify the printer operation policy"
+msgstr ""
+
+#: berkeley/lpr.c:443 systemv/lp.c:769
+msgid "-o sides=one-sided      Specify 1-sided printing"
+msgstr ""
+
+#: berkeley/lpr.c:444 systemv/lp.c:770
+msgid ""
+"-o sides=two-sided-long-edge\n"
+"                        Specify 2-sided portrait printing"
+msgstr ""
+
+#: berkeley/lpr.c:446 systemv/lp.c:772
+msgid ""
+"-o sides=two-sided-short-edge\n"
+"                        Specify 2-sided landscape printing"
+msgstr ""
+
+#: tools/ippfind.c:2777
+msgid "-p                      Print URI if true"
+msgstr ""
+
+#: systemv/lpstat.c:2058
+msgid "-p [printer(s)]         Show the processing state of destinations"
+msgstr ""
+
+#: systemv/lpoptions.c:544
+msgid "-p destination          Specify a destination"
+msgstr ""
+
+#: systemv/lpadmin.c:1646
+msgid "-p destination          Specify/add the named destination"
+msgstr ""
+
+#: tools/ippeveprinter.c:7686
+msgid "-p port                 Set port number for printer"
+msgstr ""
+
+#: tools/ippfind.c:2778
+msgid "-q                      Quietly report match via exit code"
+msgstr ""
+
+#: systemv/cupstestppd.c:3863 tools/ipptool.c:4330
+msgid "-q                      Run silently"
+msgstr ""
+
+#: berkeley/lpr.c:448
+msgid "-q                      Specify the job should be held for printing"
+msgstr ""
+
+#: systemv/lp.c:775
+msgid "-q priority             Specify the priority from low (1) to high (100)"
+msgstr ""
+
+#: berkeley/lpr.c:449
+msgid "-r                      Remove the file(s) after submission"
+msgstr ""
+
+#: systemv/lpstat.c:2059
+msgid "-r                      Show whether the CUPS server is running"
+msgstr ""
+
+#: tools/ippfind.c:2779
+msgid "-r                      True if service is remote"
+msgstr ""
+
+#: systemv/cupstestppd.c:3864
+msgid "-r                      Use 'relaxed' open mode"
+msgstr ""
+
+#: systemv/lpadmin.c:1647
+msgid "-r class                Remove the named destination from a class"
+msgstr ""
+
+#: systemv/cupsaccept.c:246
+msgid "-r reason               Specify a reason message that others can see"
+msgstr ""
+
+#: tools/ippeveprinter.c:7687
+msgid "-r subtype,[subtype]    Set DNS-SD service subtype"
+msgstr ""
+
+#: systemv/lp.c:776
+msgid "-s                      Be silent"
+msgstr ""
+
+#: tools/ippfind.c:2780
+msgid "-s                      Print service name if true"
+msgstr ""
+
+#: systemv/lpstat.c:2061
+msgid "-s                      Show a status summary"
+msgstr ""
+
+#: scheduler/main.c:2141
+msgid "-s cups-files.conf      Set cups-files.conf file to use."
+msgstr ""
+
+#: tools/ippeveprinter.c:7688
+msgid "-s speed[,color-speed]  Set speed in pages per minute"
+msgstr ""
+
+#: tools/ipptool.c:4331
+msgid "-t                      Produce a test report"
+msgstr ""
+
+#: systemv/lpstat.c:2062
+msgid "-t                      Show all status information"
+msgstr ""
+
+#: scheduler/main.c:2142
+msgid "-t                      Test the configuration file."
+msgstr ""
+
+#: tools/ippfind.c:2781
+msgid "-t key                  True if the TXT record contains the key"
+msgstr ""
+
+#: systemv/lp.c:777
+msgid "-t title                Specify the job title"
+msgstr ""
+
+#: systemv/lpstat.c:2063
+msgid "-u [user(s)]            Show jobs queued by the current or specified users"
+msgstr ""
+
+#: systemv/lpadmin.c:1649
+msgid "-u allow:all            Allow all users to print"
+msgstr ""
+
+#: systemv/lpadmin.c:1650
+msgid "-u allow:list           Allow the list of users or groups (@name) to print"
+msgstr ""
+
+#: systemv/lpadmin.c:1651
+msgid "-u deny:list            Prevent the list of users or groups (@name) to print"
+msgstr ""
+
+#: systemv/cancel.c:405
+msgid "-u owner                Specify the owner to use for jobs"
+msgstr ""
+
+#: tools/ippfind.c:2782
+msgid "-u regex                Match URI to regular expression"
+msgstr ""
+
+#: systemv/cupstestppd.c:3865 tools/ippeveprinter.c:7689 tools/ipptool.c:4332
+msgid "-v                      Be verbose"
+msgstr ""
+
+#: systemv/lpinfo.c:503
+msgid "-v                      Show devices"
+msgstr ""
+
+#: systemv/lpstat.c:2064
+msgid "-v [printer(s)]         Show the devices for each destination"
+msgstr ""
+
+#: systemv/lpadmin.c:1653
+msgid "-v device-uri           Specify the device URI for the printer"
+msgstr ""
+
+#: systemv/cupstestppd.c:3866
+msgid "-vv                     Be very verbose"
+msgstr ""
+
+#: systemv/cancel.c:407
+msgid "-x                      Purge jobs rather than just canceling"
+msgstr ""
+
+#: systemv/lpoptions.c:546
+msgid "-x destination          Remove default options for destination"
+msgstr ""
+
+#: systemv/lpadmin.c:1654
+msgid "-x destination          Remove the named destination"
+msgstr ""
+
+#: tools/ippfind.c:2783
+msgid ""
+"-x utility [argument ...] ;\n"
+"                        Execute program if true"
+msgstr ""
+
+#: cups/dest.c:1868
+msgid "/etc/cups/lpoptions file names default destination that does not exist."
+msgstr ""
+
+#: ppdc/sample.c:306
+msgid "0"
+msgstr ""
+
+#: ppdc/sample.c:307
+msgid "1"
+msgstr ""
+
+#: ppdc/sample.c:379
+msgid "1 inch/sec."
+msgstr ""
+
+#: ppdc/sample.c:172
+msgid "1.25x0.25\""
+msgstr ""
+
+#: ppdc/sample.c:173
+msgid "1.25x2.25\""
+msgstr ""
+
+#: ppdc/sample.c:427
+msgid "1.5 inch/sec."
+msgstr ""
+
+#: ppdc/sample.c:174
+msgid "1.50x0.25\""
+msgstr ""
+
+#: ppdc/sample.c:175
+msgid "1.50x0.50\""
+msgstr ""
+
+#: ppdc/sample.c:176
+msgid "1.50x1.00\""
+msgstr ""
+
+#: ppdc/sample.c:177
+msgid "1.50x2.00\""
+msgstr ""
+
+#: ppdc/sample.c:316
+msgid "10"
+msgstr ""
+
+#: ppdc/sample.c:438
+msgid "10 inches/sec."
+msgstr ""
+
+#: ppdc/sample.c:6
+msgid "10 x 11"
+msgstr ""
+
+#: ppdc/sample.c:7
+msgid "10 x 13"
+msgstr ""
+
+#: ppdc/sample.c:8
+msgid "10 x 14"
+msgstr ""
+
+#: ppdc/sample.c:418
+msgid "100"
+msgstr ""
+
+#: ppdc/sample.c:329
+msgid "100 mm/sec."
+msgstr ""
+
+#: ppdc/sample.c:419
+msgid "105"
+msgstr ""
+
+#: ppdc/sample.c:317
+msgid "11"
+msgstr ""
+
+#: ppdc/sample.c:439
+msgid "11 inches/sec."
+msgstr ""
+
+#: ppdc/sample.c:420
+msgid "110"
+msgstr ""
+
+#: ppdc/sample.c:421
+msgid "115"
+msgstr ""
+
+#: ppdc/sample.c:318
+msgid "12"
+msgstr ""
+
+#: ppdc/sample.c:440
+msgid "12 inches/sec."
+msgstr ""
+
+#: ppdc/sample.c:9
+msgid "12 x 11"
+msgstr ""
+
+#: ppdc/sample.c:422
+msgid "120"
+msgstr ""
+
+#: ppdc/sample.c:330
+msgid "120 mm/sec."
+msgstr ""
+
+#: ppdc/sample.c:243
+msgid "120x60dpi"
+msgstr ""
+
+#: ppdc/sample.c:249
+msgid "120x72dpi"
+msgstr ""
+
+#: ppdc/sample.c:319
+msgid "13"
+msgstr ""
+
+#: ppdc/sample.c:232
+msgid "136dpi"
+msgstr ""
+
+#: ppdc/sample.c:320
+msgid "14"
+msgstr ""
+
+#: ppdc/sample.c:321
+msgid "15"
+msgstr ""
+
+#: ppdc/sample.c:323
+msgid "15 mm/sec."
+msgstr ""
+
+#: ppdc/sample.c:10
+msgid "15 x 11"
+msgstr ""
+
+#: ppdc/sample.c:331
+msgid "150 mm/sec."
+msgstr ""
+
+#: ppdc/sample.c:278
+msgid "150dpi"
+msgstr ""
+
+#: ppdc/sample.c:363
+msgid "16"
+msgstr ""
+
+#: ppdc/sample.c:364
+msgid "17"
+msgstr ""
+
+#: ppdc/sample.c:365
+msgid "18"
+msgstr ""
+
+#: ppdc/sample.c:244
+msgid "180dpi"
+msgstr ""
+
+#: ppdc/sample.c:366
+msgid "19"
+msgstr ""
+
+#: ppdc/sample.c:308
+msgid "2"
+msgstr ""
+
+#: ppdc/sample.c:380
+msgid "2 inches/sec."
+msgstr ""
+
+#: cups/ppd-cache.c:3872 ppdc/sample.c:262
+msgid "2-Sided Printing"
+msgstr ""
+
+#: ppdc/sample.c:178
+msgid "2.00x0.37\""
+msgstr ""
+
+#: ppdc/sample.c:179
+msgid "2.00x0.50\""
+msgstr ""
+
+#: ppdc/sample.c:180
+msgid "2.00x1.00\""
+msgstr ""
+
+#: ppdc/sample.c:181
+msgid "2.00x1.25\""
+msgstr ""
+
+#: ppdc/sample.c:182
+msgid "2.00x2.00\""
+msgstr ""
+
+#: ppdc/sample.c:183
+msgid "2.00x3.00\""
+msgstr ""
+
+#: ppdc/sample.c:184
+msgid "2.00x4.00\""
+msgstr ""
+
+#: ppdc/sample.c:185
+msgid "2.00x5.50\""
+msgstr ""
+
+#: ppdc/sample.c:186
+msgid "2.25x0.50\""
+msgstr ""
+
+#: ppdc/sample.c:187
+msgid "2.25x1.25\""
+msgstr ""
+
+#: ppdc/sample.c:188
+msgid "2.25x4.00\""
+msgstr ""
+
+#: ppdc/sample.c:189
+msgid "2.25x5.50\""
+msgstr ""
+
+#: ppdc/sample.c:190
+msgid "2.38x5.50\""
+msgstr ""
+
+#: ppdc/sample.c:428
+msgid "2.5 inches/sec."
+msgstr ""
+
+#: ppdc/sample.c:191
+msgid "2.50x1.00\""
+msgstr ""
+
+#: ppdc/sample.c:192
+msgid "2.50x2.00\""
+msgstr ""
+
+#: ppdc/sample.c:193
+msgid "2.75x1.25\""
+msgstr ""
+
+#: ppdc/sample.c:194
+msgid "2.9 x 1\""
+msgstr ""
+
+#: ppdc/sample.c:367
+msgid "20"
+msgstr ""
+
+#: ppdc/sample.c:324
+msgid "20 mm/sec."
+msgstr ""
+
+#: ppdc/sample.c:332
+msgid "200 mm/sec."
+msgstr ""
+
+#: ppdc/sample.c:233
+msgid "203dpi"
+msgstr ""
+
+#: ppdc/sample.c:368
+msgid "21"
+msgstr ""
+
+#: ppdc/sample.c:369
+msgid "22"
+msgstr ""
+
+#: ppdc/sample.c:370
+msgid "23"
+msgstr ""
+
+#: ppdc/sample.c:371
+msgid "24"
+msgstr ""
+
+#: ppdc/sample.c:241
+msgid "24-Pin Series"
+msgstr ""
+
+#: ppdc/sample.c:250
+msgid "240x72dpi"
+msgstr ""
+
+#: ppdc/sample.c:372
+msgid "25"
+msgstr ""
+
+#: ppdc/sample.c:333
+msgid "250 mm/sec."
+msgstr ""
+
+#: ppdc/sample.c:373
+msgid "26"
+msgstr ""
+
+#: ppdc/sample.c:374
+msgid "27"
+msgstr ""
+
+#: ppdc/sample.c:375
+msgid "28"
+msgstr ""
+
+#: ppdc/sample.c:376
+msgid "29"
+msgstr ""
+
+#: ppdc/sample.c:309
+msgid "3"
+msgstr ""
+
+#: ppdc/sample.c:381
+msgid "3 inches/sec."
+msgstr ""
+
+#: ppdc/sample.c:3
+msgid "3 x 5"
+msgstr ""
+
+#: ppdc/sample.c:195
+msgid "3.00x1.00\""
+msgstr ""
+
+#: ppdc/sample.c:196
+msgid "3.00x1.25\""
+msgstr ""
+
+#: ppdc/sample.c:197
+msgid "3.00x2.00\""
+msgstr ""
+
+#: ppdc/sample.c:198
+msgid "3.00x3.00\""
+msgstr ""
+
+#: ppdc/sample.c:199
+msgid "3.00x5.00\""
+msgstr ""
+
+#: ppdc/sample.c:200
+msgid "3.25x2.00\""
+msgstr ""
+
+#: ppdc/sample.c:201
+msgid "3.25x5.00\""
+msgstr ""
+
+#: ppdc/sample.c:202
+msgid "3.25x5.50\""
+msgstr ""
+
+#: ppdc/sample.c:203
+msgid "3.25x5.83\""
+msgstr ""
+
+#: ppdc/sample.c:204
+msgid "3.25x7.83\""
+msgstr ""
+
+#: ppdc/sample.c:4
+msgid "3.5 x 5"
+msgstr ""
+
+#: ppdc/sample.c:171
+msgid "3.5\" Disk"
+msgstr ""
+
+#: ppdc/sample.c:205
+msgid "3.50x1.00\""
+msgstr ""
+
+#: ppdc/sample.c:377
+msgid "30"
+msgstr ""
+
+#: ppdc/sample.c:325
+msgid "30 mm/sec."
+msgstr ""
+
+#: ppdc/sample.c:334
+msgid "300 mm/sec."
+msgstr ""
+
+#: ppdc/sample.c:234
+msgid "300dpi"
+msgstr ""
+
+#: ppdc/sample.c:405
+msgid "35"
+msgstr ""
+
+#: ppdc/sample.c:246
+msgid "360dpi"
+msgstr ""
+
+#: ppdc/sample.c:245
+msgid "360x180dpi"
+msgstr ""
+
+#: ppdc/sample.c:310
+msgid "4"
+msgstr ""
+
+#: ppdc/sample.c:382
+msgid "4 inches/sec."
+msgstr ""
+
+#: ppdc/sample.c:206
+msgid "4.00x1.00\""
+msgstr ""
+
+#: ppdc/sample.c:214
+msgid "4.00x13.00\""
+msgstr ""
+
+#: ppdc/sample.c:207
+msgid "4.00x2.00\""
+msgstr ""
+
+#: ppdc/sample.c:208
+msgid "4.00x2.50\""
+msgstr ""
+
+#: ppdc/sample.c:209
+msgid "4.00x3.00\""
+msgstr ""
+
+#: ppdc/sample.c:210
+msgid "4.00x4.00\""
+msgstr ""
+
+#: ppdc/sample.c:211
+msgid "4.00x5.00\""
+msgstr ""
+
+#: ppdc/sample.c:212
+msgid "4.00x6.00\""
+msgstr ""
+
+#: ppdc/sample.c:213
+msgid "4.00x6.50\""
+msgstr ""
+
+#: ppdc/sample.c:406
+msgid "40"
+msgstr ""
+
+#: ppdc/sample.c:326
+msgid "40 mm/sec."
+msgstr ""
+
+#: ppdc/sample.c:407
+msgid "45"
+msgstr ""
+
+#: ppdc/sample.c:311
+msgid "5"
+msgstr ""
+
+#: ppdc/sample.c:432
+msgid "5 inches/sec."
+msgstr ""
+
+#: ppdc/sample.c:5
+msgid "5 x 7"
+msgstr ""
+
+#: ppdc/sample.c:408
+msgid "50"
+msgstr ""
+
+#: ppdc/sample.c:409
+msgid "55"
+msgstr ""
+
+#: ppdc/sample.c:312
+msgid "6"
+msgstr ""
+
+#: ppdc/sample.c:433
+msgid "6 inches/sec."
+msgstr ""
+
+#: ppdc/sample.c:215
+msgid "6.00x1.00\""
+msgstr ""
+
+#: ppdc/sample.c:216
+msgid "6.00x2.00\""
+msgstr ""
+
+#: ppdc/sample.c:217
+msgid "6.00x3.00\""
+msgstr ""
+
+#: ppdc/sample.c:218
+msgid "6.00x4.00\""
+msgstr ""
+
+#: ppdc/sample.c:219
+msgid "6.00x5.00\""
+msgstr ""
+
+#: ppdc/sample.c:220
+msgid "6.00x6.00\""
+msgstr ""
+
+#: ppdc/sample.c:221
+msgid "6.00x6.50\""
+msgstr ""
+
+#: ppdc/sample.c:410
+msgid "60"
+msgstr ""
+
+#: ppdc/sample.c:327
+msgid "60 mm/sec."
+msgstr ""
+
+#: ppdc/sample.c:253
+msgid "600dpi"
+msgstr ""
+
+#: ppdc/sample.c:242
+msgid "60dpi"
+msgstr ""
+
+#: ppdc/sample.c:248
+msgid "60x72dpi"
+msgstr ""
+
+#: ppdc/sample.c:411
+msgid "65"
+msgstr ""
+
+#: ppdc/sample.c:313
+msgid "7"
+msgstr ""
+
+#: ppdc/sample.c:435
+msgid "7 inches/sec."
+msgstr ""
+
+#: ppdc/sample.c:11
+msgid "7 x 9"
+msgstr ""
+
+#: ppdc/sample.c:412
+msgid "70"
+msgstr ""
+
+#: ppdc/sample.c:413
+msgid "75"
+msgstr ""
+
+#: ppdc/sample.c:314
+msgid "8"
+msgstr ""
+
+#: ppdc/sample.c:436
+msgid "8 inches/sec."
+msgstr ""
+
+#: ppdc/sample.c:12
+msgid "8 x 10"
+msgstr ""
+
+#: ppdc/sample.c:222
+msgid "8.00x1.00\""
+msgstr ""
+
+#: ppdc/sample.c:223
+msgid "8.00x2.00\""
+msgstr ""
+
+#: ppdc/sample.c:224
+msgid "8.00x3.00\""
+msgstr ""
+
+#: ppdc/sample.c:225
+msgid "8.00x4.00\""
+msgstr ""
+
+#: ppdc/sample.c:226
+msgid "8.00x5.00\""
+msgstr ""
+
+#: ppdc/sample.c:227
+msgid "8.00x6.00\""
+msgstr ""
+
+#: ppdc/sample.c:228
+msgid "8.00x6.50\""
+msgstr ""
+
+#: ppdc/sample.c:414
+msgid "80"
+msgstr ""
+
+#: ppdc/sample.c:328
+msgid "80 mm/sec."
+msgstr ""
+
+#: ppdc/sample.c:415
+msgid "85"
+msgstr ""
+
+#: ppdc/sample.c:315
+msgid "9"
+msgstr ""
+
+#: ppdc/sample.c:437
+msgid "9 inches/sec."
+msgstr ""
+
+#: ppdc/sample.c:13
+msgid "9 x 11"
+msgstr ""
+
+#: ppdc/sample.c:14
+msgid "9 x 12"
+msgstr ""
+
+#: ppdc/sample.c:247
+msgid "9-Pin Series"
+msgstr ""
+
+#: ppdc/sample.c:416
+msgid "90"
+msgstr ""
+
+#: ppdc/sample.c:417
+msgid "95"
+msgstr ""
+
+#: berkeley/lpc.c:199
+msgid "?Invalid help command unknown."
+msgstr ""
+
+#: scheduler/ipp.c:2283
+#, c-format
+msgid "A class named \"%s\" already exists."
+msgstr ""
+
+#: scheduler/ipp.c:890
+#, c-format
+msgid "A printer named \"%s\" already exists."
+msgstr ""
+
+#: ppdc/sample.c:15
+msgid "A0"
+msgstr ""
+
+#: ppdc/sample.c:16
+msgid "A0 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:17
+msgid "A1"
+msgstr ""
+
+#: ppdc/sample.c:18
+msgid "A1 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:37
+msgid "A10"
+msgstr ""
+
+#: ppdc/sample.c:19
+msgid "A2"
+msgstr ""
+
+#: ppdc/sample.c:20
+msgid "A2 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:21
+msgid "A3"
+msgstr ""
+
+#: ppdc/sample.c:22
+msgid "A3 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:23
+msgid "A3 Oversize"
+msgstr ""
+
+#: ppdc/sample.c:24
+msgid "A3 Oversize Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:25
+msgid "A4"
+msgstr ""
+
+#: ppdc/sample.c:27
+msgid "A4 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:26
+msgid "A4 Oversize"
+msgstr ""
+
+#: ppdc/sample.c:28
+msgid "A4 Small"
+msgstr ""
+
+#: ppdc/sample.c:29
+msgid "A5"
+msgstr ""
+
+#: ppdc/sample.c:31
+msgid "A5 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:30
+msgid "A5 Oversize"
+msgstr ""
+
+#: ppdc/sample.c:32
+msgid "A6"
+msgstr ""
+
+#: ppdc/sample.c:33
+msgid "A6 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:34
+msgid "A7"
+msgstr ""
+
+#: ppdc/sample.c:35
+msgid "A8"
+msgstr ""
+
+#: ppdc/sample.c:36
+msgid "A9"
+msgstr ""
+
+#: ppdc/sample.c:38
+msgid "ANSI A"
+msgstr ""
+
+#: ppdc/sample.c:39
+msgid "ANSI B"
+msgstr ""
+
+#: ppdc/sample.c:40
+msgid "ANSI C"
+msgstr ""
+
+#: ppdc/sample.c:41
+msgid "ANSI D"
+msgstr ""
+
+#: ppdc/sample.c:42
+msgid "ANSI E"
+msgstr ""
+
+#: ppdc/sample.c:47
+msgid "ARCH C"
+msgstr ""
+
+#: ppdc/sample.c:48
+msgid "ARCH C Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:49
+msgid "ARCH D"
+msgstr ""
+
+#: ppdc/sample.c:50
+msgid "ARCH D Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:51
+msgid "ARCH E"
+msgstr ""
+
+#: ppdc/sample.c:52
+msgid "ARCH E Long Edge"
+msgstr ""
+
+#: cgi-bin/classes.c:155 cgi-bin/printers.c:158
+msgid "Accept Jobs"
+msgstr ""
+
+#: cups/http-support.c:1494
+msgid "Accepted"
+msgstr ""
+
+#: cgi-bin/admin.c:336
+msgid "Add Class"
+msgstr ""
+
+#: cgi-bin/admin.c:649
+msgid "Add Printer"
+msgstr ""
+
+#: ppdc/sample.c:163
+msgid "Address"
+msgstr ""
+
+#: cgi-bin/admin.c:172 cgi-bin/admin.c:246 cgi-bin/admin.c:2249
+msgid "Administration"
+msgstr ""
+
+#: ppdc/sample.c:424
+msgid "Always"
+msgstr ""
+
+#: backend/socket.c:113
+msgid "AppSocket/HP JetDirect"
+msgstr ""
+
+#: ppdc/sample.c:445
+msgid "Applicator"
+msgstr ""
+
+#: scheduler/ipp.c:987
+#, c-format
+msgid "Attempt to set %s printer-state to bad value %d."
+msgstr ""
+
+#: scheduler/ipp.c:5422 scheduler/ipp.c:5448
+#, c-format
+msgid "Attribute \"%s\" is in the wrong group."
+msgstr ""
+
+#: scheduler/ipp.c:5424 scheduler/ipp.c:5450
+#, c-format
+msgid "Attribute \"%s\" is the wrong value type."
+msgstr ""
+
+#: scheduler/ipp.c:227
+#, c-format
+msgid "Attribute groups are out of order (%x < %x)."
+msgstr ""
+
+#: ppdc/sample.c:126
+msgid "B0"
+msgstr ""
+
+#: ppdc/sample.c:127
+msgid "B1"
+msgstr ""
+
+#: ppdc/sample.c:137
+msgid "B10"
+msgstr ""
+
+#: ppdc/sample.c:128
+msgid "B2"
+msgstr ""
+
+#: ppdc/sample.c:129
+msgid "B3"
+msgstr ""
+
+#: ppdc/sample.c:130
+msgid "B4"
+msgstr ""
+
+#: ppdc/sample.c:131
+msgid "B5"
+msgstr ""
+
+#: ppdc/sample.c:132
+msgid "B5 Oversize"
+msgstr ""
+
+#: ppdc/sample.c:133
+msgid "B6"
+msgstr ""
+
+#: ppdc/sample.c:134
+msgid "B7"
+msgstr ""
+
+#: ppdc/sample.c:135
+msgid "B8"
+msgstr ""
+
+#: ppdc/sample.c:136
+msgid "B9"
+msgstr ""
+
+#: scheduler/ipp.c:7504
+#, c-format
+msgid "Bad \"printer-id\" value %d."
+msgstr ""
+
+#: scheduler/ipp.c:10336
+#, c-format
+msgid "Bad '%s' value."
+msgstr ""
+
+#: scheduler/ipp.c:11284
+#, c-format
+msgid "Bad 'document-format' value \"%s\"."
+msgstr ""
+
+#: cups/ppd.c:307
+msgid "Bad CloseUI/JCLCloseUI"
+msgstr ""
+
+#: cups/dest.c:1661
+msgid "Bad NULL dests pointer"
+msgstr ""
+
+#: cups/ppd.c:290
+msgid "Bad OpenGroup"
+msgstr ""
+
+#: cups/ppd.c:292
+msgid "Bad OpenUI/JCLOpenUI"
+msgstr ""
+
+#: cups/ppd.c:294
+msgid "Bad OrderDependency"
+msgstr ""
+
+#: cups/ppd-cache.c:483 cups/ppd-cache.c:530 cups/ppd-cache.c:564
+#: cups/ppd-cache.c:570 cups/ppd-cache.c:586 cups/ppd-cache.c:602
+#: cups/ppd-cache.c:611 cups/ppd-cache.c:619 cups/ppd-cache.c:636
+#: cups/ppd-cache.c:644 cups/ppd-cache.c:659 cups/ppd-cache.c:667
+#: cups/ppd-cache.c:688 cups/ppd-cache.c:700 cups/ppd-cache.c:715
+#: cups/ppd-cache.c:727 cups/ppd-cache.c:749 cups/ppd-cache.c:757
+#: cups/ppd-cache.c:775 cups/ppd-cache.c:783 cups/ppd-cache.c:798
+#: cups/ppd-cache.c:806 cups/ppd-cache.c:824 cups/ppd-cache.c:832
+#: cups/ppd-cache.c:859 cups/ppd-cache.c:934 cups/ppd-cache.c:942
+#: cups/ppd-cache.c:950
+msgid "Bad PPD cache file."
+msgstr ""
+
+#: scheduler/ipp.c:2659
+msgid "Bad PPD file."
+msgstr ""
+
+#: cups/http-support.c:1512
+msgid "Bad Request"
+msgstr ""
+
+#: cups/snmp.c:956
+msgid "Bad SNMP version number"
+msgstr ""
+
+#: cups/ppd.c:295
+msgid "Bad UIConstraints"
+msgstr ""
+
+#: cups/dest.c:1195
+msgid "Bad URI."
+msgstr ""
+
+#: cups/hash.c:48 cups/http-support.c:1606
+msgid "Bad arguments to function"
+msgstr ""
+
+#: scheduler/ipp.c:1372
+#, c-format
+msgid "Bad copies value %d."
+msgstr ""
+
+#: cups/ppd.c:303
+msgid "Bad custom parameter"
+msgstr ""
+
+#: cups/http-support.c:1746 scheduler/ipp.c:2365
+#, c-format
+msgid "Bad device-uri \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:2410
+#, c-format
+msgid "Bad device-uri scheme \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:8486 scheduler/ipp.c:8504 scheduler/ipp.c:9732
+#, c-format
+msgid "Bad document-format \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:9750
+#, c-format
+msgid "Bad document-format-default \"%s\"."
+msgstr ""
+
+#: cups/ppd-util.c:169
+msgid "Bad filename buffer"
+msgstr ""
+
+#: cups/http-support.c:1615
+msgid "Bad hostname/address in URI"
+msgstr ""
+
+#: scheduler/ipp.c:1554
+#, c-format
+msgid "Bad job-name value: %s"
+msgstr ""
+
+#: scheduler/ipp.c:1540
+msgid "Bad job-name value: Wrong type or count."
+msgstr ""
+
+#: scheduler/ipp.c:10374
+msgid "Bad job-priority value."
+msgstr ""
+
+#: scheduler/ipp.c:1402
+#, c-format
+msgid "Bad job-sheets value \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:1386
+msgid "Bad job-sheets value type."
+msgstr ""
+
+#: scheduler/ipp.c:10404
+msgid "Bad job-state value."
+msgstr ""
+
+#: scheduler/ipp.c:3006 scheduler/ipp.c:3468 scheduler/ipp.c:6253
+#: scheduler/ipp.c:6400 scheduler/ipp.c:7912 scheduler/ipp.c:8184
+#: scheduler/ipp.c:9050 scheduler/ipp.c:9274 scheduler/ipp.c:9626
+#: scheduler/ipp.c:10235
+#, c-format
+msgid "Bad job-uri \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:2049 scheduler/ipp.c:5773
+#, c-format
+msgid "Bad notify-pull-method \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:2014 scheduler/ipp.c:5737
+#, c-format
+msgid "Bad notify-recipient-uri \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:5848
+#, c-format
+msgid "Bad notify-user-data \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:1418
+#, c-format
+msgid "Bad number-up value %d."
+msgstr ""
+
+#: scheduler/ipp.c:1435
+#, c-format
+msgid "Bad page-ranges values %d-%d."
+msgstr ""
+
+#: cups/http-support.c:1612
+msgid "Bad port number in URI"
+msgstr ""
+
+#: scheduler/ipp.c:2456
+#, c-format
+msgid "Bad port-monitor \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:2537
+#, c-format
+msgid "Bad printer-state value %d."
+msgstr ""
+
+#: cups/dest.c:678 cups/dest.c:1245
+msgid "Bad printer-uri."
+msgstr ""
+
+#: scheduler/ipp.c:201
+#, c-format
+msgid "Bad request ID %d."
+msgstr ""
+
+#: scheduler/ipp.c:191
+#, c-format
+msgid "Bad request version number %d.%d."
+msgstr ""
+
+#: cups/http-support.c:1609
+msgid "Bad resource in URI"
+msgstr ""
+
+#: cups/http-support.c:1621
+msgid "Bad scheme in URI"
+msgstr ""
+
+#: cups/http-support.c:1618
+msgid "Bad username in URI"
+msgstr ""
+
+#: cups/ppd.c:305
+msgid "Bad value string"
+msgstr ""
+
+#: cups/http-support.c:1624
+msgid "Bad/empty URI"
+msgstr ""
+
+#: cgi-bin/admin.c:2794 cgi-bin/admin.c:3043
+msgid "Banners"
+msgstr ""
+
+#: ppdc/sample.c:282
+msgid "Bond Paper"
+msgstr ""
+
+#: cups/ppd-cache.c:4152
+msgid "Booklet"
+msgstr ""
+
+#: backend/usb-darwin.c:2008
+#, c-format
+msgid "Boolean expected for waiteof option \"%s\"."
+msgstr ""
+
+#: filter/pstops.c:2026
+msgid "Buffer overflow detected, aborting."
+msgstr ""
+
+#: ppdc/sample.c:277
+msgid "CMYK"
+msgstr ""
+
+#: ppdc/sample.c:358
+msgid "CPCL Label Printer"
+msgstr ""
+
+#: cgi-bin/classes.c:159 cgi-bin/printers.c:162
+msgid "Cancel Jobs"
+msgstr ""
+
+#: backend/ipp.c:2287
+msgid "Canceling print job."
+msgstr ""
+
+#: scheduler/ipp.c:963 scheduler/ipp.c:2512
+msgid "Cannot change printer-is-shared for remote queues."
+msgstr ""
+
+#: scheduler/ipp.c:2499
+msgid "Cannot share a remote Kerberized printer."
+msgstr ""
+
+#: ppdc/sample.c:271
+msgid "Cassette"
+msgstr ""
+
+#: cgi-bin/admin.c:1347 cgi-bin/admin.c:1489 cgi-bin/admin.c:1502
+#: cgi-bin/admin.c:1513
+msgid "Change Settings"
+msgstr ""
+
+#: scheduler/ipp.c:2061 scheduler/ipp.c:5785
+#, c-format
+msgid "Character set \"%s\" not supported."
+msgstr ""
+
+#: cgi-bin/classes.c:181 cgi-bin/classes.c:307
+msgid "Classes"
+msgstr ""
+
+#: cgi-bin/printers.c:168
+msgid "Clean Print Heads"
+msgstr ""
+
+#: scheduler/ipp.c:3920
+msgid "Close-Job doesn't support the job-uri attribute."
+msgstr ""
+
+#: cups/ppd-cache.c:3790 ppdc/sample.c:276
+msgid "Color"
+msgstr ""
+
+#: cups/ppd-cache.c:3751 ppdc/sample.c:274
+msgid "Color Mode"
+msgstr ""
+
+#: berkeley/lpc.c:190
+msgid ""
+"Commands may be abbreviated.  Commands are:\n"
+"\n"
+"exit    help    quit    status  ?"
+msgstr ""
+
+#: cups/snmp.c:960
+msgid "Community name uses indefinite length"
+msgstr ""
+
+#: backend/ipp.c:865 backend/lpd.c:929 backend/socket.c:375
+msgid "Connected to printer."
+msgstr ""
+
+#: backend/ipp.c:701 backend/lpd.c:753 backend/socket.c:295
+msgid "Connecting to printer."
+msgstr ""
+
+#: cups/http-support.c:1482
+msgid "Continue"
+msgstr ""
+
+#: ppdc/sample.c:360
+msgid "Continuous"
+msgstr ""
+
+#: backend/lpd.c:1078 backend/lpd.c:1210
+msgid "Control file sent successfully."
+msgstr ""
+
+#: backend/ipp.c:1396 backend/lpd.c:445
+msgid "Copying print data."
+msgstr ""
+
+#: cups/http-support.c:1491
+msgid "Created"
+msgstr ""
+
+#: cups/tls-darwin.c:748 cups/tls-gnutls.c:582
+msgid "Credentials do not validate against site CA certificate."
+msgstr ""
+
+#: cups/tls-darwin.c:759 cups/tls-gnutls.c:599
+msgid "Credentials have expired."
+msgstr ""
+
+#: cups/ppd.c:1133 cups/ppd.c:1173 cups/ppd.c:1382 cups/ppd.c:1485
+msgid "Custom"
+msgstr ""
+
+#: ppdc/sample.c:354
+msgid "CustominCutInterval"
+msgstr ""
+
+#: ppdc/sample.c:352
+msgid "CustominTearInterval"
+msgstr ""
+
+#: ppdc/sample.c:338
+msgid "Cut"
+msgstr ""
+
+#: ppdc/sample.c:446
+msgid "Cutter"
+msgstr ""
+
+#: ppdc/sample.c:239
+msgid "Dark"
+msgstr ""
+
+#: ppdc/sample.c:235
+msgid "Darkness"
+msgstr ""
+
+#: backend/lpd.c:1163
+msgid "Data file sent successfully."
+msgstr ""
+
+#: cups/ppd-cache.c:3798 cups/ppd-cache.c:3807
+msgid "Deep Color"
+msgstr ""
+
+#: cups/ppd-cache.c:3784
+msgid "Deep Gray"
+msgstr ""
+
+#: cgi-bin/admin.c:1786 cgi-bin/admin.c:1797 cgi-bin/admin.c:1842
+msgid "Delete Class"
+msgstr ""
+
+#: cgi-bin/admin.c:1871 cgi-bin/admin.c:1882 cgi-bin/admin.c:1927
+msgid "Delete Printer"
+msgstr ""
+
+#: ppdc/sample.c:273
+msgid "DeskJet Series"
+msgstr ""
+
+#: scheduler/ipp.c:1301
+#, c-format
+msgid "Destination \"%s\" is not accepting jobs."
+msgstr ""
+
+#: cups/ppd-cache.c:3828 cups/ppd-cache.c:3834
+msgid "Device CMYK"
+msgstr ""
+
+#: cups/ppd-cache.c:3816 cups/ppd-cache.c:3822
+msgid "Device Gray"
+msgstr ""
+
+#: cups/ppd-cache.c:3840 cups/ppd-cache.c:3846
+msgid "Device RGB"
+msgstr ""
+
+#: systemv/lpinfo.c:273
+#, c-format
+msgid ""
+"Device: uri = %s\n"
+"        class = %s\n"
+"        info = %s\n"
+"        make-and-model = %s\n"
+"        device-id = %s\n"
+"        location = %s"
+msgstr ""
+
+#: ppdc/sample.c:431
+msgid "Direct Thermal Media"
+msgstr ""
+
+#: cups/file.c:285
+#, c-format
+msgid "Directory \"%s\" contains a relative path."
+msgstr ""
+
+#: cups/file.c:257
+#, c-format
+msgid "Directory \"%s\" has insecure permissions (0%o/uid=%d/gid=%d)."
+msgstr ""
+
+#: cups/file.c:274
+#, c-format
+msgid "Directory \"%s\" is a file."
+msgstr ""
+
+#: cups/file.c:245
+#, c-format
+msgid "Directory \"%s\" not available: %s"
+msgstr ""
+
+#: cups/file.c:230
+#, c-format
+msgid "Directory \"%s\" permissions OK (0%o/uid=%d/gid=%d)."
+msgstr ""
+
+#: ppdc/sample.c:340
+msgid "Disabled"
+msgstr ""
+
+#: scheduler/ipp.c:6302
+#, c-format
+msgid "Document #%d does not exist in job #%d."
+msgstr ""
+
+#: cups/ppd-cache.c:4283 cups/ppd-cache.c:4285 cups/ppd-cache.c:4348
+#: cups/ppd-cache.c:4385
+msgid "Draft"
+msgstr ""
+
+#: ppdc/sample.c:267
+msgid "Duplexer"
+msgstr ""
+
+#: ppdc/sample.c:229
+msgid "Dymo"
+msgstr ""
+
+#: ppdc/sample.c:426
+msgid "EPL1 Label Printer"
+msgstr ""
+
+#: ppdc/sample.c:429
+msgid "EPL2 Label Printer"
+msgstr ""
+
+#: cgi-bin/admin.c:1541 cgi-bin/admin.c:1553 cgi-bin/admin.c:1607
+#: cgi-bin/admin.c:1614 cgi-bin/admin.c:1649 cgi-bin/admin.c:1662
+#: cgi-bin/admin.c:1686 cgi-bin/admin.c:1759
+msgid "Edit Configuration File"
+msgstr ""
+
+#: cups/http.c:4649
+msgid "Encryption is not supported."
+msgstr ""
+
+#. TRANSLATORS: Banner/cover sheet after the print job.
+#: cgi-bin/admin.c:3068
+msgid "Ending Banner"
+msgstr ""
+
+#: ppdc/sample.c:2
+msgid "English"
+msgstr ""
+
+#: scheduler/client.c:1981
+msgid "Enter your username and password or the root username and password to access this page. If you are using Kerberos authentication, make sure you have a valid Kerberos ticket."
+msgstr ""
+
+#: ppdc/sample.c:73
+msgid "Envelope #10"
+msgstr ""
+
+#: ppdc/sample.c:74
+msgid "Envelope #11"
+msgstr ""
+
+#: ppdc/sample.c:75
+msgid "Envelope #12"
+msgstr ""
+
+#: ppdc/sample.c:76
+msgid "Envelope #14"
+msgstr ""
+
+#: ppdc/sample.c:77
+msgid "Envelope #9"
+msgstr ""
+
+#: ppdc/sample.c:89
+msgid "Envelope B4"
+msgstr ""
+
+#: ppdc/sample.c:90
+msgid "Envelope B5"
+msgstr ""
+
+#: ppdc/sample.c:91
+msgid "Envelope B6"
+msgstr ""
+
+#: ppdc/sample.c:78
+msgid "Envelope C0"
+msgstr ""
+
+#: ppdc/sample.c:79
+msgid "Envelope C1"
+msgstr ""
+
+#: ppdc/sample.c:80
+msgid "Envelope C2"
+msgstr ""
+
+#: ppdc/sample.c:81
+msgid "Envelope C3"
+msgstr ""
+
+#: ppdc/sample.c:67
+msgid "Envelope C4"
+msgstr ""
+
+#: ppdc/sample.c:68
+msgid "Envelope C5"
+msgstr ""
+
+#: ppdc/sample.c:69
+msgid "Envelope C6"
+msgstr ""
+
+#: ppdc/sample.c:82
+msgid "Envelope C65"
+msgstr ""
+
+#: ppdc/sample.c:83
+msgid "Envelope C7"
+msgstr ""
+
+#: ppdc/sample.c:84
+msgid "Envelope Choukei 3"
+msgstr ""
+
+#: ppdc/sample.c:85
+msgid "Envelope Choukei 3 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:86
+msgid "Envelope Choukei 4"
+msgstr ""
+
+#: ppdc/sample.c:87
+msgid "Envelope Choukei 4 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:70
+msgid "Envelope DL"
+msgstr ""
+
+#: ppdc/sample.c:261
+msgid "Envelope Feed"
+msgstr ""
+
+#: ppdc/sample.c:88
+msgid "Envelope Invite"
+msgstr ""
+
+#: ppdc/sample.c:92
+msgid "Envelope Italian"
+msgstr ""
+
+#: ppdc/sample.c:93
+msgid "Envelope Kaku2"
+msgstr ""
+
+#: ppdc/sample.c:94
+msgid "Envelope Kaku2 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:95
+msgid "Envelope Kaku3"
+msgstr ""
+
+#: ppdc/sample.c:96
+msgid "Envelope Kaku3 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:97
+msgid "Envelope Monarch"
+msgstr ""
+
+#: ppdc/sample.c:99
+msgid "Envelope PRC1"
+msgstr ""
+
+#: ppdc/sample.c:100
+msgid "Envelope PRC1 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:117
+msgid "Envelope PRC10"
+msgstr ""
+
+#: ppdc/sample.c:118
+msgid "Envelope PRC10 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:101
+msgid "Envelope PRC2"
+msgstr ""
+
+#: ppdc/sample.c:102
+msgid "Envelope PRC2 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:103
+msgid "Envelope PRC3"
+msgstr ""
+
+#: ppdc/sample.c:104
+msgid "Envelope PRC3 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:105
+msgid "Envelope PRC4"
+msgstr ""
+
+#: ppdc/sample.c:106
+msgid "Envelope PRC4 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:108
+msgid "Envelope PRC5 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:107
+msgid "Envelope PRC5PRC5"
+msgstr ""
+
+#: ppdc/sample.c:109
+msgid "Envelope PRC6"
+msgstr ""
+
+#: ppdc/sample.c:110
+msgid "Envelope PRC6 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:111
+msgid "Envelope PRC7"
+msgstr ""
+
+#: ppdc/sample.c:112
+msgid "Envelope PRC7 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:113
+msgid "Envelope PRC8"
+msgstr ""
+
+#: ppdc/sample.c:114
+msgid "Envelope PRC8 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:115
+msgid "Envelope PRC9"
+msgstr ""
+
+#: ppdc/sample.c:116
+msgid "Envelope PRC9 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:98
+msgid "Envelope Personal"
+msgstr ""
+
+#: ppdc/sample.c:119
+msgid "Envelope You4"
+msgstr ""
+
+#: ppdc/sample.c:120
+msgid "Envelope You4 Long Edge"
+msgstr ""
+
+#: tools/ippfind.c:2822
+msgid "Environment Variables:"
+msgstr ""
+
+#: ppdc/sample.c:240
+msgid "Epson"
+msgstr ""
+
+#: cgi-bin/admin.c:3111
+msgid "Error Policy"
+msgstr ""
+
+#: filter/rastertopwg.c:452
+msgid "Error reading raster data."
+msgstr ""
+
+#: filter/rastertopwg.c:421 filter/rastertopwg.c:442 filter/rastertopwg.c:460
+#: filter/rastertopwg.c:471
+msgid "Error sending raster data."
+msgstr ""
+
+#: systemv/lpinfo.c:208 systemv/lpmove.c:85
+msgid "Error: need hostname after \"-h\" option."
+msgstr ""
+
+#: ppdc/sample.c:122
+msgid "European Fanfold"
+msgstr ""
+
+#: ppdc/sample.c:123
+msgid "European Fanfold Legal"
+msgstr ""
+
+#: ppdc/sample.c:350
+msgid "Every 10 Labels"
+msgstr ""
+
+#: ppdc/sample.c:342
+msgid "Every 2 Labels"
+msgstr ""
+
+#: ppdc/sample.c:343
+msgid "Every 3 Labels"
+msgstr ""
+
+#: ppdc/sample.c:344
+msgid "Every 4 Labels"
+msgstr ""
+
+#: ppdc/sample.c:345
+msgid "Every 5 Labels"
+msgstr ""
+
+#: ppdc/sample.c:346
+msgid "Every 6 Labels"
+msgstr ""
+
+#: ppdc/sample.c:347
+msgid "Every 7 Labels"
+msgstr ""
+
+#: ppdc/sample.c:348
+msgid "Every 8 Labels"
+msgstr ""
+
+#: ppdc/sample.c:349
+msgid "Every 9 Labels"
+msgstr ""
+
+#: ppdc/sample.c:341
+msgid "Every Label"
+msgstr ""
+
+#: ppdc/sample.c:121
+msgid "Executive"
+msgstr ""
+
+#: cups/http-support.c:1540
+msgid "Expectation Failed"
+msgstr ""
+
+#: tools/ippfind.c:2771
+msgid "Expressions:"
+msgstr ""
+
+#: cups/ppd-cache.c:3758
+msgid "Fast Grayscale"
+msgstr ""
+
+#: cups/file.c:289
+#, c-format
+msgid "File \"%s\" contains a relative path."
+msgstr ""
+
+#: cups/file.c:264
+#, c-format
+msgid "File \"%s\" has insecure permissions (0%o/uid=%d/gid=%d)."
+msgstr ""
+
+#: cups/file.c:278
+#, c-format
+msgid "File \"%s\" is a directory."
+msgstr ""
+
+#: cups/file.c:250
+#, c-format
+msgid "File \"%s\" not available: %s"
+msgstr ""
+
+#: cups/file.c:236
+#, c-format
+msgid "File \"%s\" permissions OK (0%o/uid=%d/gid=%d)."
+msgstr ""
+
+#: ppdc/sample.c:169
+msgid "File Folder"
+msgstr ""
+
+#: scheduler/ipp.c:2386
+#, c-format
+msgid "File device URIs have been disabled. To enable, see the FileDevice directive in \"%s/cups-files.conf\"."
+msgstr ""
+
+#: filter/rastertoepson.c:1131 filter/rastertohp.c:802
+#: filter/rastertolabel.c:1259
+#, c-format
+msgid "Finished page %d."
+msgstr ""
+
+#: cups/ppd-cache.c:4171
+msgid "Finishing Preset"
+msgstr ""
+
+#: cups/ppd-cache.c:4061
+msgid "Fold"
+msgstr ""
+
+#: ppdc/sample.c:125
+msgid "Folio"
+msgstr ""
+
+#: cups/http-support.c:1519
+msgid "Forbidden"
+msgstr ""
+
+#: cups/http-support.c:1503
+msgid "Found"
+msgstr ""
+
+#: cups/ppd.c:757 cups/ppd.c:1286
+msgid "General"
+msgstr ""
+
+#: ppdc/sample.c:251
+msgid "Generic"
+msgstr ""
+
+#: cups/snmp.c:970
+msgid "Get-Response-PDU uses indefinite length"
+msgstr ""
+
+#: ppdc/sample.c:285
+msgid "Glossy Paper"
+msgstr ""
+
+#: scheduler/ipp.c:2984 scheduler/ipp.c:3394 scheduler/ipp.c:3932
+#: scheduler/ipp.c:6231 scheduler/ipp.c:6378 scheduler/ipp.c:7889
+#: scheduler/ipp.c:9028 scheduler/ipp.c:9252 scheduler/ipp.c:9604
+#: scheduler/ipp.c:10213
+msgid "Got a printer-uri attribute but no job-id."
+msgstr ""
+
+#: cups/ppd-cache.c:3767 cups/ppd-cache.c:3778 ppdc/sample.c:275
+msgid "Grayscale"
+msgstr ""
+
+#: ppdc/sample.c:272
+msgid "HP"
+msgstr ""
+
+#: ppdc/sample.c:170
+msgid "Hanging Folder"
+msgstr ""
+
+#: cups/hash.c:292
+msgid "Hash buffer too small."
+msgstr ""
+
+#: cgi-bin/help.c:133
+msgid "Help file not in index."
+msgstr ""
+
+#: cups/ppd-cache.c:4290 cups/ppd-cache.c:4359 cups/ppd-cache.c:4390
+msgid "High"
+msgstr ""
+
+#: cups/ipp.c:3094 cups/ipp.c:3121 cups/ipp.c:3144
+msgid "IPP 1setOf attribute with incompatible value tags."
+msgstr ""
+
+#: cups/ipp.c:3057
+msgid "IPP attribute has no name."
+msgstr ""
+
+#: cups/ipp.c:6802
+msgid "IPP attribute is not a member of the message."
+msgstr ""
+
+#: cups/ipp.c:3507
+msgid "IPP begCollection value not 0 bytes."
+msgstr ""
+
+#: cups/ipp.c:3285
+msgid "IPP boolean value not 1 byte."
+msgstr ""
+
+#: cups/ipp.c:3350
+msgid "IPP date value not 11 bytes."
+msgstr ""
+
+#: cups/ipp.c:3528
+msgid "IPP endCollection value not 0 bytes."
+msgstr ""
+
+#: cups/ipp.c:3260
+msgid "IPP enum value not 4 bytes."
+msgstr ""
+
+#: cups/ipp.c:2975
+msgid "IPP extension tag larger than 0x7FFFFFFF."
+msgstr ""
+
+#: cups/ipp.c:3257
+msgid "IPP integer value not 4 bytes."
+msgstr ""
+
+#: cups/ipp.c:3460
+msgid "IPP language length overflows value."
+msgstr ""
+
+#: cups/ipp.c:3469
+msgid "IPP language length too large."
+msgstr ""
+
+#: cups/ipp.c:3171
+msgid "IPP member name is not empty."
+msgstr ""
+
+#: cups/ipp.c:3554
+msgid "IPP memberName value is empty."
+msgstr ""
+
+#: cups/ipp.c:3546
+msgid "IPP memberName with no attribute."
+msgstr ""
+
+#: cups/ipp.c:3035
+msgid "IPP name larger than 32767 bytes."
+msgstr ""
+
+#: cups/ipp.c:3427
+msgid "IPP nameWithLanguage value less than minimum 4 bytes."
+msgstr ""
+
+#: cups/ipp.c:3585
+msgid "IPP octetString length too large."
+msgstr ""
+
+#: cups/ipp.c:3395
+msgid "IPP rangeOfInteger value not 8 bytes."
+msgstr ""
+
+#: cups/ipp.c:3368
+msgid "IPP resolution value not 9 bytes."
+msgstr ""
+
+#: cups/ipp.c:3487
+msgid "IPP string length overflows value."
+msgstr ""
+
+#: cups/ipp.c:3423
+msgid "IPP textWithLanguage value less than minimum 4 bytes."
+msgstr ""
+
+#: cups/ipp.c:3243
+msgid "IPP value larger than 32767 bytes."
+msgstr ""
+
+#: tools/ippfind.c:2823
+msgid "IPPFIND_SERVICE_DOMAIN  Domain name"
+msgstr ""
+
+#: tools/ippfind.c:2824
+msgid ""
+"IPPFIND_SERVICE_HOSTNAME\n"
+"                        Fully-qualified domain name"
+msgstr ""
+
+#: tools/ippfind.c:2826
+msgid "IPPFIND_SERVICE_NAME    Service instance name"
+msgstr ""
+
+#: tools/ippfind.c:2827
+msgid "IPPFIND_SERVICE_PORT    Port number"
+msgstr ""
+
+#: tools/ippfind.c:2828
+msgid "IPPFIND_SERVICE_REGTYPE DNS-SD registration type"
+msgstr ""
+
+#: tools/ippfind.c:2829
+msgid "IPPFIND_SERVICE_SCHEME  URI scheme"
+msgstr ""
+
+#: tools/ippfind.c:2830
+msgid "IPPFIND_SERVICE_URI     URI"
+msgstr ""
+
+#: tools/ippfind.c:2831
+msgid "IPPFIND_TXT_*           Value of TXT record key"
+msgstr ""
+
+#: ppdc/sample.c:1
+msgid "ISOLatin1"
+msgstr ""
+
+#: cups/ppd.c:298
+msgid "Illegal control character"
+msgstr ""
+
+#: cups/ppd.c:299
+msgid "Illegal main keyword string"
+msgstr ""
+
+#: cups/ppd.c:300
+msgid "Illegal option keyword string"
+msgstr ""
+
+#: cups/ppd.c:301
+msgid "Illegal translation string"
+msgstr ""
+
+#: cups/ppd.c:302
+msgid "Illegal whitespace character"
+msgstr ""
+
+#: ppdc/sample.c:266
+msgid "Installable Options"
+msgstr ""
+
+#: ppdc/sample.c:269
+msgid "Installed"
+msgstr ""
+
+#: ppdc/sample.c:288
+msgid "IntelliBar Label Printer"
+msgstr ""
+
+#: ppdc/sample.c:287
+msgid "Intellitech"
+msgstr ""
+
+#: cups/http-support.c:1546
+msgid "Internal Server Error"
+msgstr ""
+
+#: cups/ppd.c:289
+msgid "Internal error"
+msgstr ""
+
+#: ppdc/sample.c:167
+msgid "Internet Postage 2-Part"
+msgstr ""
+
+#: ppdc/sample.c:168
+msgid "Internet Postage 3-Part"
+msgstr ""
+
+#: backend/ipp.c:319
+msgid "Internet Printing Protocol"
+msgstr ""
+
+#: cups/ipp.c:2995
+msgid "Invalid group tag."
+msgstr ""
+
+#: cups/pwg-media.c:288 cups/pwg-media.c:307
+msgid "Invalid media name arguments."
+msgstr ""
+
+#: cups/dest-options.c:1232
+msgid "Invalid media size."
+msgstr ""
+
+#: cups/ipp.c:3045
+msgid "Invalid named IPP attribute in collection."
+msgstr ""
+
+#: scheduler/ipp.c:2705 scheduler/ipp.c:7045
+msgid "Invalid ppd-name value."
+msgstr ""
+
+#: filter/commandtops.c:108
+#, c-format
+msgid "Invalid printer command \"%s\"."
+msgstr ""
+
+#: cups/ppd.c:1404
+msgid "JCL"
+msgstr ""
+
+#: ppdc/sample.c:53
+msgid "JIS B0"
+msgstr ""
+
+#: ppdc/sample.c:55
+msgid "JIS B1"
+msgstr ""
+
+#: ppdc/sample.c:54
+msgid "JIS B10"
+msgstr ""
+
+#: ppdc/sample.c:56
+msgid "JIS B2"
+msgstr ""
+
+#: ppdc/sample.c:57
+msgid "JIS B3"
+msgstr ""
+
+#: ppdc/sample.c:58
+msgid "JIS B4"
+msgstr ""
+
+#: ppdc/sample.c:59
+msgid "JIS B4 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:60
+msgid "JIS B5"
+msgstr ""
+
+#: ppdc/sample.c:61
+msgid "JIS B5 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:62
+msgid "JIS B6"
+msgstr ""
+
+#: ppdc/sample.c:63
+msgid "JIS B6 Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:64
+msgid "JIS B7"
+msgstr ""
+
+#: ppdc/sample.c:65
+msgid "JIS B8"
+msgstr ""
+
+#: ppdc/sample.c:66
+msgid "JIS B9"
+msgstr ""
+
+#: scheduler/ipp.c:9324
+#, c-format
+msgid "Job #%d cannot be restarted - no files."
+msgstr ""
+
+#: scheduler/ipp.c:3024 scheduler/ipp.c:3258 scheduler/ipp.c:3317
+#: scheduler/ipp.c:3496 scheduler/ipp.c:3942 scheduler/ipp.c:5890
+#: scheduler/ipp.c:6271 scheduler/ipp.c:6418 scheduler/ipp.c:6755
+#: scheduler/ipp.c:7730 scheduler/ipp.c:7752 scheduler/ipp.c:7930
+#: scheduler/ipp.c:8158 scheduler/ipp.c:8201 scheduler/ipp.c:9068
+#: scheduler/ipp.c:9292 scheduler/ipp.c:9644 scheduler/ipp.c:10253
+#, c-format
+msgid "Job #%d does not exist."
+msgstr ""
+
+#: scheduler/ipp.c:3528
+#, c-format
+msgid "Job #%d is already aborted - can't cancel."
+msgstr ""
+
+#: scheduler/ipp.c:3522
+#, c-format
+msgid "Job #%d is already canceled - can't cancel."
+msgstr ""
+
+#: scheduler/ipp.c:3534
+#, c-format
+msgid "Job #%d is already completed - can't cancel."
+msgstr ""
+
+#: scheduler/ipp.c:7956 scheduler/ipp.c:8243 scheduler/ipp.c:10268
+#, c-format
+msgid "Job #%d is finished and cannot be altered."
+msgstr ""
+
+#: scheduler/ipp.c:9306
+#, c-format
+msgid "Job #%d is not complete."
+msgstr ""
+
+#: scheduler/ipp.c:3039
+#, c-format
+msgid "Job #%d is not held for authentication."
+msgstr ""
+
+#: scheduler/ipp.c:9082
+#, c-format
+msgid "Job #%d is not held."
+msgstr ""
+
+#: cgi-bin/ipp-var.c:1032
+msgid "Job Completed"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:1030
+msgid "Job Created"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:1036
+msgid "Job Options Changed"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:1034
+msgid "Job Stopped"
+msgstr ""
+
+#: scheduler/ipp.c:10382
+msgid "Job is completed and cannot be changed."
+msgstr ""
+
+#: cgi-bin/jobs.c:186
+msgid "Job operation failed"
+msgstr ""
+
+#: scheduler/ipp.c:10418 scheduler/ipp.c:10435 scheduler/ipp.c:10446
+msgid "Job state cannot be changed."
+msgstr ""
+
+#: scheduler/ipp.c:9172
+msgid "Job subscriptions cannot be renewed."
+msgstr ""
+
+#: cgi-bin/jobs.c:91 cgi-bin/jobs.c:102 cgi-bin/jobs.c:183
+msgid "Jobs"
+msgstr ""
+
+#: backend/lpd.c:162
+msgid "LPD/LPR Host or Printer"
+msgstr ""
+
+#: cups/dest.c:1856
+msgid "LPDEST environment variable names default destination that does not exist."
+msgstr ""
+
+#: ppdc/sample.c:230
+msgid "Label Printer"
+msgstr ""
+
+#: ppdc/sample.c:441
+msgid "Label Top"
+msgstr ""
+
+#: scheduler/ipp.c:2070 scheduler/ipp.c:5794
+#, c-format
+msgid "Language \"%s\" not supported."
+msgstr ""
+
+#: ppdc/sample.c:164
+msgid "Large Address"
+msgstr ""
+
+#: ppdc/sample.c:286
+msgid "LaserJet Series PCL 4/5"
+msgstr ""
+
+#: ppdc/sample.c:43
+msgid "Letter Oversize"
+msgstr ""
+
+#: ppdc/sample.c:44
+msgid "Letter Oversize Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:236
+msgid "Light"
+msgstr ""
+
+#: cups/ppd.c:297
+msgid "Line longer than the maximum allowed (255 characters)"
+msgstr ""
+
+#: cgi-bin/admin.c:1950
+msgid "List Available Printers"
+msgstr ""
+
+#: tools/ippeveprinter.c:604
+#, c-format
+msgid "Listening on port %d."
+msgstr ""
+
+#: scheduler/ipp.c:5503
+msgid "Local printer created."
+msgstr ""
+
+#: cups/ppd-cache.c:3872 ppdc/sample.c:264
+msgid "Long-Edge (Portrait)"
+msgstr ""
+
+#: cups/http-support.c:1870
+msgid "Looking for printer."
+msgstr ""
+
+#: ppdc/sample.c:260
+msgid "Manual Feed"
+msgstr ""
+
+#: cups/ppd.c:804 cups/ppd.c:1341
+msgid "Media Size"
+msgstr ""
+
+#: cups/ppd.c:808 cups/ppd.c:1345 ppdc/sample.c:254
+msgid "Media Source"
+msgstr ""
+
+#: ppdc/sample.c:359
+msgid "Media Tracking"
+msgstr ""
+
+#: cups/ppd.c:806 cups/ppd.c:1343 ppdc/sample.c:280
+msgid "Media Type"
+msgstr ""
+
+#: ppdc/sample.c:237
+msgid "Medium"
+msgstr ""
+
+#: cups/ppd.c:286
+msgid "Memory allocation error"
+msgstr ""
+
+#: cups/ppd.c:306
+msgid "Missing CloseGroup"
+msgstr ""
+
+#: cups/ppd.c:308
+msgid "Missing CloseUI/JCLCloseUI"
+msgstr ""
+
+#: cups/ppd.c:287
+msgid "Missing PPD-Adobe-4.x header"
+msgstr ""
+
+#: cups/ppd.c:296
+msgid "Missing asterisk in column 1"
+msgstr ""
+
+#: scheduler/ipp.c:6294
+msgid "Missing document-number attribute."
+msgstr ""
+
+#: cgi-bin/admin.c:502 cgi-bin/admin.c:1798 cgi-bin/admin.c:1883
+#: cgi-bin/admin.c:2289 cgi-bin/admin.c:2543 cgi-bin/admin.c:2654
+#: cgi-bin/admin.c:3367
+msgid "Missing form variable"
+msgstr ""
+
+#: scheduler/ipp.c:9698
+msgid "Missing last-document attribute in request."
+msgstr ""
+
+#: cups/pwg-media.c:547
+msgid "Missing media or media-col."
+msgstr ""
+
+#: cups/pwg-media.c:466
+msgid "Missing media-size in media-col."
+msgstr ""
+
+#: scheduler/ipp.c:6895
+msgid "Missing notify-subscription-ids attribute."
+msgstr ""
+
+#: cups/ppd.c:304
+msgid "Missing option keyword"
+msgstr ""
+
+#: scheduler/ipp.c:3165 scheduler/ipp.c:3190
+msgid "Missing requesting-user-name attribute."
+msgstr ""
+
+#: scheduler/ipp.c:5420 scheduler/ipp.c:5446
+#, c-format
+msgid "Missing required attribute \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:347
+msgid "Missing required attributes."
+msgstr ""
+
+#: cups/http-support.c:1636
+msgid "Missing resource in URI"
+msgstr ""
+
+#: cups/http-support.c:1630
+msgid "Missing scheme in URI"
+msgstr ""
+
+#: cups/ppd.c:288
+msgid "Missing value string"
+msgstr ""
+
+#: cups/pwg-media.c:454
+msgid "Missing x-dimension in media-size."
+msgstr ""
+
+#: cups/pwg-media.c:460
+msgid "Missing y-dimension in media-size."
+msgstr ""
+
+#: systemv/lpinfo.c:443 systemv/lpinfo.c:467
+#, c-format
+msgid ""
+"Model:  name = %s\n"
+"        natural_language = %s\n"
+"        make-and-model = %s\n"
+"        device-id = %s"
+msgstr ""
+
+#: tools/ippfind.c:2801
+msgid "Modifiers:"
+msgstr ""
+
+#: cgi-bin/admin.c:336
+msgid "Modify Class"
+msgstr ""
+
+#: cgi-bin/admin.c:649
+msgid "Modify Printer"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:407 cgi-bin/ipp-var.c:498
+msgid "Move All Jobs"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:346 cgi-bin/ipp-var.c:405 cgi-bin/ipp-var.c:496
+msgid "Move Job"
+msgstr ""
+
+#: cups/http-support.c:1500
+msgid "Moved Permanently"
+msgstr ""
+
+#: cups/ppd.c:285
+msgid "NULL PPD file pointer"
+msgstr ""
+
+#: cups/snmp.c:1007
+msgid "Name OID uses indefinite length"
+msgstr ""
+
+#: scheduler/ipp.c:1056
+msgid "Nested classes are not allowed."
+msgstr ""
+
+#: ppdc/sample.c:425
+msgid "Never"
+msgstr ""
+
+#: cups/tls-darwin.c:690 cups/tls-gnutls.c:524
+msgid "New credentials are not valid for name."
+msgstr ""
+
+#: cups/tls-darwin.c:680 cups/tls-gnutls.c:514
+msgid "New credentials are older than stored credentials."
+msgstr ""
+
+#: cups/ppd.c:1974
+msgid "No"
+msgstr ""
+
+#: cups/http-support.c:1497
+msgid "No Content"
+msgstr ""
+
+#: cups/ppd-cache.c:3076
+msgid "No IPP attributes."
+msgstr ""
+
+#: cups/ppd-util.c:489
+msgid "No PPD name"
+msgstr ""
+
+#: cups/snmp.c:1001
+msgid "No VarBind SEQUENCE"
+msgstr ""
+
+#: cups/request.c:548 cups/request.c:920
+msgid "No active connection"
+msgstr ""
+
+#: cups/request.c:329
+msgid "No active connection."
+msgstr ""
+
+#: scheduler/ipp.c:3445
+#, c-format
+msgid "No active jobs on %s."
+msgstr ""
+
+#: scheduler/ipp.c:207
+msgid "No attributes in request."
+msgstr ""
+
+#: scheduler/ipp.c:3066
+msgid "No authentication information provided."
+msgstr ""
+
+#: cups/tls-darwin.c:630 cups/tls-gnutls.c:461
+msgid "No common name specified."
+msgstr ""
+
+#: cups/snmp.c:958
+msgid "No community name"
+msgstr ""
+
+#: cups/dest.c:1860 cups/dest.c:1872
+msgid "No default destination."
+msgstr ""
+
+#: scheduler/ipp.c:6094
+msgid "No default printer."
+msgstr ""
+
+#: cgi-bin/ipp-var.c:418 scheduler/ipp.c:7476
+msgid "No destinations added."
+msgstr ""
+
+#: backend/usb.c:187
+msgid "No device URI found in argv[0] or in DEVICE_URI environment variable."
+msgstr ""
+
+#: cups/snmp.c:988
+msgid "No error-index"
+msgstr ""
+
+#: cups/snmp.c:980
+msgid "No error-status"
+msgstr ""
+
+#: scheduler/ipp.c:8448 scheduler/ipp.c:9712
+msgid "No file in print request."
+msgstr ""
+
+#: cups/ppd-util.c:162
+msgid "No modification time"
+msgstr ""
+
+#: cups/snmp.c:1005
+msgid "No name OID"
+msgstr ""
+
+#: filter/rastertoepson.c:1161 filter/rastertohp.c:833
+#: filter/rastertolabel.c:1288
+msgid "No pages were found."
+msgstr ""
+
+#: cups/ppd-util.c:155
+msgid "No printer name"
+msgstr ""
+
+#: cups/ppd-util.c:658
+msgid "No printer-uri found"
+msgstr ""
+
+#: cups/ppd-util.c:642
+msgid "No printer-uri found for class"
+msgstr ""
+
+#: scheduler/ipp.c:6501
+msgid "No printer-uri in request."
+msgstr ""
+
+#: cups/http.c:2217
+msgid "No request URI."
+msgstr ""
+
+#: cups/http.c:2234
+msgid "No request protocol version."
+msgstr ""
+
+#: cups/request.c:337
+msgid "No request sent."
+msgstr ""
+
+#: cups/snmp.c:972
+msgid "No request-id"
+msgstr ""
+
+#: cups/tls-darwin.c:710 cups/tls-gnutls.c:544
+msgid "No stored credentials, not valid for name."
+msgstr ""
+
+#: scheduler/ipp.c:5679
+msgid "No subscription attributes in request."
+msgstr ""
+
+#: scheduler/ipp.c:7829
+msgid "No subscriptions found."
+msgstr ""
+
+#: cups/snmp.c:996
+msgid "No variable-bindings SEQUENCE"
+msgstr ""
+
+#: cups/snmp.c:951
+msgid "No version number"
+msgstr ""
+
+#: ppdc/sample.c:362
+msgid "Non-continuous (Mark sensing)"
+msgstr ""
+
+#: ppdc/sample.c:361
+msgid "Non-continuous (Web sensing)"
+msgstr ""
+
+#: cups/ppd-cache.c:4014 cups/ppd-cache.c:4064 cups/ppd-cache.c:4114
+#: cups/ppd-cache.c:4174
+msgid "None"
+msgstr ""
+
+#: cups/ppd-cache.c:4287 cups/ppd-cache.c:4353 cups/ppd-cache.c:4387
+#: ppdc/sample.c:238
+msgid "Normal"
+msgstr ""
+
+#: cups/http-support.c:1522
+msgid "Not Found"
+msgstr ""
+
+#: cups/http-support.c:1534
+msgid "Not Implemented"
+msgstr ""
+
+#: ppdc/sample.c:268
+msgid "Not Installed"
+msgstr ""
+
+#: cups/http-support.c:1509
+msgid "Not Modified"
+msgstr ""
+
+#: cups/http-support.c:1537
+msgid "Not Supported"
+msgstr ""
+
+#: scheduler/ipp.c:1510 scheduler/ipp.c:10979
+msgid "Not allowed to print."
+msgstr ""
+
+#: ppdc/sample.c:146
+msgid "Note"
+msgstr ""
+
+#: cups/http-support.c:1488 cups/http-support.c:1627 cups/ppd.c:283
+msgid "OK"
+msgstr ""
+
+#: cups/ppd-cache.c:3872 ppdc/sample.c:263
+msgid "Off (1-Sided)"
+msgstr ""
+
+#: ppdc/sample.c:356
+msgid "Oki"
+msgstr ""
+
+#: cgi-bin/help.c:81 cgi-bin/help.c:122 cgi-bin/help.c:132 cgi-bin/help.c:162
+msgid "Online Help"
+msgstr ""
+
+#: scheduler/ipp.c:5399
+msgid "Only local users can create a local printer."
+msgstr ""
+
+#: cups/adminutil.c:202
+#, c-format
+msgid "Open of %s failed: %s"
+msgstr ""
+
+#: cups/ppd.c:291
+msgid "OpenGroup without a CloseGroup first"
+msgstr ""
+
+#: cups/ppd.c:293
+msgid "OpenUI/JCLOpenUI without a CloseUI/JCLCloseUI first"
+msgstr ""
+
+#: cgi-bin/admin.c:3138
+msgid "Operation Policy"
+msgstr ""
+
+#: filter/pstops.c:2174
+#, c-format
+msgid "Option \"%s\" cannot be included via %%%%IncludeFeature."
+msgstr ""
+
+#: cgi-bin/admin.c:2785 cgi-bin/admin.c:2869
+msgid "Options Installed"
+msgstr ""
+
+#: berkeley/lpq.c:642 berkeley/lpr.c:431 berkeley/lprm.c:232
+#: scheduler/cupsfilter.c:1476 scheduler/main.c:2133 systemv/cancel.c:401
+#: systemv/cupsaccept.c:243 systemv/cupsctl.c:232 systemv/cupstestppd.c:3857
+#: systemv/lp.c:750 systemv/lpadmin.c:1620 systemv/lpinfo.c:497
+#: systemv/lpmove.c:216 systemv/lpoptions.c:538 systemv/lpstat.c:2044
+#: tools/ippeveprinter.c:7664 tools/ippfind.c:2765 tools/ipptool.c:4307
+#: ppdc/ppdc.cxx:426 ppdc/ppdhtml.cxx:173 ppdc/ppdi.cxx:119
+#: ppdc/ppdmerge.cxx:356 ppdc/ppdpo.cxx:243
+msgid "Options:"
+msgstr ""
+
+#: cups/dest-localization.c:169
+msgid "Other Media"
+msgstr ""
+
+#: cups/dest-localization.c:167
+msgid "Other Tray"
+msgstr ""
+
+#: cups/ppd-cache.c:491
+msgid "Out of date PPD cache file."
+msgstr ""
+
+#: cups/ppd-cache.c:1934
+msgid "Out of memory."
+msgstr ""
+
+#: cups/ppd.c:810 cups/ppd.c:1347
+msgid "Output Mode"
+msgstr ""
+
+#: ppdc/sample.c:252
+msgid "PCL Laser Printer"
+msgstr ""
+
+#: ppdc/sample.c:149
+msgid "PRC16K"
+msgstr ""
+
+#: ppdc/sample.c:150
+msgid "PRC16K Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:151
+msgid "PRC32K"
+msgstr ""
+
+#: ppdc/sample.c:154
+msgid "PRC32K Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:152
+msgid "PRC32K Oversize"
+msgstr ""
+
+#: ppdc/sample.c:153
+msgid "PRC32K Oversize Long Edge"
+msgstr ""
+
+#: cups/dest.c:1858
+msgid "PRINTER environment variable names default destination that does not exist."
+msgstr ""
+
+#: cups/snmp.c:968
+msgid "Packet does not contain a Get-Response-PDU"
+msgstr ""
+
+#: cups/snmp.c:947
+msgid "Packet does not start with SEQUENCE"
+msgstr ""
+
+#: ppdc/sample.c:355
+msgid "ParamCustominCutInterval"
+msgstr ""
+
+#: ppdc/sample.c:353
+msgid "ParamCustominTearInterval"
+msgstr ""
+
+#: cups/auth.c:235 cups/auth.c:394
+#, c-format
+msgid "Password for %s on %s? "
+msgstr ""
+
+#: cgi-bin/classes.c:153
+msgid "Pause Class"
+msgstr ""
+
+#: cgi-bin/printers.c:156
+msgid "Pause Printer"
+msgstr ""
+
+#: ppdc/sample.c:443
+msgid "Peel-Off"
+msgstr ""
+
+#: ppdc/sample.c:160
+msgid "Photo"
+msgstr ""
+
+#: ppdc/sample.c:161
+msgid "Photo Labels"
+msgstr ""
+
+#: ppdc/sample.c:281
+msgid "Plain Paper"
+msgstr ""
+
+#: cgi-bin/admin.c:2803 cgi-bin/admin.c:3087
+msgid "Policies"
+msgstr ""
+
+#: cgi-bin/admin.c:2810 cgi-bin/admin.c:3156 cgi-bin/admin.c:3169
+msgid "Port Monitor"
+msgstr ""
+
+#: ppdc/sample.c:270
+msgid "PostScript Printer"
+msgstr ""
+
+#: ppdc/sample.c:147
+msgid "Postcard"
+msgstr ""
+
+#: ppdc/sample.c:71
+msgid "Postcard Double"
+msgstr ""
+
+#: ppdc/sample.c:72
+msgid "Postcard Double Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:148
+msgid "Postcard Long Edge"
+msgstr ""
+
+#: backend/ipp.c:973 backend/ipp.c:981
+msgid "Preparing to print."
+msgstr ""
+
+#: ppdc/sample.c:290
+msgid "Print Density"
+msgstr ""
+
+#: cups/notify.c:69
+msgid "Print Job:"
+msgstr ""
+
+#: ppdc/sample.c:335
+msgid "Print Mode"
+msgstr ""
+
+#: cups/ppd-cache.c:4281 cups/ppd-cache.c:4343 cups/ppd-cache.c:4383
+msgid "Print Quality"
+msgstr ""
+
+#: ppdc/sample.c:378
+msgid "Print Rate"
+msgstr ""
+
+#: cgi-bin/printers.c:165
+msgid "Print Self-Test Page"
+msgstr ""
+
+#: ppdc/sample.c:322
+msgid "Print Speed"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:774
+msgid "Print Test Page"
+msgstr ""
+
+#: ppdc/sample.c:351
+msgid "Print and Cut"
+msgstr ""
+
+#: ppdc/sample.c:339
+msgid "Print and Tear"
+msgstr ""
+
+#: backend/socket.c:406 backend/usb-unix.c:177
+msgid "Print file sent."
+msgstr ""
+
+#: backend/ipp.c:2261
+msgid "Print job canceled at printer."
+msgstr ""
+
+#: backend/ipp.c:2253
+msgid "Print job too large."
+msgstr ""
+
+#: backend/ipp.c:1721
+msgid "Print job was not accepted."
+msgstr ""
+
+#: scheduler/ipp.c:5465
+#, c-format
+msgid "Printer \"%s\" already exists."
+msgstr ""
+
+#: cgi-bin/ipp-var.c:1024
+msgid "Printer Added"
+msgstr ""
+
+#: ppdc/sample.c:255
+msgid "Printer Default"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:1028
+msgid "Printer Deleted"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:1026
+msgid "Printer Modified"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:1022
+msgid "Printer Paused"
+msgstr ""
+
+#: ppdc/sample.c:289
+msgid "Printer Settings"
+msgstr ""
+
+#: backend/ipp.c:2256
+msgid "Printer cannot print supplied content."
+msgstr ""
+
+#: backend/ipp.c:2259
+msgid "Printer cannot print with supplied options."
+msgstr ""
+
+#: cups/ppd-cache.c:4556
+msgid "Printer does not support required IPP attributes or document formats."
+msgstr ""
+
+#: cups/notify.c:113
+msgid "Printer:"
+msgstr ""
+
+#: cgi-bin/printers.c:190 cgi-bin/printers.c:317
+msgid "Printers"
+msgstr ""
+
+#: filter/rastertoepson.c:1107 filter/rastertohp.c:774
+#: filter/rastertolabel.c:1235
+#, c-format
+msgid "Printing page %d, %u%% complete."
+msgstr ""
+
+#: cups/ppd-cache.c:4111
+msgid "Punch"
+msgstr ""
+
+#: ppdc/sample.c:155
+msgid "Quarto"
+msgstr ""
+
+#: scheduler/ipp.c:1505 scheduler/ipp.c:10974
+msgid "Quota limit reached."
+msgstr ""
+
+#: berkeley/lpq.c:495
+msgid "Rank    Owner   Job     File(s)                         Total Size"
+msgstr ""
+
+#: cgi-bin/classes.c:157 cgi-bin/printers.c:160
+msgid "Reject Jobs"
+msgstr ""
+
+#: backend/lpd.c:1074 backend/lpd.c:1206
+#, c-format
+msgid "Remote host did not accept control file (%d)."
+msgstr ""
+
+#: backend/lpd.c:1159
+#, c-format
+msgid "Remote host did not accept data file (%d)."
+msgstr ""
+
+#: ppdc/sample.c:423
+msgid "Reprint After Error"
+msgstr ""
+
+#: cups/http-support.c:1525
+msgid "Request Entity Too Large"
+msgstr ""
+
+#: cups/ppd.c:812 cups/ppd.c:1349 ppdc/sample.c:231
+msgid "Resolution"
+msgstr ""
+
+#: cgi-bin/classes.c:151
+msgid "Resume Class"
+msgstr ""
+
+#: cgi-bin/printers.c:153
+msgid "Resume Printer"
+msgstr ""
+
+#: ppdc/sample.c:165
+msgid "Return Address"
+msgstr ""
+
+#: ppdc/sample.c:444
+msgid "Rewind"
+msgstr ""
+
+#: cups/snmp.c:949
+msgid "SEQUENCE uses indefinite length"
+msgstr ""
+
+#: cups/http-support.c:1549
+msgid "SSL/TLS Negotiation Error"
+msgstr ""
+
+#: cups/http-support.c:1506
+msgid "See Other"
+msgstr ""
+
+#: scheduler/ipp.c:7099 scheduler/ipp.c:7118
+msgid "See remote printer."
+msgstr ""
+
+#: cups/tls-darwin.c:765 cups/tls-gnutls.c:606
+msgid "Self-signed credentials are blocked."
+msgstr ""
+
+#: backend/usb-darwin.c:566 backend/usb-libusb.c:343
+msgid "Sending data to printer."
+msgstr ""
+
+#: cgi-bin/ipp-var.c:1038
+msgid "Server Restarted"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:1044
+msgid "Server Security Auditing"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:1040
+msgid "Server Started"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:1042
+msgid "Server Stopped"
+msgstr ""
+
+#: cups/tls-darwin.c:1275 cups/tls-gnutls.c:1298
+msgid "Server credentials not set."
+msgstr ""
+
+#: cups/http-support.c:1543
+msgid "Service Unavailable"
+msgstr ""
+
+#: cgi-bin/admin.c:2290 cgi-bin/admin.c:2336 cgi-bin/admin.c:2493
+#: cgi-bin/admin.c:2512
+msgid "Set Allowed Users"
+msgstr ""
+
+#: cgi-bin/admin.c:2539
+msgid "Set As Server Default"
+msgstr ""
+
+#: cgi-bin/admin.c:2639
+msgid "Set Class Options"
+msgstr ""
+
+#: cgi-bin/admin.c:2639 cgi-bin/admin.c:2813 cgi-bin/admin.c:3198
+msgid "Set Printer Options"
+msgstr ""
+
+#: cgi-bin/admin.c:3368 cgi-bin/admin.c:3412 cgi-bin/admin.c:3430
+msgid "Set Publishing"
+msgstr ""
+
+#: ppdc/sample.c:166
+msgid "Shipping Address"
+msgstr ""
+
+#: cups/ppd-cache.c:3872 ppdc/sample.c:265
+msgid "Short-Edge (Landscape)"
+msgstr ""
+
+#: ppdc/sample.c:283
+msgid "Special Paper"
+msgstr ""
+
+#: backend/lpd.c:1115
+#, c-format
+msgid "Spooling job, %.0f%% complete."
+msgstr ""
+
+#: ppdc/sample.c:336
+msgid "Standard"
+msgstr ""
+
+#: cups/ppd-cache.c:4011
+msgid "Staple"
+msgstr ""
+
+#. TRANSLATORS: Banner/cover sheet before the print job.
+#: cgi-bin/admin.c:3059
+msgid "Starting Banner"
+msgstr ""
+
+#: filter/rastertoepson.c:1083 filter/rastertohp.c:750
+#: filter/rastertolabel.c:1211
+#, c-format
+msgid "Starting page %d."
+msgstr ""
+
+#: ppdc/sample.c:156
+msgid "Statement"
+msgstr ""
+
+#: scheduler/ipp.c:3591 scheduler/ipp.c:6911 scheduler/ipp.c:7636
+#: scheduler/ipp.c:9160
+#, c-format
+msgid "Subscription #%d does not exist."
+msgstr ""
+
+#: tools/ippfind.c:2812
+msgid "Substitutions:"
+msgstr ""
+
+#: ppdc/sample.c:157
+msgid "Super A"
+msgstr ""
+
+#: ppdc/sample.c:158
+msgid "Super B"
+msgstr ""
+
+#: ppdc/sample.c:162
+msgid "Super B/A3"
+msgstr ""
+
+#: cups/http-support.c:1485
+msgid "Switching Protocols"
+msgstr ""
+
+#: ppdc/sample.c:159
+msgid "Tabloid"
+msgstr ""
+
+#: ppdc/sample.c:45
+msgid "Tabloid Oversize"
+msgstr ""
+
+#: ppdc/sample.c:46
+msgid "Tabloid Oversize Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:337
+msgid "Tear"
+msgstr ""
+
+#: ppdc/sample.c:442
+msgid "Tear-Off"
+msgstr ""
+
+#: ppdc/sample.c:383
+msgid "Tear-Off Adjust Position"
+msgstr ""
+
+#: scheduler/ipp.c:1341
+#, c-format
+msgid "The \"%s\" attribute is required for print jobs."
+msgstr ""
+
+#: scheduler/ipp.c:6572 scheduler/ipp.c:6652 scheduler/ipp.c:6665
+#: scheduler/ipp.c:6677 scheduler/ipp.c:6692
+#, c-format
+msgid "The %s attribute cannot be provided with job-ids."
+msgstr ""
+
+#: scheduler/ipp.c:1320
+#, c-format
+msgid "The '%s' Job Status attribute cannot be supplied in a job creation request."
+msgstr ""
+
+#: scheduler/ipp.c:5194
+#, c-format
+msgid "The '%s' operation attribute cannot be supplied in a Create-Job request."
+msgstr ""
+
+#: scheduler/ipp.c:7141
+#, c-format
+msgid "The PPD file \"%s\" could not be found."
+msgstr ""
+
+#: scheduler/ipp.c:7130
+#, c-format
+msgid "The PPD file \"%s\" could not be opened: %s"
+msgstr ""
+
+#: filter/rastertoepson.c:1052 filter/rastertohp.c:721
+#: filter/rastertolabel.c:1175
+msgid "The PPD file could not be opened."
+msgstr ""
+
+#: cgi-bin/admin.c:515
+msgid "The class name may only contain up to 127 printable characters and may not contain spaces, slashes (/), or the pound sign (#)."
+msgstr ""
+
+#: scheduler/ipp.c:2097
+msgid "The notify-lease-duration attribute cannot be used with job subscriptions."
+msgstr ""
+
+#: scheduler/ipp.c:2080 scheduler/ipp.c:5804
+#, c-format
+msgid "The notify-user-data value is too large (%d > 63 octets)."
+msgstr ""
+
+#: backend/ipp.c:993
+msgid "The printer configuration is incorrect or the printer no longer exists."
+msgstr ""
+
+#: backend/lpd.c:678 backend/lpd.c:1067 backend/lpd.c:1149 backend/lpd.c:1199
+msgid "The printer did not respond."
+msgstr ""
+
+#: backend/ipp.c:766 backend/ipp.c:956 backend/ipp.c:1070 backend/ipp.c:1523
+#: backend/ipp.c:1693 backend/lpd.c:886 backend/socket.c:354
+#: backend/usb-unix.c:117 backend/usb-unix.c:407 backend/usb-unix.c:490
+msgid "The printer is in use."
+msgstr ""
+
+#: backend/runloop.c:236 backend/runloop.c:356
+msgid "The printer is not connected."
+msgstr ""
+
+#: backend/ipp.c:744 backend/ipp.c:777 backend/ipp.c:952 backend/lpd.c:865
+#: backend/lpd.c:906 backend/socket.c:333 backend/socket.c:366
+msgid "The printer is not responding."
+msgstr ""
+
+#: backend/runloop.c:378
+msgid "The printer is now connected."
+msgstr ""
+
+#: backend/usb-darwin.c:1342
+msgid "The printer is now online."
+msgstr ""
+
+#: backend/usb-darwin.c:1381
+msgid "The printer is offline."
+msgstr ""
+
+#: backend/ipp.c:760 backend/lpd.c:880 backend/socket.c:348
+msgid "The printer is unreachable at this time."
+msgstr ""
+
+#: backend/ipp.c:753 backend/lpd.c:873 backend/socket.c:341
+msgid "The printer may not exist or is unavailable at this time."
+msgstr ""
+
+#: cgi-bin/admin.c:698
+msgid "The printer name may only contain up to 127 printable characters and may not contain spaces, slashes (/ \\), quotes (' \"), question mark (?), or the pound sign (#)."
+msgstr ""
+
+#: scheduler/ipp.c:762 scheduler/ipp.c:1047 scheduler/ipp.c:3230
+#: scheduler/ipp.c:3411 scheduler/ipp.c:5177 scheduler/ipp.c:5638
+#: scheduler/ipp.c:5972 scheduler/ipp.c:6538 scheduler/ipp.c:7345
+#: scheduler/ipp.c:7401 scheduler/ipp.c:7742 scheduler/ipp.c:8017
+#: scheduler/ipp.c:8106 scheduler/ipp.c:8139 scheduler/ipp.c:8463
+#: scheduler/ipp.c:8870 scheduler/ipp.c:8952 scheduler/ipp.c:10122
+#: scheduler/ipp.c:10584 scheduler/ipp.c:10937 scheduler/ipp.c:11019
+#: scheduler/ipp.c:11348
+msgid "The printer or class does not exist."
+msgstr ""
+
+#: scheduler/ipp.c:1259
+msgid "The printer or class is not shared."
+msgstr ""
+
+#: scheduler/ipp.c:868 scheduler/ipp.c:2261
+#, c-format
+msgid "The printer-uri \"%s\" contains invalid characters."
+msgstr ""
+
+#: scheduler/ipp.c:3207
+msgid "The printer-uri attribute is required."
+msgstr ""
+
+#: scheduler/ipp.c:852
+msgid "The printer-uri must be of the form \"ipp://HOSTNAME/classes/CLASSNAME\"."
+msgstr ""
+
+#: scheduler/ipp.c:2245
+msgid "The printer-uri must be of the form \"ipp://HOSTNAME/printers/PRINTERNAME\"."
+msgstr ""
+
+#: scheduler/client.c:2003
+msgid "The web interface is currently disabled. Run \"cupsctl WebInterface=yes\" to enable it."
+msgstr ""
+
+#: scheduler/ipp.c:6636
+#, c-format
+msgid "The which-jobs value \"%s\" is not supported."
+msgstr ""
+
+#: scheduler/ipp.c:5901
+msgid "There are too many subscriptions."
+msgstr ""
+
+#: backend/usb-darwin.c:398 backend/usb-darwin.c:464 backend/usb-darwin.c:528
+#: backend/usb-darwin.c:549 backend/usb-libusb.c:268 backend/usb-libusb.c:322
+msgid "There was an unrecoverable USB error."
+msgstr ""
+
+#: ppdc/sample.c:430
+msgid "Thermal Transfer Media"
+msgstr ""
+
+#: scheduler/ipp.c:1499
+msgid "Too many active jobs."
+msgstr ""
+
+#: scheduler/ipp.c:1393
+#, c-format
+msgid "Too many job-sheets values (%d > 2)."
+msgstr ""
+
+#: scheduler/ipp.c:2574
+#, c-format
+msgid "Too many printer-state-reasons values (%d > %d)."
+msgstr ""
+
+#: ppdc/sample.c:284
+msgid "Transparency"
+msgstr ""
+
+#: ppdc/sample.c:279
+msgid "Tray"
+msgstr ""
+
+#: ppdc/sample.c:256
+msgid "Tray 1"
+msgstr ""
+
+#: ppdc/sample.c:257
+msgid "Tray 2"
+msgstr ""
+
+#: ppdc/sample.c:258
+msgid "Tray 3"
+msgstr ""
+
+#: ppdc/sample.c:259
+msgid "Tray 4"
+msgstr ""
+
+#: cups/tls-darwin.c:670 cups/tls-darwin.c:752 cups/tls-gnutls.c:504
+#: cups/tls-gnutls.c:586
+msgid "Trust on first use is disabled."
+msgstr ""
+
+#: cups/http-support.c:1528
+msgid "URI Too Long"
+msgstr ""
+
+#: cups/http-support.c:1603
+msgid "URI too large"
+msgstr ""
+
+#: ppdc/sample.c:124
+msgid "US Fanfold"
+msgstr ""
+
+#: ppdc/sample.c:138
+msgid "US Ledger"
+msgstr ""
+
+#: ppdc/sample.c:139
+msgid "US Legal"
+msgstr ""
+
+#: ppdc/sample.c:140
+msgid "US Legal Oversize"
+msgstr ""
+
+#: ppdc/sample.c:141
+msgid "US Letter"
+msgstr ""
+
+#: ppdc/sample.c:142
+msgid "US Letter Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:143
+msgid "US Letter Oversize"
+msgstr ""
+
+#: ppdc/sample.c:144
+msgid "US Letter Oversize Long Edge"
+msgstr ""
+
+#: ppdc/sample.c:145
+msgid "US Letter Small"
+msgstr ""
+
+#: cgi-bin/admin.c:1651 cgi-bin/admin.c:1664 cgi-bin/admin.c:1688
+msgid "Unable to access cupsd.conf file"
+msgstr ""
+
+#: cgi-bin/help.c:123
+msgid "Unable to access help file."
+msgstr ""
+
+#: cgi-bin/admin.c:580
+msgid "Unable to add class"
+msgstr ""
+
+#: backend/ipp.c:1880
+msgid "Unable to add document to print job."
+msgstr ""
+
+#: scheduler/ipp.c:1574
+#, c-format
+msgid "Unable to add job for destination \"%s\"."
+msgstr ""
+
+#: cgi-bin/admin.c:823 cgi-bin/admin.c:1193
+msgid "Unable to add printer"
+msgstr ""
+
+#: scheduler/ipp.c:1177
+msgid "Unable to allocate memory for file types."
+msgstr ""
+
+#: filter/pstops.c:415
+msgid "Unable to allocate memory for page info"
+msgstr ""
+
+#: filter/pstops.c:409
+msgid "Unable to allocate memory for pages array"
+msgstr ""
+
+#: tools/ippeveprinter.c:1486
+msgid "Unable to allocate memory for printer"
+msgstr ""
+
+#: backend/ipp.c:2165 backend/ipp.c:2696
+msgid "Unable to cancel print job."
+msgstr ""
+
+#: cgi-bin/admin.c:2494
+msgid "Unable to change printer"
+msgstr ""
+
+#: cgi-bin/admin.c:3413
+msgid "Unable to change printer-is-shared attribute"
+msgstr ""
+
+#: cgi-bin/admin.c:1349 cgi-bin/admin.c:1491
+msgid "Unable to change server settings"
+msgstr ""
+
+#: cups/ipp.c:5179
+#, c-format
+msgid "Unable to compile mimeMediaType regular expression: %s."
+msgstr ""
+
+#: cups/ipp.c:5134
+#, c-format
+msgid "Unable to compile naturalLanguage regular expression: %s."
+msgstr ""
+
+#: filter/commandtops.c:401
+msgid "Unable to configure printer options."
+msgstr ""
+
+#: cups/adminutil.c:158 cups/request.c:1057
+msgid "Unable to connect to host."
+msgstr ""
+
+#: backend/ipp.c:723 backend/ipp.c:1275 backend/lpd.c:846 backend/socket.c:314
+#: backend/usb-unix.c:103
+msgid "Unable to contact printer, queuing on next printer in class."
+msgstr ""
+
+#: scheduler/ipp.c:2676
+#, c-format
+msgid "Unable to copy PPD file - %s"
+msgstr ""
+
+#: scheduler/ipp.c:2721
+msgid "Unable to copy PPD file."
+msgstr ""
+
+#: cups/tls-darwin.c:636 cups/tls-gnutls.c:467
+msgid "Unable to create credentials from array."
+msgstr ""
+
+#: cups/ppd-util.c:573 cups/util.c:478
+msgid "Unable to create printer-uri"
+msgstr ""
+
+#: scheduler/ipp.c:5475
+msgid "Unable to create printer."
+msgstr ""
+
+#: cups/tls-darwin.c:1566 cups/tls-gnutls.c:1510
+msgid "Unable to create server credentials."
+msgstr ""
+
+#: tools/ippeveprinter.c:626
+#, c-format
+msgid "Unable to create spool directory \"%s\": %s"
+msgstr ""
+
+#: cgi-bin/admin.c:1542 cgi-bin/admin.c:1554 scheduler/cupsfilter.c:1284
+msgid "Unable to create temporary file"
+msgstr ""
+
+#: cgi-bin/admin.c:1845
+msgid "Unable to delete class"
+msgstr ""
+
+#: cgi-bin/admin.c:1930
+msgid "Unable to delete printer"
+msgstr ""
+
+#: cgi-bin/classes.c:246 cgi-bin/printers.c:255
+msgid "Unable to do maintenance command"
+msgstr ""
+
+#: cgi-bin/admin.c:1666
+msgid "Unable to edit cupsd.conf files larger than 1MB"
+msgstr ""
+
+#: cups/tls-darwin.c:1793
+#, c-format
+msgid "Unable to establish a secure connection to host (%d)."
+msgstr ""
+
+#: cups/tls-darwin.c:1754
+msgid "Unable to establish a secure connection to host (certificate chain invalid)."
+msgstr ""
+
+#: cups/tls-darwin.c:1744
+msgid "Unable to establish a secure connection to host (certificate not yet valid)."
+msgstr ""
+
+#: cups/tls-darwin.c:1739
+msgid "Unable to establish a secure connection to host (expired certificate)."
+msgstr ""
+
+#: cups/tls-darwin.c:1749
+msgid "Unable to establish a secure connection to host (host name mismatch)."
+msgstr ""
+
+#: cups/tls-darwin.c:1759
+msgid "Unable to establish a secure connection to host (peer dropped connection before responding)."
+msgstr ""
+
+#: cups/tls-darwin.c:1734
+msgid "Unable to establish a secure connection to host (self-signed certificate)."
+msgstr ""
+
+#: cups/tls-darwin.c:1729
+msgid "Unable to establish a secure connection to host (untrusted certificate)."
+msgstr ""
+
+#: cups/tls-sspi.c:1277 cups/tls-sspi.c:1294
+msgid "Unable to establish a secure connection to host."
+msgstr ""
+
+#: tools/ippeveprinter.c:1461 tools/ippeveprinter.c:1471
+#, c-format
+msgid "Unable to execute command \"%s\": %s"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:347
+msgid "Unable to find destination for job"
+msgstr ""
+
+#: cups/http-support.c:2094
+msgid "Unable to find printer."
+msgstr ""
+
+#: cups/tls-darwin.c:1579
+msgid "Unable to find server credentials."
+msgstr ""
+
+#: backend/ipp.c:3359
+msgid "Unable to get backend exit status."
+msgstr ""
+
+#: cgi-bin/classes.c:426
+msgid "Unable to get class list"
+msgstr ""
+
+#: cgi-bin/classes.c:525
+msgid "Unable to get class status"
+msgstr ""
+
+#: cgi-bin/admin.c:1087
+msgid "Unable to get list of printer drivers"
+msgstr ""
+
+#: cgi-bin/admin.c:2344
+msgid "Unable to get printer attributes"
+msgstr ""
+
+#: cgi-bin/printers.c:443
+msgid "Unable to get printer list"
+msgstr ""
+
+#: cgi-bin/printers.c:545
+msgid "Unable to get printer status"
+msgstr ""
+
+#: backend/ipp.c:1017
+msgid "Unable to get printer status."
+msgstr ""
+
+#: cgi-bin/help.c:82
+msgid "Unable to load help index."
+msgstr ""
+
+#: backend/network.c:69
+#, c-format
+msgid "Unable to locate printer \"%s\"."
+msgstr ""
+
+#: backend/dnssd.c:752 backend/ipp.c:336 backend/lpd.c:181
+#: backend/socket.c:155
+msgid "Unable to locate printer."
+msgstr ""
+
+#: cgi-bin/admin.c:579
+msgid "Unable to modify class"
+msgstr ""
+
+#: cgi-bin/admin.c:822 cgi-bin/admin.c:1192
+msgid "Unable to modify printer"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:414 cgi-bin/ipp-var.c:503
+msgid "Unable to move job"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:416 cgi-bin/ipp-var.c:505
+msgid "Unable to move jobs"
+msgstr ""
+
+#: cgi-bin/admin.c:2690 cups/ppd.c:284
+msgid "Unable to open PPD file"
+msgstr ""
+
+#: cgi-bin/admin.c:2161
+msgid "Unable to open cupsd.conf file:"
+msgstr ""
+
+#: backend/usb-unix.c:127
+msgid "Unable to open device file"
+msgstr ""
+
+#: scheduler/ipp.c:6315
+#, c-format
+msgid "Unable to open document #%d in job #%d."
+msgstr ""
+
+#: cgi-bin/help.c:356
+msgid "Unable to open help file."
+msgstr ""
+
+#: backend/ipp.c:377 backend/ipp.c:1620 backend/ipp.c:1833 backend/lpd.c:469
+#: backend/socket.c:142 backend/usb.c:224 filter/gziptoany.c:65
+#: filter/pstops.c:262
+msgid "Unable to open print file"
+msgstr ""
+
+#: filter/rastertoepson.c:1012 filter/rastertohp.c:681
+#: filter/rastertolabel.c:1133
+msgid "Unable to open raster file"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:777
+msgid "Unable to print test page"
+msgstr ""
+
+#: backend/runloop.c:78 backend/runloop.c:307 backend/usb-darwin.c:636
+#: backend/usb-darwin.c:680 backend/usb-libusb.c:413 backend/usb-libusb.c:448
+msgid "Unable to read print data."
+msgstr ""
+
+#: tools/ippeveprinter.c:6613 tools/ippeveprinter.c:6631
+#: tools/ippeveprinter.c:6650 tools/ippeveprinter.c:6664
+#, c-format
+msgid "Unable to register \"%s.%s\": %d"
+msgstr ""
+
+#: scheduler/ipp.c:8622 scheduler/ipp.c:9865
+msgid "Unable to rename job document file."
+msgstr ""
+
+#: cups/dest.c:3265
+msgid "Unable to resolve printer-uri."
+msgstr ""
+
+#: filter/pstops.c:527
+msgid "Unable to see in file"
+msgstr ""
+
+#: cgi-bin/ipp-var.c:580 cgi-bin/ipp-var.c:600
+msgid "Unable to send command to printer driver"
+msgstr ""
+
+#: backend/usb-darwin.c:758 backend/usb-libusb.c:524
+msgid "Unable to send data to printer."
+msgstr ""
+
+#: cgi-bin/admin.c:3314
+msgid "Unable to set options"
+msgstr ""
+
+#: cgi-bin/admin.c:2581
+msgid "Unable to set server default"
+msgstr ""
+
+#: backend/ipp.c:3218 backend/ipp.c:3295 backend/ipp.c:3303
+msgid "Unable to start backend process."
+msgstr ""
+
+#: cgi-bin/admin.c:1604
+msgid "Unable to upload cupsd.conf file"
+msgstr ""
+
+#: backend/usb-darwin.c:2148 backend/usb-darwin.c:2172
+msgid "Unable to use legacy USB class driver."
+msgstr ""
+
+#: backend/runloop.c:107 backend/runloop.c:362
+msgid "Unable to write print data"
+msgstr ""
+
+#: filter/gziptoany.c:84
+#, c-format
+msgid "Unable to write uncompressed print data: %s"
+msgstr ""
+
+#: cups/http-support.c:1516
+msgid "Unauthorized"
+msgstr ""
+
+#: cgi-bin/admin.c:3010
+msgid "Units"
+msgstr ""
+
+#: cups/http-support.c:1556 cups/http-support.c:1640 cups/ppd.c:313
+msgid "Unknown"
+msgstr ""
+
+#: filter/pstops.c:2182
+#, c-format
+msgid "Unknown choice \"%s\" for option \"%s\"."
+msgstr ""
+
+#: tools/ippeveprinter.c:3848
+#, c-format
+msgid "Unknown directive \"%s\" on line %d of \"%s\" ignored."
+msgstr ""
+
+#: backend/ipp.c:519
+#, c-format
+msgid "Unknown encryption option value: \"%s\"."
+msgstr ""
+
+#: backend/lpd.c:327
+#, c-format
+msgid "Unknown file order: \"%s\"."
+msgstr ""
+
+#: backend/lpd.c:298
+#, c-format
+msgid "Unknown format character: \"%c\"."
+msgstr ""
+
+#: cups/hash.c:278
+msgid "Unknown hash algorithm."
+msgstr ""
+
+#: cups/dest-options.c:1157
+msgid "Unknown media size name."
+msgstr ""
+
+#: backend/ipp.c:583
+#, c-format
+msgid "Unknown option \"%s\" with value \"%s\"."
+msgstr ""
+
+#: filter/pstops.c:2165
+#, c-format
+msgid "Unknown option \"%s\"."
+msgstr ""
+
+#: backend/lpd.c:313
+#, c-format
+msgid "Unknown print mode: \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:10806
+#, c-format
+msgid "Unknown printer-error-policy \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:10789
+#, c-format
+msgid "Unknown printer-op-policy \"%s\"."
+msgstr ""
+
+#: cups/http.c:2266
+msgid "Unknown request method."
+msgstr ""
+
+#: cups/http.c:2286
+msgid "Unknown request version."
+msgstr ""
+
+#: cups/http-support.c:1633
+msgid "Unknown scheme in URI"
+msgstr ""
+
+#: cups/http-addrlist.c:824
+msgid "Unknown service name."
+msgstr ""
+
+#: backend/ipp.c:548
+#, c-format
+msgid "Unknown version option value: \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:11265
+#, c-format
+msgid "Unsupported 'compression' value \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:11295
+#, c-format
+msgid "Unsupported 'document-format' value \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:7969 scheduler/ipp.c:10348 scheduler/ipp.c:11309
+msgid "Unsupported 'job-hold-until' value."
+msgstr ""
+
+#: scheduler/ipp.c:11325
+msgid "Unsupported 'job-name' value."
+msgstr ""
+
+#: scheduler/ipp.c:298
+#, c-format
+msgid "Unsupported character set \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:8429 scheduler/ipp.c:9677
+#, c-format
+msgid "Unsupported compression \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:8565 scheduler/ipp.c:9830
+#, c-format
+msgid "Unsupported document-format \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:9813
+#, c-format
+msgid "Unsupported document-format \"%s/%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:1359
+#, c-format
+msgid "Unsupported format \"%s\"."
+msgstr ""
+
+#: scheduler/ipp.c:1457
+msgid "Unsupported margins."
+msgstr ""
+
+#: cups/pwg-media.c:541
+msgid "Unsupported media value."
+msgstr ""
+
+#: filter/pstops.c:2447
+#, c-format
+msgid "Unsupported number-up value %d, using number-up=1."
+msgstr ""
+
+#: filter/pstops.c:2481
+#, c-format
+msgid "Unsupported number-up-layout value %s, using number-up-layout=lrtb."
+msgstr ""
+
+#: filter/pstops.c:2532
+#, c-format
+msgid "Unsupported page-border value %s, using page-border=none."
+msgstr ""
+
+#: filter/rastertopwg.c:132 filter/rastertopwg.c:168 filter/rastertopwg.c:176
+#: filter/rastertopwg.c:185
+msgid "Unsupported raster data."
+msgstr ""
+
+#: cups/snmp.c:1066
+msgid "Unsupported value type"
+msgstr ""
+
+#: cups/http-support.c:1531
+msgid "Upgrade Required"
+msgstr ""
+
+#: systemv/cupsaccept.c:242
+#, c-format
+msgid "Usage: %s [options] destination(s)"
+msgstr ""
+
+#: backend/dnssd.c:192 backend/ipp.c:325 backend/lpd.c:168
+#: backend/socket.c:119 backend/usb.c:170 filter/commandtops.c:57
+#: filter/gziptoany.c:38 filter/pstops.c:223 monitor/bcp.c:48
+#: monitor/tbcp.c:47
+#, c-format
+msgid "Usage: %s job-id user title copies options [file]"
+msgstr ""
+
+#: systemv/cancel.c:398
+msgid ""
+"Usage: cancel [options] [id]\n"
+"       cancel [options] [destination]\n"
+"       cancel [options] [destination-id]"
+msgstr ""
+
+#: systemv/cupsctl.c:231
+msgid "Usage: cupsctl [options] [param=value ... paramN=valueN]"
+msgstr ""
+
+#: scheduler/main.c:2132
+msgid "Usage: cupsd [options]"
+msgstr ""
+
+#: scheduler/cupsfilter.c:1475
+msgid "Usage: cupsfilter [ options ] [ -- ] filename"
+msgstr ""
+
+#: systemv/cupstestppd.c:3855
+msgid ""
+"Usage: cupstestppd [options] filename1.ppd[.gz] [... filenameN.ppd[.gz]]\n"
+"       program | cupstestppd [options] -"
+msgstr ""
+
+#: tools/ippeveprinter.c:7663
+msgid "Usage: ippeveprinter [options] \"name\""
+msgstr ""
+
+#: tools/ippfind.c:2759
+msgid ""
+"Usage: ippfind [options] regtype[,subtype][.domain.] ... [expression]\n"
+"       ippfind [options] name[.regtype[.domain.]] ... [expression]\n"
+"       ippfind --help\n"
+"       ippfind --version"
+msgstr ""
+
+#: tools/ipptool.c:4306
+msgid "Usage: ipptool [options] URI filename [ ... filenameN ]"
+msgstr ""
+
+#: systemv/lp.c:748
+msgid ""
+"Usage: lp [options] [--] [file(s)]\n"
+"       lp [options] -i id"
+msgstr ""
+
+#: systemv/lpadmin.c:1615
+msgid ""
+"Usage: lpadmin [options] -d destination\n"
+"       lpadmin [options] -p destination\n"
+"       lpadmin [options] -p destination -c class\n"
+"       lpadmin [options] -p destination -r class\n"
+"       lpadmin [options] -x destination"
+msgstr ""
+
+#: systemv/lpinfo.c:495
+msgid ""
+"Usage: lpinfo [options] -m\n"
+"       lpinfo [options] -v"
+msgstr ""
+
+#: systemv/lpmove.c:214
+msgid ""
+"Usage: lpmove [options] job destination\n"
+"       lpmove [options] source-destination destination"
+msgstr ""
+
+#: systemv/lpoptions.c:534
+msgid ""
+"Usage: lpoptions [options] -d destination\n"
+"       lpoptions [options] [-p destination] [-l]\n"
+"       lpoptions [options] [-p destination] -o option[=value]\n"
+"       lpoptions [options] -x destination"
+msgstr ""
+
+#: berkeley/lpq.c:641
+msgid "Usage: lpq [options] [+interval]"
+msgstr ""
+
+#: berkeley/lpr.c:430
+msgid "Usage: lpr [options] [file(s)]"
+msgstr ""
+
+#: berkeley/lprm.c:230
+msgid ""
+"Usage: lprm [options] [id]\n"
+"       lprm [options] -"
+msgstr ""
+
+#: systemv/lpstat.c:2043
+msgid "Usage: lpstat [options]"
+msgstr ""
+
+#: ppdc/ppdc.cxx:424
+msgid "Usage: ppdc [options] filename.drv [ ... filenameN.drv ]"
+msgstr ""
+
+#: ppdc/ppdhtml.cxx:171
+msgid "Usage: ppdhtml [options] filename.drv >filename.html"
+msgstr ""
+
+#: ppdc/ppdi.cxx:117
+msgid "Usage: ppdi [options] filename.ppd [ ... filenameN.ppd ]"
+msgstr ""
+
+#: ppdc/ppdmerge.cxx:354
+msgid "Usage: ppdmerge [options] filename.ppd [ ... filenameN.ppd ]"
+msgstr ""
+
+#: ppdc/ppdpo.cxx:241
+msgid "Usage: ppdpo [options] -o filename.po filename.drv [ ... filenameN.drv ]"
+msgstr ""
+
+#: backend/snmp.c:185
+msgid "Usage: snmp [host-or-ip-address]"
+msgstr ""
+
+#: tools/ippeveprinter.c:631
+#, c-format
+msgid "Using spool directory \"%s\"."
+msgstr ""
+
+#: cups/snmp.c:1018
+msgid "Value uses indefinite length"
+msgstr ""
+
+#: cups/snmp.c:1003
+msgid "VarBind uses indefinite length"
+msgstr ""
+
+#: cups/snmp.c:953
+msgid "Version uses indefinite length"
+msgstr ""
+
+#: backend/ipp.c:2000
+msgid "Waiting for job to complete."
+msgstr ""
+
+#: backend/usb-darwin.c:429 backend/usb-darwin.c:483 backend/usb-libusb.c:220
+msgid "Waiting for printer to become available."
+msgstr ""
+
+#: backend/socket.c:417
+msgid "Waiting for printer to finish."
+msgstr ""
+
+#: systemv/cupstestppd.c:3854
+msgid "Warning: This program will be removed in a future version of CUPS."
+msgstr ""
+
+#: cups/http-support.c:1552
+msgid "Web Interface is Disabled"
+msgstr ""
+
+#: cups/ppd.c:1972
+msgid "Yes"
+msgstr ""
+
+#: scheduler/client.c:1991
+msgid "You cannot access this page."
+msgstr ""
+
+#: scheduler/client.c:1997
+#, c-format
+msgid "You must access this page using the URL https://%s:%d%s."
+msgstr ""
+
+#: scheduler/client.c:1989
+msgid "Your account does not have the necessary privileges."
+msgstr ""
+
+#: ppdc/sample.c:434
+msgid "ZPL Label Printer"
+msgstr ""
+
+#: ppdc/sample.c:357
+msgid "Zebra"
+msgstr ""
+
+#: cups/notify.c:89
+msgid "aborted"
+msgstr ""
+
+#. TRANSLATORS: Accuracy Units
+#: locale/ipp-strings.c:2
+msgid "accuracy-units"
+msgstr ""
+
+#. TRANSLATORS: Millimeters
+#: locale/ipp-strings.c:4
+msgid "accuracy-units.mm"
+msgstr ""
+
+#. TRANSLATORS: Nanometers
+#: locale/ipp-strings.c:6
+msgid "accuracy-units.nm"
+msgstr ""
+
+#. TRANSLATORS: Micrometers
+#: locale/ipp-strings.c:8
+msgid "accuracy-units.um"
+msgstr ""
+
+#. TRANSLATORS: Bale Output
+#: locale/ipp-strings.c:10
+msgid "baling"
+msgstr ""
+
+#. TRANSLATORS: Bale Using
+#: locale/ipp-strings.c:12
+msgid "baling-type"
+msgstr ""
+
+#. TRANSLATORS: Band
+#: locale/ipp-strings.c:14
+msgid "baling-type.band"
+msgstr ""
+
+#. TRANSLATORS: Shrink Wrap
+#: locale/ipp-strings.c:16
+msgid "baling-type.shrink-wrap"
+msgstr ""
+
+#. TRANSLATORS: Wrap
+#: locale/ipp-strings.c:18
+msgid "baling-type.wrap"
+msgstr ""
+
+#. TRANSLATORS: Bale After
+#: locale/ipp-strings.c:20
+msgid "baling-when"
+msgstr ""
+
+#. TRANSLATORS: Job
+#: locale/ipp-strings.c:22
+msgid "baling-when.after-job"
+msgstr ""
+
+#. TRANSLATORS: Sets
+#: locale/ipp-strings.c:24
+msgid "baling-when.after-sets"
+msgstr ""
+
+#. TRANSLATORS: Bind Output
+#: locale/ipp-strings.c:26
+msgid "binding"
+msgstr ""
+
+#. TRANSLATORS: Bind Edge
+#: locale/ipp-strings.c:28
+msgid "binding-reference-edge"
+msgstr ""
+
+#. TRANSLATORS: Bottom
+#: locale/ipp-strings.c:30
+msgid "binding-reference-edge.bottom"
+msgstr ""
+
+#. TRANSLATORS: Left
+#: locale/ipp-strings.c:32
+msgid "binding-reference-edge.left"
+msgstr ""
+
+#. TRANSLATORS: Right
+#: locale/ipp-strings.c:34
+msgid "binding-reference-edge.right"
+msgstr ""
+
+#. TRANSLATORS: Top
+#: locale/ipp-strings.c:36
+msgid "binding-reference-edge.top"
+msgstr ""
+
+#. TRANSLATORS: Binder Type
+#: locale/ipp-strings.c:38
+msgid "binding-type"
+msgstr ""
+
+#. TRANSLATORS: Adhesive
+#: locale/ipp-strings.c:40
+msgid "binding-type.adhesive"
+msgstr ""
+
+#. TRANSLATORS: Comb
+#: locale/ipp-strings.c:42
+msgid "binding-type.comb"
+msgstr ""
+
+#. TRANSLATORS: Flat
+#: locale/ipp-strings.c:44
+msgid "binding-type.flat"
+msgstr ""
+
+#. TRANSLATORS: Padding
+#: locale/ipp-strings.c:46
+msgid "binding-type.padding"
+msgstr ""
+
+#. TRANSLATORS: Perfect
+#: locale/ipp-strings.c:48
+msgid "binding-type.perfect"
+msgstr ""
+
+#. TRANSLATORS: Spiral
+#: locale/ipp-strings.c:50
+msgid "binding-type.spiral"
+msgstr ""
+
+#. TRANSLATORS: Tape
+#: locale/ipp-strings.c:52
+msgid "binding-type.tape"
+msgstr ""
+
+#. TRANSLATORS: Velo
+#: locale/ipp-strings.c:54
+msgid "binding-type.velo"
+msgstr ""
+
+#: cups/notify.c:86
+msgid "canceled"
+msgstr ""
+
+#. TRANSLATORS: Chamber Humidity
+#: locale/ipp-strings.c:56
+msgid "chamber-humidity"
+msgstr ""
+
+#. TRANSLATORS: Chamber Temperature
+#: locale/ipp-strings.c:58
+msgid "chamber-temperature"
+msgstr ""
+
+#. TRANSLATORS: Print Job Cost
+#: locale/ipp-strings.c:60
+msgid "charge-info-message"
+msgstr ""
+
+#. TRANSLATORS: Coat Sheets
+#: locale/ipp-strings.c:62
+msgid "coating"
+msgstr ""
+
+#. TRANSLATORS: Add Coating To
+#: locale/ipp-strings.c:64
+msgid "coating-sides"
+msgstr ""
+
+#. TRANSLATORS: Back
+#: locale/ipp-strings.c:66
+msgid "coating-sides.back"
+msgstr ""
+
+#. TRANSLATORS: Front and Back
+#: locale/ipp-strings.c:68
+msgid "coating-sides.both"
+msgstr ""
+
+#. TRANSLATORS: Front
+#: locale/ipp-strings.c:70
+msgid "coating-sides.front"
+msgstr ""
+
+#. TRANSLATORS: Type of Coating
+#: locale/ipp-strings.c:72
+msgid "coating-type"
+msgstr ""
+
+#. TRANSLATORS: Archival
+#: locale/ipp-strings.c:74
+msgid "coating-type.archival"
+msgstr ""
+
+#. TRANSLATORS: Archival Glossy
+#: locale/ipp-strings.c:76
+msgid "coating-type.archival-glossy"
+msgstr ""
+
+#. TRANSLATORS: Archival Matte
+#: locale/ipp-strings.c:78
+msgid "coating-type.archival-matte"
+msgstr ""
+
+#. TRANSLATORS: Archival Semi Gloss
+#: locale/ipp-strings.c:80
+msgid "coating-type.archival-semi-gloss"
+msgstr ""
+
+#. TRANSLATORS: Glossy
+#: locale/ipp-strings.c:82
+msgid "coating-type.glossy"
+msgstr ""
+
+#. TRANSLATORS: High Gloss
+#: locale/ipp-strings.c:84
+msgid "coating-type.high-gloss"
+msgstr ""
+
+#. TRANSLATORS: Matte
+#: locale/ipp-strings.c:86
+msgid "coating-type.matte"
+msgstr ""
+
+#. TRANSLATORS: Semi-gloss
+#: locale/ipp-strings.c:88
+msgid "coating-type.semi-gloss"
+msgstr ""
+
+#. TRANSLATORS: Silicone
+#: locale/ipp-strings.c:90
+msgid "coating-type.silicone"
+msgstr ""
+
+#. TRANSLATORS: Translucent
+#: locale/ipp-strings.c:92
+msgid "coating-type.translucent"
+msgstr ""
+
+#: cups/notify.c:92
+msgid "completed"
+msgstr ""
+
+#. TRANSLATORS: Print Confirmation Sheet
+#: locale/ipp-strings.c:94
+msgid "confirmation-sheet-print"
+msgstr ""
+
+#. TRANSLATORS: Copies
+#: locale/ipp-strings.c:96
+msgid "copies"
+msgstr ""
+
+#. TRANSLATORS: Back Cover
+#: locale/ipp-strings.c:98
+msgid "cover-back"
+msgstr ""
+
+#. TRANSLATORS: Front Cover
+#: locale/ipp-strings.c:100
+msgid "cover-front"
+msgstr ""
+
+#. TRANSLATORS: Cover Sheet Info
+#: locale/ipp-strings.c:102
+msgid "cover-sheet-info"
+msgstr ""
+
+#. TRANSLATORS: Date Time
+#: locale/ipp-strings.c:104
+msgid "cover-sheet-info-supported.date-time"
+msgstr ""
+
+#. TRANSLATORS: From Name
+#: locale/ipp-strings.c:106
+msgid "cover-sheet-info-supported.from-name"
+msgstr ""
+
+#. TRANSLATORS: Logo
+#: locale/ipp-strings.c:108
+msgid "cover-sheet-info-supported.logo"
+msgstr ""
+
+#. TRANSLATORS: Message
+#: locale/ipp-strings.c:110
+msgid "cover-sheet-info-supported.message"
+msgstr ""
+
+#. TRANSLATORS: Organization
+#: locale/ipp-strings.c:112
+msgid "cover-sheet-info-supported.organization"
+msgstr ""
+
+#. TRANSLATORS: Subject
+#: locale/ipp-strings.c:114
+msgid "cover-sheet-info-supported.subject"
+msgstr ""
+
+#. TRANSLATORS: To Name
+#: locale/ipp-strings.c:116
+msgid "cover-sheet-info-supported.to-name"
+msgstr ""
+
+#. TRANSLATORS: Printed Cover
+#: locale/ipp-strings.c:118
+msgid "cover-type"
+msgstr ""
+
+#. TRANSLATORS: No Cover
+#: locale/ipp-strings.c:120
+msgid "cover-type.no-cover"
+msgstr ""
+
+#. TRANSLATORS: Back Only
+#: locale/ipp-strings.c:122
+msgid "cover-type.print-back"
+msgstr ""
+
+#. TRANSLATORS: Front and Back
+#: locale/ipp-strings.c:124
+msgid "cover-type.print-both"
+msgstr ""
+
+#. TRANSLATORS: Front Only
+#: locale/ipp-strings.c:126
+msgid "cover-type.print-front"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:128
+msgid "cover-type.print-none"
+msgstr ""
+
+#. TRANSLATORS: Cover Output
+#: locale/ipp-strings.c:130
+msgid "covering"
+msgstr ""
+
+#. TRANSLATORS: Add Cover
+#: locale/ipp-strings.c:132
+msgid "covering-name"
+msgstr ""
+
+#. TRANSLATORS: Plain
+#: locale/ipp-strings.c:134
+msgid "covering-name.plain"
+msgstr ""
+
+#. TRANSLATORS: Pre-cut
+#: locale/ipp-strings.c:136
+msgid "covering-name.pre-cut"
+msgstr ""
+
+#. TRANSLATORS: Pre-printed
+#: locale/ipp-strings.c:138
+msgid "covering-name.pre-printed"
+msgstr ""
+
+#: scheduler/ipp.c:6187
+msgid "cups-deviced failed to execute."
+msgstr ""
+
+#: scheduler/ipp.c:7073 scheduler/ipp.c:7312
+msgid "cups-driverd failed to execute."
+msgstr ""
+
+#: systemv/cupsctl.c:170
+#, c-format
+msgid "cupsctl: Cannot set %s directly."
+msgstr ""
+
+#: systemv/cupsctl.c:183
+#, c-format
+msgid "cupsctl: Unable to connect to server: %s"
+msgstr ""
+
+#: systemv/cupsctl.c:226
+#, c-format
+msgid "cupsctl: Unknown option \"%s\""
+msgstr ""
+
+#: systemv/cupsctl.c:228
+#, c-format
+msgid "cupsctl: Unknown option \"-%c\""
+msgstr ""
+
+#: scheduler/main.c:174
+msgid "cupsd: Expected config filename after \"-c\" option."
+msgstr ""
+
+#: scheduler/main.c:270
+msgid "cupsd: Expected cups-files.conf filename after \"-s\" option."
+msgstr ""
+
+#: scheduler/main.c:244
+msgid "cupsd: On-demand support not compiled in, running in normal mode."
+msgstr ""
+
+#: scheduler/main.c:281
+msgid "cupsd: Relative cups-files.conf filename not allowed."
+msgstr ""
+
+#: scheduler/main.c:205 scheduler/main.c:212
+msgid "cupsd: Unable to get current directory."
+msgstr ""
+
+#: scheduler/main.c:340 scheduler/main.c:350
+msgid "cupsd: Unable to get path to cups-files.conf file."
+msgstr ""
+
+#: scheduler/main.c:321
+#, c-format
+msgid "cupsd: Unknown argument \"%s\" - aborting."
+msgstr ""
+
+#: scheduler/main.c:312
+#, c-format
+msgid "cupsd: Unknown option \"%c\" - aborting."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1257
+#, c-format
+msgid "cupsfilter: Invalid document number %d."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1251
+#, c-format
+msgid "cupsfilter: Invalid job ID %d."
+msgstr ""
+
+#: scheduler/cupsfilter.c:342
+msgid "cupsfilter: Only one filename can be specified."
+msgstr ""
+
+#: scheduler/cupsfilter.c:1299
+#, c-format
+msgid "cupsfilter: Unable to get job file - %s"
+msgstr ""
+
+#: systemv/cupstestppd.c:238
+msgid "cupstestppd: The -q option is incompatible with the -v option."
+msgstr ""
+
+#: systemv/cupstestppd.c:254
+msgid "cupstestppd: The -v option is incompatible with the -q option."
+msgstr ""
+
+#. TRANSLATORS: Detailed Status Message
+#: locale/ipp-strings.c:140
+msgid "detailed-status-message"
+msgstr ""
+
+#: systemv/lpstat.c:1253 systemv/lpstat.c:1256 systemv/lpstat.c:1259
+#, c-format
+msgid "device for %s/%s: %s"
+msgstr ""
+
+#: systemv/lpstat.c:1239 systemv/lpstat.c:1242 systemv/lpstat.c:1245
+#, c-format
+msgid "device for %s: %s"
+msgstr ""
+
+#. TRANSLATORS: Copies
+#: locale/ipp-strings.c:142
+msgid "document-copies"
+msgstr ""
+
+#. TRANSLATORS: Document Privacy Attributes
+#: locale/ipp-strings.c:144
+msgid "document-privacy-attributes"
+msgstr ""
+
+#. TRANSLATORS: All
+#: locale/ipp-strings.c:146
+msgid "document-privacy-attributes.all"
+msgstr ""
+
+#. TRANSLATORS: Default
+#: locale/ipp-strings.c:148
+msgid "document-privacy-attributes.default"
+msgstr ""
+
+#. TRANSLATORS: Document Description
+#: locale/ipp-strings.c:150
+msgid "document-privacy-attributes.document-description"
+msgstr ""
+
+#. TRANSLATORS: Document Template
+#: locale/ipp-strings.c:152
+msgid "document-privacy-attributes.document-template"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:154
+msgid "document-privacy-attributes.none"
+msgstr ""
+
+#. TRANSLATORS: Document Privacy Scope
+#: locale/ipp-strings.c:156
+msgid "document-privacy-scope"
+msgstr ""
+
+#. TRANSLATORS: All
+#: locale/ipp-strings.c:158
+msgid "document-privacy-scope.all"
+msgstr ""
+
+#. TRANSLATORS: Default
+#: locale/ipp-strings.c:160
+msgid "document-privacy-scope.default"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:162
+msgid "document-privacy-scope.none"
+msgstr ""
+
+#. TRANSLATORS: Owner
+#: locale/ipp-strings.c:164
+msgid "document-privacy-scope.owner"
+msgstr ""
+
+#. TRANSLATORS: Document State
+#: locale/ipp-strings.c:166
+msgid "document-state"
+msgstr ""
+
+#. TRANSLATORS: Detailed Document State
+#: locale/ipp-strings.c:168
+msgid "document-state-reasons"
+msgstr ""
+
+#. TRANSLATORS: Aborted By System
+#: locale/ipp-strings.c:170
+msgid "document-state-reasons.aborted-by-system"
+msgstr ""
+
+#. TRANSLATORS: Canceled At Device
+#: locale/ipp-strings.c:172
+msgid "document-state-reasons.canceled-at-device"
+msgstr ""
+
+#. TRANSLATORS: Canceled By Operator
+#: locale/ipp-strings.c:174
+msgid "document-state-reasons.canceled-by-operator"
+msgstr ""
+
+#. TRANSLATORS: Canceled By User
+#: locale/ipp-strings.c:176
+msgid "document-state-reasons.canceled-by-user"
+msgstr ""
+
+#. TRANSLATORS: Completed Successfully
+#: locale/ipp-strings.c:178
+msgid "document-state-reasons.completed-successfully"
+msgstr ""
+
+#. TRANSLATORS: Completed With Errors
+#: locale/ipp-strings.c:180
+msgid "document-state-reasons.completed-with-errors"
+msgstr ""
+
+#. TRANSLATORS: Completed With Warnings
+#: locale/ipp-strings.c:182
+msgid "document-state-reasons.completed-with-warnings"
+msgstr ""
+
+#. TRANSLATORS: Compression Error
+#: locale/ipp-strings.c:184
+msgid "document-state-reasons.compression-error"
+msgstr ""
+
+#. TRANSLATORS: Data Insufficient
+#: locale/ipp-strings.c:186
+msgid "document-state-reasons.data-insufficient"
+msgstr ""
+
+#. TRANSLATORS: Digital Signature Did Not Verify
+#: locale/ipp-strings.c:188
+msgid "document-state-reasons.digital-signature-did-not-verify"
+msgstr ""
+
+#. TRANSLATORS: Digital Signature Type Not Supported
+#: locale/ipp-strings.c:190
+msgid "document-state-reasons.digital-signature-type-not-supported"
+msgstr ""
+
+#. TRANSLATORS: Digital Signature Wait
+#: locale/ipp-strings.c:192
+msgid "document-state-reasons.digital-signature-wait"
+msgstr ""
+
+#. TRANSLATORS: Document Access Error
+#: locale/ipp-strings.c:194
+msgid "document-state-reasons.document-access-error"
+msgstr ""
+
+#. TRANSLATORS: Document Fetchable
+#: locale/ipp-strings.c:196
+msgid "document-state-reasons.document-fetchable"
+msgstr ""
+
+#. TRANSLATORS: Document Format Error
+#: locale/ipp-strings.c:198
+msgid "document-state-reasons.document-format-error"
+msgstr ""
+
+#. TRANSLATORS: Document Password Error
+#: locale/ipp-strings.c:200
+msgid "document-state-reasons.document-password-error"
+msgstr ""
+
+#. TRANSLATORS: Document Permission Error
+#: locale/ipp-strings.c:202
+msgid "document-state-reasons.document-permission-error"
+msgstr ""
+
+#. TRANSLATORS: Document Security Error
+#: locale/ipp-strings.c:204
+msgid "document-state-reasons.document-security-error"
+msgstr ""
+
+#. TRANSLATORS: Document Unprintable Error
+#: locale/ipp-strings.c:206
+msgid "document-state-reasons.document-unprintable-error"
+msgstr ""
+
+#. TRANSLATORS: Errors Detected
+#: locale/ipp-strings.c:208
+msgid "document-state-reasons.errors-detected"
+msgstr ""
+
+#. TRANSLATORS: Incoming
+#: locale/ipp-strings.c:210
+msgid "document-state-reasons.incoming"
+msgstr ""
+
+#. TRANSLATORS: Interpreting
+#: locale/ipp-strings.c:212
+msgid "document-state-reasons.interpreting"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:214
+msgid "document-state-reasons.none"
+msgstr ""
+
+#. TRANSLATORS: Outgoing
+#: locale/ipp-strings.c:216
+msgid "document-state-reasons.outgoing"
+msgstr ""
+
+#. TRANSLATORS: Printing
+#: locale/ipp-strings.c:218
+msgid "document-state-reasons.printing"
+msgstr ""
+
+#. TRANSLATORS: Processing To Stop Point
+#: locale/ipp-strings.c:220
+msgid "document-state-reasons.processing-to-stop-point"
+msgstr ""
+
+#. TRANSLATORS: Queued
+#: locale/ipp-strings.c:222
+msgid "document-state-reasons.queued"
+msgstr ""
+
+#. TRANSLATORS: Queued For Marker
+#: locale/ipp-strings.c:224
+msgid "document-state-reasons.queued-for-marker"
+msgstr ""
+
+#. TRANSLATORS: Queued In Device
+#: locale/ipp-strings.c:226
+msgid "document-state-reasons.queued-in-device"
+msgstr ""
+
+#. TRANSLATORS: Resources Are Not Ready
+#: locale/ipp-strings.c:228
+msgid "document-state-reasons.resources-are-not-ready"
+msgstr ""
+
+#. TRANSLATORS: Resources Are Not Supported
+#: locale/ipp-strings.c:230
+msgid "document-state-reasons.resources-are-not-supported"
+msgstr ""
+
+#. TRANSLATORS: Submission Interrupted
+#: locale/ipp-strings.c:232
+msgid "document-state-reasons.submission-interrupted"
+msgstr ""
+
+#. TRANSLATORS: Transforming
+#: locale/ipp-strings.c:234
+msgid "document-state-reasons.transforming"
+msgstr ""
+
+#. TRANSLATORS: Unsupported Compression
+#: locale/ipp-strings.c:236
+msgid "document-state-reasons.unsupported-compression"
+msgstr ""
+
+#. TRANSLATORS: Unsupported Document Format
+#: locale/ipp-strings.c:238
+msgid "document-state-reasons.unsupported-document-format"
+msgstr ""
+
+#. TRANSLATORS: Warnings Detected
+#: locale/ipp-strings.c:240
+msgid "document-state-reasons.warnings-detected"
+msgstr ""
+
+#. TRANSLATORS: Pending
+#: locale/ipp-strings.c:242
+msgid "document-state.3"
+msgstr ""
+
+#. TRANSLATORS: Processing
+#: locale/ipp-strings.c:244
+msgid "document-state.5"
+msgstr ""
+
+#. TRANSLATORS: Stopped
+#: locale/ipp-strings.c:246
+msgid "document-state.6"
+msgstr ""
+
+#. TRANSLATORS: Canceled
+#: locale/ipp-strings.c:248
+msgid "document-state.7"
+msgstr ""
+
+#. TRANSLATORS: Aborted
+#: locale/ipp-strings.c:250
+msgid "document-state.8"
+msgstr ""
+
+#. TRANSLATORS: Completed
+#: locale/ipp-strings.c:252
+msgid "document-state.9"
+msgstr ""
+
+#: cups/snmp.c:990
+msgid "error-index uses indefinite length"
+msgstr ""
+
+#: cups/snmp.c:982
+msgid "error-status uses indefinite length"
+msgstr ""
+
+#: tools/ippfind.c:2808
+msgid ""
+"expression --and expression\n"
+"                        Logical AND"
+msgstr ""
+
+#: tools/ippfind.c:2810
+msgid ""
+"expression --or expression\n"
+"                        Logical OR"
+msgstr ""
+
+#: tools/ippfind.c:2807
+msgid "expression expression   Logical AND"
+msgstr ""
+
+#. TRANSLATORS: Feed Orientation
+#: locale/ipp-strings.c:254
+msgid "feed-orientation"
+msgstr ""
+
+#. TRANSLATORS: Long Edge First
+#: locale/ipp-strings.c:256
+msgid "feed-orientation.long-edge-first"
+msgstr ""
+
+#. TRANSLATORS: Short Edge First
+#: locale/ipp-strings.c:258
+msgid "feed-orientation.short-edge-first"
+msgstr ""
+
+#. TRANSLATORS: Fetch Status Code
+#: locale/ipp-strings.c:260
+msgid "fetch-status-code"
+msgstr ""
+
+#. TRANSLATORS: Finishing Template
+#: locale/ipp-strings.c:262
+msgid "finishing-template"
+msgstr ""
+
+#. TRANSLATORS: Bale
+#: locale/ipp-strings.c:264
+msgid "finishing-template.bale"
+msgstr ""
+
+#. TRANSLATORS: Bind
+#: locale/ipp-strings.c:266
+msgid "finishing-template.bind"
+msgstr ""
+
+#. TRANSLATORS: Bind Bottom
+#: locale/ipp-strings.c:268
+msgid "finishing-template.bind-bottom"
+msgstr ""
+
+#. TRANSLATORS: Bind Left
+#: locale/ipp-strings.c:270
+msgid "finishing-template.bind-left"
+msgstr ""
+
+#. TRANSLATORS: Bind Right
+#: locale/ipp-strings.c:272
+msgid "finishing-template.bind-right"
+msgstr ""
+
+#. TRANSLATORS: Bind Top
+#: locale/ipp-strings.c:274
+msgid "finishing-template.bind-top"
+msgstr ""
+
+#. TRANSLATORS: Booklet Maker
+#: locale/ipp-strings.c:276
+msgid "finishing-template.booklet-maker"
+msgstr ""
+
+#. TRANSLATORS: Coat
+#: locale/ipp-strings.c:278
+msgid "finishing-template.coat"
+msgstr ""
+
+#. TRANSLATORS: Cover
+#: locale/ipp-strings.c:280
+msgid "finishing-template.cover"
+msgstr ""
+
+#. TRANSLATORS: Edge Stitch
+#: locale/ipp-strings.c:282
+msgid "finishing-template.edge-stitch"
+msgstr ""
+
+#. TRANSLATORS: Edge Stitch Bottom
+#: locale/ipp-strings.c:284
+msgid "finishing-template.edge-stitch-bottom"
+msgstr ""
+
+#. TRANSLATORS: Edge Stitch Left
+#: locale/ipp-strings.c:286
+msgid "finishing-template.edge-stitch-left"
+msgstr ""
+
+#. TRANSLATORS: Edge Stitch Right
+#: locale/ipp-strings.c:288
+msgid "finishing-template.edge-stitch-right"
+msgstr ""
+
+#. TRANSLATORS: Edge Stitch Top
+#: locale/ipp-strings.c:290
+msgid "finishing-template.edge-stitch-top"
+msgstr ""
+
+#. TRANSLATORS: Fold
+#: locale/ipp-strings.c:292
+msgid "finishing-template.fold"
+msgstr ""
+
+#. TRANSLATORS: Accordion Fold
+#: locale/ipp-strings.c:294
+msgid "finishing-template.fold-accordion"
+msgstr ""
+
+#. TRANSLATORS: Double Gate Fold
+#: locale/ipp-strings.c:296
+msgid "finishing-template.fold-double-gate"
+msgstr ""
+
+#. TRANSLATORS: Engineering Z Fold
+#: locale/ipp-strings.c:298
+msgid "finishing-template.fold-engineering-z"
+msgstr ""
+
+#. TRANSLATORS: Gate Fold
+#: locale/ipp-strings.c:300
+msgid "finishing-template.fold-gate"
+msgstr ""
+
+#. TRANSLATORS: Half Fold
+#: locale/ipp-strings.c:302
+msgid "finishing-template.fold-half"
+msgstr ""
+
+#. TRANSLATORS: Half Z Fold
+#: locale/ipp-strings.c:304
+msgid "finishing-template.fold-half-z"
+msgstr ""
+
+#. TRANSLATORS: Left Gate Fold
+#: locale/ipp-strings.c:306
+msgid "finishing-template.fold-left-gate"
+msgstr ""
+
+#. TRANSLATORS: Letter Fold
+#: locale/ipp-strings.c:308
+msgid "finishing-template.fold-letter"
+msgstr ""
+
+#. TRANSLATORS: Parallel Fold
+#: locale/ipp-strings.c:310
+msgid "finishing-template.fold-parallel"
+msgstr ""
+
+#. TRANSLATORS: Poster Fold
+#: locale/ipp-strings.c:312
+msgid "finishing-template.fold-poster"
+msgstr ""
+
+#. TRANSLATORS: Right Gate Fold
+#: locale/ipp-strings.c:314
+msgid "finishing-template.fold-right-gate"
+msgstr ""
+
+#. TRANSLATORS: Z Fold
+#: locale/ipp-strings.c:316
+msgid "finishing-template.fold-z"
+msgstr ""
+
+#. TRANSLATORS: JDF F10-1
+#: locale/ipp-strings.c:318
+msgid "finishing-template.jdf-f10-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F10-2
+#: locale/ipp-strings.c:320
+msgid "finishing-template.jdf-f10-2"
+msgstr ""
+
+#. TRANSLATORS: JDF F10-3
+#: locale/ipp-strings.c:322
+msgid "finishing-template.jdf-f10-3"
+msgstr ""
+
+#. TRANSLATORS: JDF F12-1
+#: locale/ipp-strings.c:324
+msgid "finishing-template.jdf-f12-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F12-10
+#: locale/ipp-strings.c:326
+msgid "finishing-template.jdf-f12-10"
+msgstr ""
+
+#. TRANSLATORS: JDF F12-11
+#: locale/ipp-strings.c:328
+msgid "finishing-template.jdf-f12-11"
+msgstr ""
+
+#. TRANSLATORS: JDF F12-12
+#: locale/ipp-strings.c:330
+msgid "finishing-template.jdf-f12-12"
+msgstr ""
+
+#. TRANSLATORS: JDF F12-13
+#: locale/ipp-strings.c:332
+msgid "finishing-template.jdf-f12-13"
+msgstr ""
+
+#. TRANSLATORS: JDF F12-14
+#: locale/ipp-strings.c:334
+msgid "finishing-template.jdf-f12-14"
+msgstr ""
+
+#. TRANSLATORS: JDF F12-2
+#: locale/ipp-strings.c:336
+msgid "finishing-template.jdf-f12-2"
+msgstr ""
+
+#. TRANSLATORS: JDF F12-3
+#: locale/ipp-strings.c:338
+msgid "finishing-template.jdf-f12-3"
+msgstr ""
+
+#. TRANSLATORS: JDF F12-4
+#: locale/ipp-strings.c:340
+msgid "finishing-template.jdf-f12-4"
+msgstr ""
+
+#. TRANSLATORS: JDF F12-5
+#: locale/ipp-strings.c:342
+msgid "finishing-template.jdf-f12-5"
+msgstr ""
+
+#. TRANSLATORS: JDF F12-6
+#: locale/ipp-strings.c:344
+msgid "finishing-template.jdf-f12-6"
+msgstr ""
+
+#. TRANSLATORS: JDF F12-7
+#: locale/ipp-strings.c:346
+msgid "finishing-template.jdf-f12-7"
+msgstr ""
+
+#. TRANSLATORS: JDF F12-8
+#: locale/ipp-strings.c:348
+msgid "finishing-template.jdf-f12-8"
+msgstr ""
+
+#. TRANSLATORS: JDF F12-9
+#: locale/ipp-strings.c:350
+msgid "finishing-template.jdf-f12-9"
+msgstr ""
+
+#. TRANSLATORS: JDF F14-1
+#: locale/ipp-strings.c:352
+msgid "finishing-template.jdf-f14-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F16-1
+#: locale/ipp-strings.c:354
+msgid "finishing-template.jdf-f16-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F16-10
+#: locale/ipp-strings.c:356
+msgid "finishing-template.jdf-f16-10"
+msgstr ""
+
+#. TRANSLATORS: JDF F16-11
+#: locale/ipp-strings.c:358
+msgid "finishing-template.jdf-f16-11"
+msgstr ""
+
+#. TRANSLATORS: JDF F16-12
+#: locale/ipp-strings.c:360
+msgid "finishing-template.jdf-f16-12"
+msgstr ""
+
+#. TRANSLATORS: JDF F16-13
+#: locale/ipp-strings.c:362
+msgid "finishing-template.jdf-f16-13"
+msgstr ""
+
+#. TRANSLATORS: JDF F16-14
+#: locale/ipp-strings.c:364
+msgid "finishing-template.jdf-f16-14"
+msgstr ""
+
+#. TRANSLATORS: JDF F16-2
+#: locale/ipp-strings.c:366
+msgid "finishing-template.jdf-f16-2"
+msgstr ""
+
+#. TRANSLATORS: JDF F16-3
+#: locale/ipp-strings.c:368
+msgid "finishing-template.jdf-f16-3"
+msgstr ""
+
+#. TRANSLATORS: JDF F16-4
+#: locale/ipp-strings.c:370
+msgid "finishing-template.jdf-f16-4"
+msgstr ""
+
+#. TRANSLATORS: JDF F16-5
+#: locale/ipp-strings.c:372
+msgid "finishing-template.jdf-f16-5"
+msgstr ""
+
+#. TRANSLATORS: JDF F16-6
+#: locale/ipp-strings.c:374
+msgid "finishing-template.jdf-f16-6"
+msgstr ""
+
+#. TRANSLATORS: JDF F16-7
+#: locale/ipp-strings.c:376
+msgid "finishing-template.jdf-f16-7"
+msgstr ""
+
+#. TRANSLATORS: JDF F16-8
+#: locale/ipp-strings.c:378
+msgid "finishing-template.jdf-f16-8"
+msgstr ""
+
+#. TRANSLATORS: JDF F16-9
+#: locale/ipp-strings.c:380
+msgid "finishing-template.jdf-f16-9"
+msgstr ""
+
+#. TRANSLATORS: JDF F18-1
+#: locale/ipp-strings.c:382
+msgid "finishing-template.jdf-f18-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F18-2
+#: locale/ipp-strings.c:384
+msgid "finishing-template.jdf-f18-2"
+msgstr ""
+
+#. TRANSLATORS: JDF F18-3
+#: locale/ipp-strings.c:386
+msgid "finishing-template.jdf-f18-3"
+msgstr ""
+
+#. TRANSLATORS: JDF F18-4
+#: locale/ipp-strings.c:388
+msgid "finishing-template.jdf-f18-4"
+msgstr ""
+
+#. TRANSLATORS: JDF F18-5
+#: locale/ipp-strings.c:390
+msgid "finishing-template.jdf-f18-5"
+msgstr ""
+
+#. TRANSLATORS: JDF F18-6
+#: locale/ipp-strings.c:392
+msgid "finishing-template.jdf-f18-6"
+msgstr ""
+
+#. TRANSLATORS: JDF F18-7
+#: locale/ipp-strings.c:394
+msgid "finishing-template.jdf-f18-7"
+msgstr ""
+
+#. TRANSLATORS: JDF F18-8
+#: locale/ipp-strings.c:396
+msgid "finishing-template.jdf-f18-8"
+msgstr ""
+
+#. TRANSLATORS: JDF F18-9
+#: locale/ipp-strings.c:398
+msgid "finishing-template.jdf-f18-9"
+msgstr ""
+
+#. TRANSLATORS: JDF F2-1
+#: locale/ipp-strings.c:400
+msgid "finishing-template.jdf-f2-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F20-1
+#: locale/ipp-strings.c:402
+msgid "finishing-template.jdf-f20-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F20-2
+#: locale/ipp-strings.c:404
+msgid "finishing-template.jdf-f20-2"
+msgstr ""
+
+#. TRANSLATORS: JDF F24-1
+#: locale/ipp-strings.c:406
+msgid "finishing-template.jdf-f24-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F24-10
+#: locale/ipp-strings.c:408
+msgid "finishing-template.jdf-f24-10"
+msgstr ""
+
+#. TRANSLATORS: JDF F24-11
+#: locale/ipp-strings.c:410
+msgid "finishing-template.jdf-f24-11"
+msgstr ""
+
+#. TRANSLATORS: JDF F24-2
+#: locale/ipp-strings.c:412
+msgid "finishing-template.jdf-f24-2"
+msgstr ""
+
+#. TRANSLATORS: JDF F24-3
+#: locale/ipp-strings.c:414
+msgid "finishing-template.jdf-f24-3"
+msgstr ""
+
+#. TRANSLATORS: JDF F24-4
+#: locale/ipp-strings.c:416
+msgid "finishing-template.jdf-f24-4"
+msgstr ""
+
+#. TRANSLATORS: JDF F24-5
+#: locale/ipp-strings.c:418
+msgid "finishing-template.jdf-f24-5"
+msgstr ""
+
+#. TRANSLATORS: JDF F24-6
+#: locale/ipp-strings.c:420
+msgid "finishing-template.jdf-f24-6"
+msgstr ""
+
+#. TRANSLATORS: JDF F24-7
+#: locale/ipp-strings.c:422
+msgid "finishing-template.jdf-f24-7"
+msgstr ""
+
+#. TRANSLATORS: JDF F24-8
+#: locale/ipp-strings.c:424
+msgid "finishing-template.jdf-f24-8"
+msgstr ""
+
+#. TRANSLATORS: JDF F24-9
+#: locale/ipp-strings.c:426
+msgid "finishing-template.jdf-f24-9"
+msgstr ""
+
+#. TRANSLATORS: JDF F28-1
+#: locale/ipp-strings.c:428
+msgid "finishing-template.jdf-f28-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F32-1
+#: locale/ipp-strings.c:430
+msgid "finishing-template.jdf-f32-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F32-2
+#: locale/ipp-strings.c:432
+msgid "finishing-template.jdf-f32-2"
+msgstr ""
+
+#. TRANSLATORS: JDF F32-3
+#: locale/ipp-strings.c:434
+msgid "finishing-template.jdf-f32-3"
+msgstr ""
+
+#. TRANSLATORS: JDF F32-4
+#: locale/ipp-strings.c:436
+msgid "finishing-template.jdf-f32-4"
+msgstr ""
+
+#. TRANSLATORS: JDF F32-5
+#: locale/ipp-strings.c:438
+msgid "finishing-template.jdf-f32-5"
+msgstr ""
+
+#. TRANSLATORS: JDF F32-6
+#: locale/ipp-strings.c:440
+msgid "finishing-template.jdf-f32-6"
+msgstr ""
+
+#. TRANSLATORS: JDF F32-7
+#: locale/ipp-strings.c:442
+msgid "finishing-template.jdf-f32-7"
+msgstr ""
+
+#. TRANSLATORS: JDF F32-8
+#: locale/ipp-strings.c:444
+msgid "finishing-template.jdf-f32-8"
+msgstr ""
+
+#. TRANSLATORS: JDF F32-9
+#: locale/ipp-strings.c:446
+msgid "finishing-template.jdf-f32-9"
+msgstr ""
+
+#. TRANSLATORS: JDF F36-1
+#: locale/ipp-strings.c:448
+msgid "finishing-template.jdf-f36-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F36-2
+#: locale/ipp-strings.c:450
+msgid "finishing-template.jdf-f36-2"
+msgstr ""
+
+#. TRANSLATORS: JDF F4-1
+#: locale/ipp-strings.c:452
+msgid "finishing-template.jdf-f4-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F4-2
+#: locale/ipp-strings.c:454
+msgid "finishing-template.jdf-f4-2"
+msgstr ""
+
+#. TRANSLATORS: JDF F40-1
+#: locale/ipp-strings.c:456
+msgid "finishing-template.jdf-f40-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F48-1
+#: locale/ipp-strings.c:458
+msgid "finishing-template.jdf-f48-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F48-2
+#: locale/ipp-strings.c:460
+msgid "finishing-template.jdf-f48-2"
+msgstr ""
+
+#. TRANSLATORS: JDF F6-1
+#: locale/ipp-strings.c:462
+msgid "finishing-template.jdf-f6-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F6-2
+#: locale/ipp-strings.c:464
+msgid "finishing-template.jdf-f6-2"
+msgstr ""
+
+#. TRANSLATORS: JDF F6-3
+#: locale/ipp-strings.c:466
+msgid "finishing-template.jdf-f6-3"
+msgstr ""
+
+#. TRANSLATORS: JDF F6-4
+#: locale/ipp-strings.c:468
+msgid "finishing-template.jdf-f6-4"
+msgstr ""
+
+#. TRANSLATORS: JDF F6-5
+#: locale/ipp-strings.c:470
+msgid "finishing-template.jdf-f6-5"
+msgstr ""
+
+#. TRANSLATORS: JDF F6-6
+#: locale/ipp-strings.c:472
+msgid "finishing-template.jdf-f6-6"
+msgstr ""
+
+#. TRANSLATORS: JDF F6-7
+#: locale/ipp-strings.c:474
+msgid "finishing-template.jdf-f6-7"
+msgstr ""
+
+#. TRANSLATORS: JDF F6-8
+#: locale/ipp-strings.c:476
+msgid "finishing-template.jdf-f6-8"
+msgstr ""
+
+#. TRANSLATORS: JDF F64-1
+#: locale/ipp-strings.c:478
+msgid "finishing-template.jdf-f64-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F64-2
+#: locale/ipp-strings.c:480
+msgid "finishing-template.jdf-f64-2"
+msgstr ""
+
+#. TRANSLATORS: JDF F8-1
+#: locale/ipp-strings.c:482
+msgid "finishing-template.jdf-f8-1"
+msgstr ""
+
+#. TRANSLATORS: JDF F8-2
+#: locale/ipp-strings.c:484
+msgid "finishing-template.jdf-f8-2"
+msgstr ""
+
+#. TRANSLATORS: JDF F8-3
+#: locale/ipp-strings.c:486
+msgid "finishing-template.jdf-f8-3"
+msgstr ""
+
+#. TRANSLATORS: JDF F8-4
+#: locale/ipp-strings.c:488
+msgid "finishing-template.jdf-f8-4"
+msgstr ""
+
+#. TRANSLATORS: JDF F8-5
+#: locale/ipp-strings.c:490
+msgid "finishing-template.jdf-f8-5"
+msgstr ""
+
+#. TRANSLATORS: JDF F8-6
+#: locale/ipp-strings.c:492
+msgid "finishing-template.jdf-f8-6"
+msgstr ""
+
+#. TRANSLATORS: JDF F8-7
+#: locale/ipp-strings.c:494
+msgid "finishing-template.jdf-f8-7"
+msgstr ""
+
+#. TRANSLATORS: Jog Offset
+#: locale/ipp-strings.c:496
+msgid "finishing-template.jog-offset"
+msgstr ""
+
+#. TRANSLATORS: Laminate
+#: locale/ipp-strings.c:498
+msgid "finishing-template.laminate"
+msgstr ""
+
+#. TRANSLATORS: Punch
+#: locale/ipp-strings.c:500
+msgid "finishing-template.punch"
+msgstr ""
+
+#. TRANSLATORS: Punch Bottom Left
+#: locale/ipp-strings.c:502
+msgid "finishing-template.punch-bottom-left"
+msgstr ""
+
+#. TRANSLATORS: Punch Bottom Right
+#: locale/ipp-strings.c:504
+msgid "finishing-template.punch-bottom-right"
+msgstr ""
+
+#. TRANSLATORS: 2-hole Punch Bottom
+#: locale/ipp-strings.c:506
+msgid "finishing-template.punch-dual-bottom"
+msgstr ""
+
+#. TRANSLATORS: 2-hole Punch Left
+#: locale/ipp-strings.c:508
+msgid "finishing-template.punch-dual-left"
+msgstr ""
+
+#. TRANSLATORS: 2-hole Punch Right
+#: locale/ipp-strings.c:510
+msgid "finishing-template.punch-dual-right"
+msgstr ""
+
+#. TRANSLATORS: 2-hole Punch Top
+#: locale/ipp-strings.c:512
+msgid "finishing-template.punch-dual-top"
+msgstr ""
+
+#. TRANSLATORS: Multi-hole Punch Bottom
+#: locale/ipp-strings.c:514
+msgid "finishing-template.punch-multiple-bottom"
+msgstr ""
+
+#. TRANSLATORS: Multi-hole Punch Left
+#: locale/ipp-strings.c:516
+msgid "finishing-template.punch-multiple-left"
+msgstr ""
+
+#. TRANSLATORS: Multi-hole Punch Right
+#: locale/ipp-strings.c:518
+msgid "finishing-template.punch-multiple-right"
+msgstr ""
+
+#. TRANSLATORS: Multi-hole Punch Top
+#: locale/ipp-strings.c:520
+msgid "finishing-template.punch-multiple-top"
+msgstr ""
+
+#. TRANSLATORS: 4-hole Punch Bottom
+#: locale/ipp-strings.c:522
+msgid "finishing-template.punch-quad-bottom"
+msgstr ""
+
+#. TRANSLATORS: 4-hole Punch Left
+#: locale/ipp-strings.c:524
+msgid "finishing-template.punch-quad-left"
+msgstr ""
+
+#. TRANSLATORS: 4-hole Punch Right
+#: locale/ipp-strings.c:526
+msgid "finishing-template.punch-quad-right"
+msgstr ""
+
+#. TRANSLATORS: 4-hole Punch Top
+#: locale/ipp-strings.c:528
+msgid "finishing-template.punch-quad-top"
+msgstr ""
+
+#. TRANSLATORS: Punch Top Left
+#: locale/ipp-strings.c:530
+msgid "finishing-template.punch-top-left"
+msgstr ""
+
+#. TRANSLATORS: Punch Top Right
+#: locale/ipp-strings.c:532
+msgid "finishing-template.punch-top-right"
+msgstr ""
+
+#. TRANSLATORS: 3-hole Punch Bottom
+#: locale/ipp-strings.c:534
+msgid "finishing-template.punch-triple-bottom"
+msgstr ""
+
+#. TRANSLATORS: 3-hole Punch Left
+#: locale/ipp-strings.c:536
+msgid "finishing-template.punch-triple-left"
+msgstr ""
+
+#. TRANSLATORS: 3-hole Punch Right
+#: locale/ipp-strings.c:538
+msgid "finishing-template.punch-triple-right"
+msgstr ""
+
+#. TRANSLATORS: 3-hole Punch Top
+#: locale/ipp-strings.c:540
+msgid "finishing-template.punch-triple-top"
+msgstr ""
+
+#. TRANSLATORS: Saddle Stitch
+#: locale/ipp-strings.c:542
+msgid "finishing-template.saddle-stitch"
+msgstr ""
+
+#. TRANSLATORS: Staple
+#: locale/ipp-strings.c:544
+msgid "finishing-template.staple"
+msgstr ""
+
+#. TRANSLATORS: Staple Bottom Left
+#: locale/ipp-strings.c:546
+msgid "finishing-template.staple-bottom-left"
+msgstr ""
+
+#. TRANSLATORS: Staple Bottom Right
+#: locale/ipp-strings.c:548
+msgid "finishing-template.staple-bottom-right"
+msgstr ""
+
+#. TRANSLATORS: 2 Staples on Bottom
+#: locale/ipp-strings.c:550
+msgid "finishing-template.staple-dual-bottom"
+msgstr ""
+
+#. TRANSLATORS: 2 Staples on Left
+#: locale/ipp-strings.c:552
+msgid "finishing-template.staple-dual-left"
+msgstr ""
+
+#. TRANSLATORS: 2 Staples on Right
+#: locale/ipp-strings.c:554
+msgid "finishing-template.staple-dual-right"
+msgstr ""
+
+#. TRANSLATORS: 2 Staples on Top
+#: locale/ipp-strings.c:556
+msgid "finishing-template.staple-dual-top"
+msgstr ""
+
+#. TRANSLATORS: Staple Top Left
+#: locale/ipp-strings.c:558
+msgid "finishing-template.staple-top-left"
+msgstr ""
+
+#. TRANSLATORS: Staple Top Right
+#: locale/ipp-strings.c:560
+msgid "finishing-template.staple-top-right"
+msgstr ""
+
+#. TRANSLATORS: 3 Staples on Bottom
+#: locale/ipp-strings.c:562
+msgid "finishing-template.staple-triple-bottom"
+msgstr ""
+
+#. TRANSLATORS: 3 Staples on Left
+#: locale/ipp-strings.c:564
+msgid "finishing-template.staple-triple-left"
+msgstr ""
+
+#. TRANSLATORS: 3 Staples on Right
+#: locale/ipp-strings.c:566
+msgid "finishing-template.staple-triple-right"
+msgstr ""
+
+#. TRANSLATORS: 3 Staples on Top
+#: locale/ipp-strings.c:568
+msgid "finishing-template.staple-triple-top"
+msgstr ""
+
+#. TRANSLATORS: Trim
+#: locale/ipp-strings.c:570
+msgid "finishing-template.trim"
+msgstr ""
+
+#. TRANSLATORS: Trim After Every Set
+#: locale/ipp-strings.c:572
+msgid "finishing-template.trim-after-copies"
+msgstr ""
+
+#. TRANSLATORS: Trim After Every Document
+#: locale/ipp-strings.c:574
+msgid "finishing-template.trim-after-documents"
+msgstr ""
+
+#. TRANSLATORS: Trim After Job
+#: locale/ipp-strings.c:576
+msgid "finishing-template.trim-after-job"
+msgstr ""
+
+#. TRANSLATORS: Trim After Every Page
+#: locale/ipp-strings.c:578
+msgid "finishing-template.trim-after-pages"
+msgstr ""
+
+#. TRANSLATORS: Finishings
+#: locale/ipp-strings.c:580
+msgid "finishings"
+msgstr ""
+
+#. TRANSLATORS: Finishings
+#: locale/ipp-strings.c:582
+msgid "finishings-col"
+msgstr ""
+
+#. TRANSLATORS: Fold
+#: locale/ipp-strings.c:584
+msgid "finishings.10"
+msgstr ""
+
+#. TRANSLATORS: Z Fold
+#: locale/ipp-strings.c:586
+msgid "finishings.100"
+msgstr ""
+
+#. TRANSLATORS: Engineering Z Fold
+#: locale/ipp-strings.c:588
+msgid "finishings.101"
+msgstr ""
+
+#. TRANSLATORS: Trim
+#: locale/ipp-strings.c:590
+msgid "finishings.11"
+msgstr ""
+
+#. TRANSLATORS: Bale
+#: locale/ipp-strings.c:592
+msgid "finishings.12"
+msgstr ""
+
+#. TRANSLATORS: Booklet Maker
+#: locale/ipp-strings.c:594
+msgid "finishings.13"
+msgstr ""
+
+#. TRANSLATORS: Jog Offset
+#: locale/ipp-strings.c:596
+msgid "finishings.14"
+msgstr ""
+
+#. TRANSLATORS: Coat
+#: locale/ipp-strings.c:598
+msgid "finishings.15"
+msgstr ""
+
+#. TRANSLATORS: Laminate
+#: locale/ipp-strings.c:600
+msgid "finishings.16"
+msgstr ""
+
+#. TRANSLATORS: Staple Top Left
+#: locale/ipp-strings.c:602
+msgid "finishings.20"
+msgstr ""
+
+#. TRANSLATORS: Staple Bottom Left
+#: locale/ipp-strings.c:604
+msgid "finishings.21"
+msgstr ""
+
+#. TRANSLATORS: Staple Top Right
+#: locale/ipp-strings.c:606
+msgid "finishings.22"
+msgstr ""
+
+#. TRANSLATORS: Staple Bottom Right
+#: locale/ipp-strings.c:608
+msgid "finishings.23"
+msgstr ""
+
+#. TRANSLATORS: Edge Stitch Left
+#: locale/ipp-strings.c:610
+msgid "finishings.24"
+msgstr ""
+
+#. TRANSLATORS: Edge Stitch Top
+#: locale/ipp-strings.c:612
+msgid "finishings.25"
+msgstr ""
+
+#. TRANSLATORS: Edge Stitch Right
+#: locale/ipp-strings.c:614
+msgid "finishings.26"
+msgstr ""
+
+#. TRANSLATORS: Edge Stitch Bottom
+#: locale/ipp-strings.c:616
+msgid "finishings.27"
+msgstr ""
+
+#. TRANSLATORS: 2 Staples on Left
+#: locale/ipp-strings.c:618
+msgid "finishings.28"
+msgstr ""
+
+#. TRANSLATORS: 2 Staples on Top
+#: locale/ipp-strings.c:620
+msgid "finishings.29"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:622
+msgid "finishings.3"
+msgstr ""
+
+#. TRANSLATORS: 2 Staples on Right
+#: locale/ipp-strings.c:624
+msgid "finishings.30"
+msgstr ""
+
+#. TRANSLATORS: 2 Staples on Bottom
+#: locale/ipp-strings.c:626
+msgid "finishings.31"
+msgstr ""
+
+#. TRANSLATORS: 3 Staples on Left
+#: locale/ipp-strings.c:628
+msgid "finishings.32"
+msgstr ""
+
+#. TRANSLATORS: 3 Staples on Top
+#: locale/ipp-strings.c:630
+msgid "finishings.33"
+msgstr ""
+
+#. TRANSLATORS: 3 Staples on Right
+#: locale/ipp-strings.c:632
+msgid "finishings.34"
+msgstr ""
+
+#. TRANSLATORS: 3 Staples on Bottom
+#: locale/ipp-strings.c:634
+msgid "finishings.35"
+msgstr ""
+
+#. TRANSLATORS: Staple
+#: locale/ipp-strings.c:636
+msgid "finishings.4"
+msgstr ""
+
+#. TRANSLATORS: Punch
+#: locale/ipp-strings.c:638
+msgid "finishings.5"
+msgstr ""
+
+#. TRANSLATORS: Bind Left
+#: locale/ipp-strings.c:640
+msgid "finishings.50"
+msgstr ""
+
+#. TRANSLATORS: Bind Top
+#: locale/ipp-strings.c:642
+msgid "finishings.51"
+msgstr ""
+
+#. TRANSLATORS: Bind Right
+#: locale/ipp-strings.c:644
+msgid "finishings.52"
+msgstr ""
+
+#. TRANSLATORS: Bind Bottom
+#: locale/ipp-strings.c:646
+msgid "finishings.53"
+msgstr ""
+
+#. TRANSLATORS: Cover
+#: locale/ipp-strings.c:648
+msgid "finishings.6"
+msgstr ""
+
+#. TRANSLATORS: Trim Pages
+#: locale/ipp-strings.c:650
+msgid "finishings.60"
+msgstr ""
+
+#. TRANSLATORS: Trim Documents
+#: locale/ipp-strings.c:652
+msgid "finishings.61"
+msgstr ""
+
+#. TRANSLATORS: Trim Copies
+#: locale/ipp-strings.c:654
+msgid "finishings.62"
+msgstr ""
+
+#. TRANSLATORS: Trim Job
+#: locale/ipp-strings.c:656
+msgid "finishings.63"
+msgstr ""
+
+#. TRANSLATORS: Bind
+#: locale/ipp-strings.c:658
+msgid "finishings.7"
+msgstr ""
+
+#. TRANSLATORS: Punch Top Left
+#: locale/ipp-strings.c:660
+msgid "finishings.70"
+msgstr ""
+
+#. TRANSLATORS: Punch Bottom Left
+#: locale/ipp-strings.c:662
+msgid "finishings.71"
+msgstr ""
+
+#. TRANSLATORS: Punch Top Right
+#: locale/ipp-strings.c:664
+msgid "finishings.72"
+msgstr ""
+
+#. TRANSLATORS: Punch Bottom Right
+#: locale/ipp-strings.c:666
+msgid "finishings.73"
+msgstr ""
+
+#. TRANSLATORS: 2-hole Punch Left
+#: locale/ipp-strings.c:668
+msgid "finishings.74"
+msgstr ""
+
+#. TRANSLATORS: 2-hole Punch Top
+#: locale/ipp-strings.c:670
+msgid "finishings.75"
+msgstr ""
+
+#. TRANSLATORS: 2-hole Punch Right
+#: locale/ipp-strings.c:672
+msgid "finishings.76"
+msgstr ""
+
+#. TRANSLATORS: 2-hole Punch Bottom
+#: locale/ipp-strings.c:674
+msgid "finishings.77"
+msgstr ""
+
+#. TRANSLATORS: 3-hole Punch Left
+#: locale/ipp-strings.c:676
+msgid "finishings.78"
+msgstr ""
+
+#. TRANSLATORS: 3-hole Punch Top
+#: locale/ipp-strings.c:678
+msgid "finishings.79"
+msgstr ""
+
+#. TRANSLATORS: Saddle Stitch
+#: locale/ipp-strings.c:680
+msgid "finishings.8"
+msgstr ""
+
+#. TRANSLATORS: 3-hole Punch Right
+#: locale/ipp-strings.c:682
+msgid "finishings.80"
+msgstr ""
+
+#. TRANSLATORS: 3-hole Punch Bottom
+#: locale/ipp-strings.c:684
+msgid "finishings.81"
+msgstr ""
+
+#. TRANSLATORS: 4-hole Punch Left
+#: locale/ipp-strings.c:686
+msgid "finishings.82"
+msgstr ""
+
+#. TRANSLATORS: 4-hole Punch Top
+#: locale/ipp-strings.c:688
+msgid "finishings.83"
+msgstr ""
+
+#. TRANSLATORS: 4-hole Punch Right
+#: locale/ipp-strings.c:690
+msgid "finishings.84"
+msgstr ""
+
+#. TRANSLATORS: 4-hole Punch Bottom
+#: locale/ipp-strings.c:692
+msgid "finishings.85"
+msgstr ""
+
+#. TRANSLATORS: Multi-hole Punch Left
+#: locale/ipp-strings.c:694
+msgid "finishings.86"
+msgstr ""
+
+#. TRANSLATORS: Multi-hole Punch Top
+#: locale/ipp-strings.c:696
+msgid "finishings.87"
+msgstr ""
+
+#. TRANSLATORS: Multi-hole Punch Right
+#: locale/ipp-strings.c:698
+msgid "finishings.88"
+msgstr ""
+
+#. TRANSLATORS: Multi-hole Punch Bottom
+#: locale/ipp-strings.c:700
+msgid "finishings.89"
+msgstr ""
+
+#. TRANSLATORS: Edge Stitch
+#: locale/ipp-strings.c:702
+msgid "finishings.9"
+msgstr ""
+
+#. TRANSLATORS: Accordion Fold
+#: locale/ipp-strings.c:704
+msgid "finishings.90"
+msgstr ""
+
+#. TRANSLATORS: Double Gate Fold
+#: locale/ipp-strings.c:706
+msgid "finishings.91"
+msgstr ""
+
+#. TRANSLATORS: Gate Fold
+#: locale/ipp-strings.c:708
+msgid "finishings.92"
+msgstr ""
+
+#. TRANSLATORS: Half Fold
+#: locale/ipp-strings.c:710
+msgid "finishings.93"
+msgstr ""
+
+#. TRANSLATORS: Half Z Fold
+#: locale/ipp-strings.c:712
+msgid "finishings.94"
+msgstr ""
+
+#. TRANSLATORS: Left Gate Fold
+#: locale/ipp-strings.c:714
+msgid "finishings.95"
+msgstr ""
+
+#. TRANSLATORS: Letter Fold
+#: locale/ipp-strings.c:716
+msgid "finishings.96"
+msgstr ""
+
+#. TRANSLATORS: Parallel Fold
+#: locale/ipp-strings.c:718
+msgid "finishings.97"
+msgstr ""
+
+#. TRANSLATORS: Poster Fold
+#: locale/ipp-strings.c:720
+msgid "finishings.98"
+msgstr ""
+
+#. TRANSLATORS: Right Gate Fold
+#: locale/ipp-strings.c:722
+msgid "finishings.99"
+msgstr ""
+
+#. TRANSLATORS: Fold
+#: locale/ipp-strings.c:724
+msgid "folding"
+msgstr ""
+
+#. TRANSLATORS: Fold Direction
+#: locale/ipp-strings.c:726
+msgid "folding-direction"
+msgstr ""
+
+#. TRANSLATORS: Inward
+#: locale/ipp-strings.c:728
+msgid "folding-direction.inward"
+msgstr ""
+
+#. TRANSLATORS: Outward
+#: locale/ipp-strings.c:730
+msgid "folding-direction.outward"
+msgstr ""
+
+#. TRANSLATORS: Fold Position
+#: locale/ipp-strings.c:732
+msgid "folding-offset"
+msgstr ""
+
+#. TRANSLATORS: Fold Edge
+#: locale/ipp-strings.c:734
+msgid "folding-reference-edge"
+msgstr ""
+
+#. TRANSLATORS: Bottom
+#: locale/ipp-strings.c:736
+msgid "folding-reference-edge.bottom"
+msgstr ""
+
+#. TRANSLATORS: Left
+#: locale/ipp-strings.c:738
+msgid "folding-reference-edge.left"
+msgstr ""
+
+#. TRANSLATORS: Right
+#: locale/ipp-strings.c:740
+msgid "folding-reference-edge.right"
+msgstr ""
+
+#. TRANSLATORS: Top
+#: locale/ipp-strings.c:742
+msgid "folding-reference-edge.top"
+msgstr ""
+
+#. TRANSLATORS: Font Name
+#: locale/ipp-strings.c:744
+msgid "font-name-requested"
+msgstr ""
+
+#. TRANSLATORS: Font Size
+#: locale/ipp-strings.c:746
+msgid "font-size-requested"
+msgstr ""
+
+#. TRANSLATORS: Force Front Side
+#: locale/ipp-strings.c:748
+msgid "force-front-side"
+msgstr ""
+
+#. TRANSLATORS: From Name
+#: locale/ipp-strings.c:750
+msgid "from-name"
+msgstr ""
+
+#: cups/notify.c:77
+msgid "held"
+msgstr ""
+
+#: berkeley/lpc.c:195
+msgid "help\t\tGet help on commands."
+msgstr ""
+
+#: cups/notify.c:118
+msgid "idle"
+msgstr ""
+
+#. TRANSLATORS: Imposition Template
+#: locale/ipp-strings.c:752
+msgid "imposition-template"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:754
+msgid "imposition-template.none"
+msgstr ""
+
+#. TRANSLATORS: Signature
+#: locale/ipp-strings.c:756
+msgid "imposition-template.signature"
+msgstr ""
+
+#. TRANSLATORS: Insert Page Number
+#: locale/ipp-strings.c:758
+msgid "insert-after-page-number"
+msgstr ""
+
+#. TRANSLATORS: Insert Count
+#: locale/ipp-strings.c:760
+msgid "insert-count"
+msgstr ""
+
+#. TRANSLATORS: Insert Sheet
+#: locale/ipp-strings.c:762
+msgid "insert-sheet"
+msgstr ""
+
+#: tools/ippeveprinter.c:4702
+#, c-format
+msgid "ippeveprinter: Unable to open \"%s\": %s on line %d."
+msgstr ""
+
+#: tools/ippfind.c:2478
+#, c-format
+msgid "ippfind: Bad regular expression: %s"
+msgstr ""
+
+#: tools/ippfind.c:295
+msgid "ippfind: Cannot use --and after --or."
+msgstr ""
+
+#: tools/ippfind.c:580
+#, c-format
+msgid "ippfind: Expected key name after %s."
+msgstr ""
+
+#: tools/ippfind.c:530 tools/ippfind.c:725
+#, c-format
+msgid "ippfind: Expected port range after %s."
+msgstr ""
+
+#: tools/ippfind.c:328
+#, c-format
+msgid "ippfind: Expected program after %s."
+msgstr ""
+
+#: tools/ippfind.c:345
+#, c-format
+msgid "ippfind: Expected semi-colon after %s."
+msgstr ""
+
+#: tools/ippfind.c:1981
+msgid "ippfind: Missing close brace in substitution."
+msgstr ""
+
+#: tools/ippfind.c:1044
+msgid "ippfind: Missing close parenthesis."
+msgstr ""
+
+#: tools/ippfind.c:302
+msgid "ippfind: Missing expression before \"--and\"."
+msgstr ""
+
+#: tools/ippfind.c:427
+msgid "ippfind: Missing expression before \"--or\"."
+msgstr ""
+
+#: tools/ippfind.c:862
+#, c-format
+msgid "ippfind: Missing key name after %s."
+msgstr ""
+
+#: tools/ippfind.c:396 tools/ippfind.c:712
+#, c-format
+msgid "ippfind: Missing name after %s."
+msgstr ""
+
+#: tools/ippfind.c:1015
+msgid "ippfind: Missing open parenthesis."
+msgstr ""
+
+#: tools/ippfind.c:892
+#, c-format
+msgid "ippfind: Missing program after %s."
+msgstr ""
+
+#: tools/ippfind.c:314 tools/ippfind.c:368 tools/ippfind.c:409
+#: tools/ippfind.c:515 tools/ippfind.c:597 tools/ippfind.c:612
+#: tools/ippfind.c:779 tools/ippfind.c:794 tools/ippfind.c:817
+#: tools/ippfind.c:877
+#, c-format
+msgid "ippfind: Missing regular expression after %s."
+msgstr ""
+
+#: tools/ippfind.c:910
+#, c-format
+msgid "ippfind: Missing semi-colon after %s."
+msgstr ""
+
+#: tools/ippfind.c:1928 tools/ippfind.c:1953
+msgid "ippfind: Out of memory."
+msgstr ""
+
+#: tools/ippfind.c:988
+msgid "ippfind: Too many parenthesis."
+msgstr ""
+
+#: tools/ippfind.c:1287 tools/ippfind.c:1415 tools/ippfind.c:2570
+#, c-format
+msgid "ippfind: Unable to browse or resolve: %s"
+msgstr ""
+
+#: tools/ippfind.c:2051 tools/ippfind.c:2078
+#, c-format
+msgid "ippfind: Unable to execute \"%s\": %s"
+msgstr ""
+
+#: tools/ippfind.c:1134 tools/ippfind.c:1142 tools/ippfind.c:1153
+#, c-format
+msgid "ippfind: Unable to use Bonjour: %s"
+msgstr ""
+
+#: tools/ippfind.c:2010
+#, c-format
+msgid "ippfind: Unknown variable \"{%s}\"."
+msgstr ""
+
+#: tools/ipptool.c:566 tools/ipptool.c:588
+msgid "ipptool: \"-i\" and \"-n\" are incompatible with \"--ippserver\", \"-P\", and \"-X\"."
+msgstr ""
+
+#: tools/ipptool.c:351 tools/ipptool.c:422
+msgid "ipptool: \"-i\" and \"-n\" are incompatible with \"-P\" and \"-X\"."
+msgstr ""
+
+#: tools/ipptool.c:634
+#, c-format
+msgid "ipptool: Bad URI \"%s\"."
+msgstr ""
+
+#: tools/ipptool.c:559
+msgid "ipptool: Invalid seconds for \"-i\"."
+msgstr ""
+
+#: tools/ipptool.c:623
+msgid "ipptool: May only specify a single URI."
+msgstr ""
+
+#: tools/ipptool.c:580
+msgid "ipptool: Missing count for \"-n\"."
+msgstr ""
+
+#: tools/ipptool.c:268
+msgid "ipptool: Missing filename for \"--ippserver\"."
+msgstr ""
+
+#: tools/ipptool.c:456
+msgid "ipptool: Missing filename for \"-f\"."
+msgstr ""
+
+#: tools/ipptool.c:437
+msgid "ipptool: Missing name=value for \"-d\"."
+msgstr ""
+
+#: tools/ipptool.c:551
+msgid "ipptool: Missing seconds for \"-i\"."
+msgstr ""
+
+#: tools/ipptool.c:649
+msgid "ipptool: URI required before test file."
+msgstr ""
+
+#. TRANSLATORS: Job Account ID
+#: locale/ipp-strings.c:764
+msgid "job-account-id"
+msgstr ""
+
+#. TRANSLATORS: Job Account Type
+#: locale/ipp-strings.c:766
+msgid "job-account-type"
+msgstr ""
+
+#. TRANSLATORS: General
+#: locale/ipp-strings.c:768
+msgid "job-account-type.general"
+msgstr ""
+
+#. TRANSLATORS: Group
+#: locale/ipp-strings.c:770
+msgid "job-account-type.group"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:772
+msgid "job-account-type.none"
+msgstr ""
+
+#. TRANSLATORS: Job Accounting Output Bin
+#: locale/ipp-strings.c:774
+msgid "job-accounting-output-bin"
+msgstr ""
+
+#. TRANSLATORS: Job Accounting Sheets
+#: locale/ipp-strings.c:776
+msgid "job-accounting-sheets"
+msgstr ""
+
+#. TRANSLATORS: Type of Job Accounting Sheets
+#: locale/ipp-strings.c:778
+msgid "job-accounting-sheets-type"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:780
+msgid "job-accounting-sheets-type.none"
+msgstr ""
+
+#. TRANSLATORS: Standard
+#: locale/ipp-strings.c:782
+msgid "job-accounting-sheets-type.standard"
+msgstr ""
+
+#. TRANSLATORS: Job Accounting User ID
+#: locale/ipp-strings.c:784
+msgid "job-accounting-user-id"
+msgstr ""
+
+#. TRANSLATORS: Job Cancel After
+#: locale/ipp-strings.c:786
+msgid "job-cancel-after"
+msgstr ""
+
+#. TRANSLATORS: Copies
+#: locale/ipp-strings.c:788
+msgid "job-copies"
+msgstr ""
+
+#. TRANSLATORS: Back Cover
+#: locale/ipp-strings.c:790
+msgid "job-cover-back"
+msgstr ""
+
+#. TRANSLATORS: Front Cover
+#: locale/ipp-strings.c:792
+msgid "job-cover-front"
+msgstr ""
+
+#. TRANSLATORS: Delay Output Until
+#: locale/ipp-strings.c:794
+msgid "job-delay-output-until"
+msgstr ""
+
+#. TRANSLATORS: Delay Output Until
+#: locale/ipp-strings.c:796
+msgid "job-delay-output-until-time"
+msgstr ""
+
+#. TRANSLATORS: Daytime
+#: locale/ipp-strings.c:798
+msgid "job-delay-output-until.day-time"
+msgstr ""
+
+#. TRANSLATORS: Evening
+#: locale/ipp-strings.c:800
+msgid "job-delay-output-until.evening"
+msgstr ""
+
+#. TRANSLATORS: Released
+#: locale/ipp-strings.c:802
+msgid "job-delay-output-until.indefinite"
+msgstr ""
+
+#. TRANSLATORS: Night
+#: locale/ipp-strings.c:804
+msgid "job-delay-output-until.night"
+msgstr ""
+
+#. TRANSLATORS: No Delay
+#: locale/ipp-strings.c:806
+msgid "job-delay-output-until.no-delay-output"
+msgstr ""
+
+#. TRANSLATORS: Second Shift
+#: locale/ipp-strings.c:808
+msgid "job-delay-output-until.second-shift"
+msgstr ""
+
+#. TRANSLATORS: Third Shift
+#: locale/ipp-strings.c:810
+msgid "job-delay-output-until.third-shift"
+msgstr ""
+
+#. TRANSLATORS: Weekend
+#: locale/ipp-strings.c:812
+msgid "job-delay-output-until.weekend"
+msgstr ""
+
+#. TRANSLATORS: On Error
+#: locale/ipp-strings.c:814
+msgid "job-error-action"
+msgstr ""
+
+#. TRANSLATORS: Abort Job
+#: locale/ipp-strings.c:816
+msgid "job-error-action.abort-job"
+msgstr ""
+
+#. TRANSLATORS: Cancel Job
+#: locale/ipp-strings.c:818
+msgid "job-error-action.cancel-job"
+msgstr ""
+
+#. TRANSLATORS: Continue Job
+#: locale/ipp-strings.c:820
+msgid "job-error-action.continue-job"
+msgstr ""
+
+#. TRANSLATORS: Suspend Job
+#: locale/ipp-strings.c:822
+msgid "job-error-action.suspend-job"
+msgstr ""
+
+#. TRANSLATORS: Print Error Sheet
+#: locale/ipp-strings.c:824
+msgid "job-error-sheet"
+msgstr ""
+
+#. TRANSLATORS: Type of Error Sheet
+#: locale/ipp-strings.c:826
+msgid "job-error-sheet-type"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:828
+msgid "job-error-sheet-type.none"
+msgstr ""
+
+#. TRANSLATORS: Standard
+#: locale/ipp-strings.c:830
+msgid "job-error-sheet-type.standard"
+msgstr ""
+
+#. TRANSLATORS: Print Error Sheet
+#: locale/ipp-strings.c:832
+msgid "job-error-sheet-when"
+msgstr ""
+
+#. TRANSLATORS: Always
+#: locale/ipp-strings.c:834
+msgid "job-error-sheet-when.always"
+msgstr ""
+
+#. TRANSLATORS: On Error
+#: locale/ipp-strings.c:836
+msgid "job-error-sheet-when.on-error"
+msgstr ""
+
+#. TRANSLATORS: Job Finishings
+#: locale/ipp-strings.c:838
+msgid "job-finishings"
+msgstr ""
+
+#. TRANSLATORS: Hold Until
+#: locale/ipp-strings.c:840
+msgid "job-hold-until"
+msgstr ""
+
+#. TRANSLATORS: Hold Until
+#: locale/ipp-strings.c:842
+msgid "job-hold-until-time"
+msgstr ""
+
+#. TRANSLATORS: Daytime
+#: locale/ipp-strings.c:844
+msgid "job-hold-until.day-time"
+msgstr ""
+
+#. TRANSLATORS: Evening
+#: locale/ipp-strings.c:846
+msgid "job-hold-until.evening"
+msgstr ""
+
+#. TRANSLATORS: Released
+#: locale/ipp-strings.c:848
+msgid "job-hold-until.indefinite"
+msgstr ""
+
+#. TRANSLATORS: Night
+#: locale/ipp-strings.c:850
+msgid "job-hold-until.night"
+msgstr ""
+
+#. TRANSLATORS: No Hold
+#: locale/ipp-strings.c:852
+msgid "job-hold-until.no-hold"
+msgstr ""
+
+#. TRANSLATORS: Second Shift
+#: locale/ipp-strings.c:854
+msgid "job-hold-until.second-shift"
+msgstr ""
+
+#. TRANSLATORS: Third Shift
+#: locale/ipp-strings.c:856
+msgid "job-hold-until.third-shift"
+msgstr ""
+
+#. TRANSLATORS: Weekend
+#: locale/ipp-strings.c:858
+msgid "job-hold-until.weekend"
+msgstr ""
+
+#. TRANSLATORS: Job Mandatory Attributes
+#: locale/ipp-strings.c:860
+msgid "job-mandatory-attributes"
+msgstr ""
+
+#. TRANSLATORS: Title
+#: locale/ipp-strings.c:862
+msgid "job-name"
+msgstr ""
+
+#. TRANSLATORS: Job Pages
+#: locale/ipp-strings.c:864
+msgid "job-pages"
+msgstr ""
+
+#. TRANSLATORS: Job Pages
+#: locale/ipp-strings.c:866
+msgid "job-pages-col"
+msgstr ""
+
+#. TRANSLATORS: Job Phone Number
+#: locale/ipp-strings.c:868
+msgid "job-phone-number"
+msgstr ""
+
+#: scheduler/ipp.c:8095
+msgid "job-printer-uri attribute missing."
+msgstr ""
+
+#. TRANSLATORS: Job Priority
+#: locale/ipp-strings.c:870
+msgid "job-priority"
+msgstr ""
+
+#. TRANSLATORS: Job Privacy Attributes
+#: locale/ipp-strings.c:872
+msgid "job-privacy-attributes"
+msgstr ""
+
+#. TRANSLATORS: All
+#: locale/ipp-strings.c:874
+msgid "job-privacy-attributes.all"
+msgstr ""
+
+#. TRANSLATORS: Default
+#: locale/ipp-strings.c:876
+msgid "job-privacy-attributes.default"
+msgstr ""
+
+#. TRANSLATORS: Job Description
+#: locale/ipp-strings.c:878
+msgid "job-privacy-attributes.job-description"
+msgstr ""
+
+#. TRANSLATORS: Job Template
+#: locale/ipp-strings.c:880
+msgid "job-privacy-attributes.job-template"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:882
+msgid "job-privacy-attributes.none"
+msgstr ""
+
+#. TRANSLATORS: Job Privacy Scope
+#: locale/ipp-strings.c:884
+msgid "job-privacy-scope"
+msgstr ""
+
+#. TRANSLATORS: All
+#: locale/ipp-strings.c:886
+msgid "job-privacy-scope.all"
+msgstr ""
+
+#. TRANSLATORS: Default
+#: locale/ipp-strings.c:888
+msgid "job-privacy-scope.default"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:890
+msgid "job-privacy-scope.none"
+msgstr ""
+
+#. TRANSLATORS: Owner
+#: locale/ipp-strings.c:892
+msgid "job-privacy-scope.owner"
+msgstr ""
+
+#. TRANSLATORS: Job Recipient Name
+#: locale/ipp-strings.c:894
+msgid "job-recipient-name"
+msgstr ""
+
+#. TRANSLATORS: Job Retain Until
+#: locale/ipp-strings.c:896
+msgid "job-retain-until"
+msgstr ""
+
+#. TRANSLATORS: Job Retain Until Interval
+#: locale/ipp-strings.c:898
+msgid "job-retain-until-interval"
+msgstr ""
+
+#. TRANSLATORS: Job Retain Until Time
+#: locale/ipp-strings.c:900
+msgid "job-retain-until-time"
+msgstr ""
+
+#. TRANSLATORS: End Of Day
+#: locale/ipp-strings.c:902
+msgid "job-retain-until.end-of-day"
+msgstr ""
+
+#. TRANSLATORS: End Of Month
+#: locale/ipp-strings.c:904
+msgid "job-retain-until.end-of-month"
+msgstr ""
+
+#. TRANSLATORS: End Of Week
+#: locale/ipp-strings.c:906
+msgid "job-retain-until.end-of-week"
+msgstr ""
+
+#. TRANSLATORS: Indefinite
+#: locale/ipp-strings.c:908
+msgid "job-retain-until.indefinite"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:910
+msgid "job-retain-until.none"
+msgstr ""
+
+#. TRANSLATORS: Job Save Disposition
+#: locale/ipp-strings.c:912
+msgid "job-save-disposition"
+msgstr ""
+
+#. TRANSLATORS: Job Sheet Message
+#: locale/ipp-strings.c:914
+msgid "job-sheet-message"
+msgstr ""
+
+#. TRANSLATORS: Banner Page
+#: locale/ipp-strings.c:916
+msgid "job-sheets"
+msgstr ""
+
+#. TRANSLATORS: Banner Page
+#: locale/ipp-strings.c:918
+msgid "job-sheets-col"
+msgstr ""
+
+#. TRANSLATORS: First Page in Document
+#: locale/ipp-strings.c:920
+msgid "job-sheets.first-print-stream-page"
+msgstr ""
+
+#. TRANSLATORS: Start and End Sheets
+#: locale/ipp-strings.c:922
+msgid "job-sheets.job-both-sheet"
+msgstr ""
+
+#. TRANSLATORS: End Sheet
+#: locale/ipp-strings.c:924
+msgid "job-sheets.job-end-sheet"
+msgstr ""
+
+#. TRANSLATORS: Start Sheet
+#: locale/ipp-strings.c:926
+msgid "job-sheets.job-start-sheet"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:928
+msgid "job-sheets.none"
+msgstr ""
+
+#. TRANSLATORS: Standard
+#: locale/ipp-strings.c:930
+msgid "job-sheets.standard"
+msgstr ""
+
+#. TRANSLATORS: Job State
+#: locale/ipp-strings.c:932
+msgid "job-state"
+msgstr ""
+
+#. TRANSLATORS: Job State Message
+#: locale/ipp-strings.c:934
+msgid "job-state-message"
+msgstr ""
+
+#. TRANSLATORS: Detailed Job State
+#: locale/ipp-strings.c:936
+msgid "job-state-reasons"
+msgstr ""
+
+#. TRANSLATORS: Stopping
+#: locale/ipp-strings.c:938
+msgid "job-state-reasons.aborted-by-system"
+msgstr ""
+
+#. TRANSLATORS: Account Authorization Failed
+#: locale/ipp-strings.c:940
+msgid "job-state-reasons.account-authorization-failed"
+msgstr ""
+
+#. TRANSLATORS: Account Closed
+#: locale/ipp-strings.c:942
+msgid "job-state-reasons.account-closed"
+msgstr ""
+
+#. TRANSLATORS: Account Info Needed
+#: locale/ipp-strings.c:944
+msgid "job-state-reasons.account-info-needed"
+msgstr ""
+
+#. TRANSLATORS: Account Limit Reached
+#: locale/ipp-strings.c:946
+msgid "job-state-reasons.account-limit-reached"
+msgstr ""
+
+#. TRANSLATORS: Decompression error
+#: locale/ipp-strings.c:948
+msgid "job-state-reasons.compression-error"
+msgstr ""
+
+#. TRANSLATORS: Conflicting Attributes
+#: locale/ipp-strings.c:950
+msgid "job-state-reasons.conflicting-attributes"
+msgstr ""
+
+#. TRANSLATORS: Connected To Destination
+#: locale/ipp-strings.c:952
+msgid "job-state-reasons.connected-to-destination"
+msgstr ""
+
+#. TRANSLATORS: Connecting To Destination
+#: locale/ipp-strings.c:954
+msgid "job-state-reasons.connecting-to-destination"
+msgstr ""
+
+#. TRANSLATORS: Destination Uri Failed
+#: locale/ipp-strings.c:956
+msgid "job-state-reasons.destination-uri-failed"
+msgstr ""
+
+#. TRANSLATORS: Digital Signature Did Not Verify
+#: locale/ipp-strings.c:958
+msgid "job-state-reasons.digital-signature-did-not-verify"
+msgstr ""
+
+#. TRANSLATORS: Digital Signature Type Not Supported
+#: locale/ipp-strings.c:960
+msgid "job-state-reasons.digital-signature-type-not-supported"
+msgstr ""
+
+#. TRANSLATORS: Document Access Error
+#: locale/ipp-strings.c:962
+msgid "job-state-reasons.document-access-error"
+msgstr ""
+
+#. TRANSLATORS: Document Format Error
+#: locale/ipp-strings.c:964
+msgid "job-state-reasons.document-format-error"
+msgstr ""
+
+#. TRANSLATORS: Document Password Error
+#: locale/ipp-strings.c:966
+msgid "job-state-reasons.document-password-error"
+msgstr ""
+
+#. TRANSLATORS: Document Permission Error
+#: locale/ipp-strings.c:968
+msgid "job-state-reasons.document-permission-error"
+msgstr ""
+
+#. TRANSLATORS: Document Security Error
+#: locale/ipp-strings.c:970
+msgid "job-state-reasons.document-security-error"
+msgstr ""
+
+#. TRANSLATORS: Document Unprintable Error
+#: locale/ipp-strings.c:972
+msgid "job-state-reasons.document-unprintable-error"
+msgstr ""
+
+#. TRANSLATORS: Errors Detected
+#: locale/ipp-strings.c:974
+msgid "job-state-reasons.errors-detected"
+msgstr ""
+
+#. TRANSLATORS: Canceled at printer
+#: locale/ipp-strings.c:976
+msgid "job-state-reasons.job-canceled-at-device"
+msgstr ""
+
+#. TRANSLATORS: Canceled by operator
+#: locale/ipp-strings.c:978
+msgid "job-state-reasons.job-canceled-by-operator"
+msgstr ""
+
+#. TRANSLATORS: Canceled by user
+#: locale/ipp-strings.c:980
+msgid "job-state-reasons.job-canceled-by-user"
+msgstr ""
+
+#. TRANSLATORS:
+#: locale/ipp-strings.c:982
+msgid "job-state-reasons.job-completed-successfully"
+msgstr ""
+
+#. TRANSLATORS: Completed with errors
+#: locale/ipp-strings.c:984
+msgid "job-state-reasons.job-completed-with-errors"
+msgstr ""
+
+#. TRANSLATORS: Completed with warnings
+#: locale/ipp-strings.c:986
+msgid "job-state-reasons.job-completed-with-warnings"
+msgstr ""
+
+#. TRANSLATORS: Insufficient data
+#: locale/ipp-strings.c:988
+msgid "job-state-reasons.job-data-insufficient"
+msgstr ""
+
+#. TRANSLATORS: Job Delay Output Until Specified
+#: locale/ipp-strings.c:990
+msgid "job-state-reasons.job-delay-output-until-specified"
+msgstr ""
+
+#. TRANSLATORS: Job Digital Signature Wait
+#: locale/ipp-strings.c:992
+msgid "job-state-reasons.job-digital-signature-wait"
+msgstr ""
+
+#. TRANSLATORS: Job Fetchable
+#: locale/ipp-strings.c:994
+msgid "job-state-reasons.job-fetchable"
+msgstr ""
+
+#. TRANSLATORS: Job Held For Review
+#: locale/ipp-strings.c:996
+msgid "job-state-reasons.job-held-for-review"
+msgstr ""
+
+#. TRANSLATORS: Job held
+#: locale/ipp-strings.c:998
+msgid "job-state-reasons.job-hold-until-specified"
+msgstr ""
+
+#. TRANSLATORS: Incoming
+#: locale/ipp-strings.c:1000
+msgid "job-state-reasons.job-incoming"
+msgstr ""
+
+#. TRANSLATORS: Interpreting
+#: locale/ipp-strings.c:1002
+msgid "job-state-reasons.job-interpreting"
+msgstr ""
+
+#. TRANSLATORS: Outgoing
+#: locale/ipp-strings.c:1004
+msgid "job-state-reasons.job-outgoing"
+msgstr ""
+
+#. TRANSLATORS: Job Password Wait
+#: locale/ipp-strings.c:1006
+msgid "job-state-reasons.job-password-wait"
+msgstr ""
+
+#. TRANSLATORS: Job Printed Successfully
+#: locale/ipp-strings.c:1008
+msgid "job-state-reasons.job-printed-successfully"
+msgstr ""
+
+#. TRANSLATORS: Job Printed With Errors
+#: locale/ipp-strings.c:1010
+msgid "job-state-reasons.job-printed-with-errors"
+msgstr ""
+
+#. TRANSLATORS: Job Printed With Warnings
+#: locale/ipp-strings.c:1012
+msgid "job-state-reasons.job-printed-with-warnings"
+msgstr ""
+
+#. TRANSLATORS: Printing
+#: locale/ipp-strings.c:1014
+msgid "job-state-reasons.job-printing"
+msgstr ""
+
+#. TRANSLATORS: Preparing to print
+#: locale/ipp-strings.c:1016
+msgid "job-state-reasons.job-queued"
+msgstr ""
+
+#. TRANSLATORS: Processing document
+#: locale/ipp-strings.c:1018
+msgid "job-state-reasons.job-queued-for-marker"
+msgstr ""
+
+#. TRANSLATORS: Job Release Wait
+#: locale/ipp-strings.c:1020
+msgid "job-state-reasons.job-release-wait"
+msgstr ""
+
+#. TRANSLATORS: Restartable
+#: locale/ipp-strings.c:1022
+msgid "job-state-reasons.job-restartable"
+msgstr ""
+
+#. TRANSLATORS: Job Resuming
+#: locale/ipp-strings.c:1024
+msgid "job-state-reasons.job-resuming"
+msgstr ""
+
+#. TRANSLATORS: Job Saved Successfully
+#: locale/ipp-strings.c:1026
+msgid "job-state-reasons.job-saved-successfully"
+msgstr ""
+
+#. TRANSLATORS: Job Saved With Errors
+#: locale/ipp-strings.c:1028
+msgid "job-state-reasons.job-saved-with-errors"
+msgstr ""
+
+#. TRANSLATORS: Job Saved With Warnings
+#: locale/ipp-strings.c:1030
+msgid "job-state-reasons.job-saved-with-warnings"
+msgstr ""
+
+#. TRANSLATORS: Job Saving
+#: locale/ipp-strings.c:1032
+msgid "job-state-reasons.job-saving"
+msgstr ""
+
+#. TRANSLATORS: Job Spooling
+#: locale/ipp-strings.c:1034
+msgid "job-state-reasons.job-spooling"
+msgstr ""
+
+#. TRANSLATORS: Job Streaming
+#: locale/ipp-strings.c:1036
+msgid "job-state-reasons.job-streaming"
+msgstr ""
+
+#. TRANSLATORS: Suspended
+#: locale/ipp-strings.c:1038
+msgid "job-state-reasons.job-suspended"
+msgstr ""
+
+#. TRANSLATORS: Job Suspended By Operator
+#: locale/ipp-strings.c:1040
+msgid "job-state-reasons.job-suspended-by-operator"
+msgstr ""
+
+#. TRANSLATORS: Job Suspended By System
+#: locale/ipp-strings.c:1042
+msgid "job-state-reasons.job-suspended-by-system"
+msgstr ""
+
+#. TRANSLATORS: Job Suspended By User
+#: locale/ipp-strings.c:1044
+msgid "job-state-reasons.job-suspended-by-user"
+msgstr ""
+
+#. TRANSLATORS: Job Suspending
+#: locale/ipp-strings.c:1046
+msgid "job-state-reasons.job-suspending"
+msgstr ""
+
+#. TRANSLATORS: Job Transferring
+#: locale/ipp-strings.c:1048
+msgid "job-state-reasons.job-transferring"
+msgstr ""
+
+#. TRANSLATORS: Transforming
+#: locale/ipp-strings.c:1050
+msgid "job-state-reasons.job-transforming"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:1052
+msgid "job-state-reasons.none"
+msgstr ""
+
+#. TRANSLATORS: Printer offline
+#: locale/ipp-strings.c:1054
+msgid "job-state-reasons.printer-stopped"
+msgstr ""
+
+#. TRANSLATORS: Printer partially stopped
+#: locale/ipp-strings.c:1056
+msgid "job-state-reasons.printer-stopped-partly"
+msgstr ""
+
+#. TRANSLATORS: Stopping
+#: locale/ipp-strings.c:1058
+msgid "job-state-reasons.processing-to-stop-point"
+msgstr ""
+
+#. TRANSLATORS: Ready
+#: locale/ipp-strings.c:1060
+msgid "job-state-reasons.queued-in-device"
+msgstr ""
+
+#. TRANSLATORS: Resources Are Not Ready
+#: locale/ipp-strings.c:1062
+msgid "job-state-reasons.resources-are-not-ready"
+msgstr ""
+
+#. TRANSLATORS: Resources Are Not Supported
+#: locale/ipp-strings.c:1064
+msgid "job-state-reasons.resources-are-not-supported"
+msgstr ""
+
+#. TRANSLATORS: Service offline
+#: locale/ipp-strings.c:1066
+msgid "job-state-reasons.service-off-line"
+msgstr ""
+
+#. TRANSLATORS: Submission Interrupted
+#: locale/ipp-strings.c:1068
+msgid "job-state-reasons.submission-interrupted"
+msgstr ""
+
+#. TRANSLATORS: Unsupported Attributes Or Values
+#: locale/ipp-strings.c:1070
+msgid "job-state-reasons.unsupported-attributes-or-values"
+msgstr ""
+
+#. TRANSLATORS: Unsupported Compression
+#: locale/ipp-strings.c:1072
+msgid "job-state-reasons.unsupported-compression"
+msgstr ""
+
+#. TRANSLATORS: Unsupported Document Format
+#: locale/ipp-strings.c:1074
+msgid "job-state-reasons.unsupported-document-format"
+msgstr ""
+
+#. TRANSLATORS: Waiting For User Action
+#: locale/ipp-strings.c:1076
+msgid "job-state-reasons.waiting-for-user-action"
+msgstr ""
+
+#. TRANSLATORS: Warnings Detected
+#: locale/ipp-strings.c:1078
+msgid "job-state-reasons.warnings-detected"
+msgstr ""
+
+#. TRANSLATORS: Pending
+#: locale/ipp-strings.c:1080
+msgid "job-state.3"
+msgstr ""
+
+#. TRANSLATORS: Held
+#: locale/ipp-strings.c:1082
+msgid "job-state.4"
+msgstr ""
+
+#. TRANSLATORS: Processing
+#: locale/ipp-strings.c:1084
+msgid "job-state.5"
+msgstr ""
+
+#. TRANSLATORS: Stopped
+#: locale/ipp-strings.c:1086
+msgid "job-state.6"
+msgstr ""
+
+#. TRANSLATORS: Canceled
+#: locale/ipp-strings.c:1088
+msgid "job-state.7"
+msgstr ""
+
+#. TRANSLATORS: Aborted
+#: locale/ipp-strings.c:1090
+msgid "job-state.8"
+msgstr ""
+
+#. TRANSLATORS: Completed
+#: locale/ipp-strings.c:1092
+msgid "job-state.9"
+msgstr ""
+
+#. TRANSLATORS: Laminate Pages
+#: locale/ipp-strings.c:1094
+msgid "laminating"
+msgstr ""
+
+#. TRANSLATORS: Laminate
+#: locale/ipp-strings.c:1096
+msgid "laminating-sides"
+msgstr ""
+
+#. TRANSLATORS: Back Only
+#: locale/ipp-strings.c:1098
+msgid "laminating-sides.back"
+msgstr ""
+
+#. TRANSLATORS: Front and Back
+#: locale/ipp-strings.c:1100
+msgid "laminating-sides.both"
+msgstr ""
+
+#. TRANSLATORS: Front Only
+#: locale/ipp-strings.c:1102
+msgid "laminating-sides.front"
+msgstr ""
+
+#. TRANSLATORS: Type of Lamination
+#: locale/ipp-strings.c:1104
+msgid "laminating-type"
+msgstr ""
+
+#. TRANSLATORS: Archival
+#: locale/ipp-strings.c:1106
+msgid "laminating-type.archival"
+msgstr ""
+
+#. TRANSLATORS: Glossy
+#: locale/ipp-strings.c:1108
+msgid "laminating-type.glossy"
+msgstr ""
+
+#. TRANSLATORS: High Gloss
+#: locale/ipp-strings.c:1110
+msgid "laminating-type.high-gloss"
+msgstr ""
+
+#. TRANSLATORS: Matte
+#: locale/ipp-strings.c:1112
+msgid "laminating-type.matte"
+msgstr ""
+
+#. TRANSLATORS: Semi-gloss
+#: locale/ipp-strings.c:1114
+msgid "laminating-type.semi-gloss"
+msgstr ""
+
+#. TRANSLATORS: Translucent
+#: locale/ipp-strings.c:1116
+msgid "laminating-type.translucent"
+msgstr ""
+
+#. TRANSLATORS: Logo
+#: locale/ipp-strings.c:1118
+msgid "logo"
+msgstr ""
+
+#: systemv/lpadmin.c:123 systemv/lpadmin.c:378
+msgid "lpadmin: Class name can only contain printable characters."
+msgstr ""
+
+#: systemv/lpadmin.c:213
+#, c-format
+msgid "lpadmin: Expected PPD after \"-%c\" option."
+msgstr ""
+
+#: systemv/lpadmin.c:459
+msgid "lpadmin: Expected allow/deny:userlist after \"-u\" option."
+msgstr ""
+
+#: systemv/lpadmin.c:369
+msgid "lpadmin: Expected class after \"-r\" option."
+msgstr ""
+
+#: systemv/lpadmin.c:113
+msgid "lpadmin: Expected class name after \"-c\" option."
+msgstr ""
+
+#: systemv/lpadmin.c:553
+msgid "lpadmin: Expected description after \"-D\" option."
+msgstr ""
+
+#: systemv/lpadmin.c:489
+msgid "lpadmin: Expected device URI after \"-v\" option."
+msgstr ""
+
+#: systemv/lpadmin.c:566
+msgid "lpadmin: Expected file type(s) after \"-I\" option."
+msgstr ""
+
+#: systemv/lpadmin.c:192
+msgid "lpadmin: Expected hostname after \"-h\" option."
+msgstr ""
+
+#: systemv/lpadmin.c:585
+msgid "lpadmin: Expected location after \"-L\" option."
+msgstr ""
+
+#: systemv/lpadmin.c:282
+msgid "lpadmin: Expected model after \"-m\" option."
+msgstr ""
+
+#: systemv/lpadmin.c:417
+msgid "lpadmin: Expected name after \"-R\" option."
+msgstr ""
+
+#: systemv/lpadmin.c:302
+msgid "lpadmin: Expected name=value after \"-o\" option."
+msgstr ""
+
+#: systemv/lpadmin.c:322
+msgid "lpadmin: Expected printer after \"-p\" option."
+msgstr ""
+
+#: systemv/lpadmin.c:155
+msgid "lpadmin: Expected printer name after \"-d\" option."
+msgstr ""
+
+#: systemv/lpadmin.c:522
+msgid "lpadmin: Expected printer or class after \"-x\" option."
+msgstr ""
+
+#: systemv/lpadmin.c:958
+msgid "lpadmin: No member names were seen."
+msgstr ""
+
+#: systemv/lpadmin.c:752
+#, c-format
+msgid "lpadmin: Printer %s is already a member of class %s."
+msgstr ""
+
+#: systemv/lpadmin.c:972
+#, c-format
+msgid "lpadmin: Printer %s is not a member of class %s."
+msgstr ""
+
+#: systemv/lpadmin.c:637
+msgid "lpadmin: Printer drivers are deprecated and will stop working in a future version of CUPS."
+msgstr ""
+
+#: systemv/lpadmin.c:164 systemv/lpadmin.c:331 systemv/lpadmin.c:531
+msgid "lpadmin: Printer name can only contain printable characters."
+msgstr ""
+
+#: systemv/lpadmin.c:618
+msgid "lpadmin: Raw queues are deprecated and will stop working in a future version of CUPS."
+msgstr ""
+
+#: systemv/lpadmin.c:616
+msgid "lpadmin: Raw queues are no longer supported on macOS."
+msgstr ""
+
+#: systemv/lpadmin.c:231
+msgid "lpadmin: System V interface scripts are no longer supported for security reasons."
+msgstr ""
+
+#: systemv/lpadmin.c:97
+msgid ""
+"lpadmin: Unable to add a printer to the class:\n"
+"         You must specify a printer name first."
+msgstr ""
+
+#: systemv/lpadmin.c:89 systemv/lpadmin.c:139 systemv/lpadmin.c:261
+#: systemv/lpadmin.c:344 systemv/lpadmin.c:393 systemv/lpadmin.c:505
+#: systemv/lpadmin.c:656
+#, c-format
+msgid "lpadmin: Unable to connect to server: %s"
+msgstr ""
+
+#: systemv/lpadmin.c:1442
+msgid "lpadmin: Unable to create temporary file"
+msgstr ""
+
+#: systemv/lpadmin.c:401
+msgid ""
+"lpadmin: Unable to delete option:\n"
+"         You must specify a printer name first."
+msgstr ""
+
+#: systemv/lpadmin.c:1453
+#, c-format
+msgid "lpadmin: Unable to open PPD \"%s\": %s"
+msgstr ""
+
+#: systemv/lpadmin.c:1433
+#, c-format
+msgid "lpadmin: Unable to open PPD \"%s\": %s on line %d."
+msgstr ""
+
+#: systemv/lpadmin.c:353
+msgid ""
+"lpadmin: Unable to remove a printer from the class:\n"
+"         You must specify a printer name first."
+msgstr ""
+
+#: systemv/lpadmin.c:645
+msgid ""
+"lpadmin: Unable to set the printer options:\n"
+"         You must specify a printer name first."
+msgstr ""
+
+#: systemv/lpadmin.c:472
+#, c-format
+msgid "lpadmin: Unknown allow/deny option \"%s\"."
+msgstr ""
+
+#: systemv/lpadmin.c:601
+#, c-format
+msgid "lpadmin: Unknown argument \"%s\"."
+msgstr ""
+
+#: systemv/lpadmin.c:594
+#, c-format
+msgid "lpadmin: Unknown option \"%c\"."
+msgstr ""
+
+#: systemv/lpadmin.c:622
+msgid "lpadmin: Use the 'everywhere' model for shared printers."
+msgstr ""
+
+#: systemv/lpadmin.c:570
+msgid "lpadmin: Warning - content type list ignored."
+msgstr ""
+
+#: berkeley/lpc.c:62 berkeley/lpc.c:90 berkeley/lpc.c:126
+msgid "lpc> "
+msgstr ""
+
+#: systemv/lpinfo.c:80
+msgid "lpinfo: Expected 1284 device ID string after \"--device-id\"."
+msgstr ""
+
+#: systemv/lpinfo.c:129
+msgid "lpinfo: Expected language after \"--language\"."
+msgstr ""
+
+#: systemv/lpinfo.c:144
+msgid "lpinfo: Expected make and model after \"--make-and-model\"."
+msgstr ""
+
+#: systemv/lpinfo.c:159
+msgid "lpinfo: Expected product string after \"--product\"."
+msgstr ""
+
+#: systemv/lpinfo.c:96
+msgid "lpinfo: Expected scheme list after \"--exclude-schemes\"."
+msgstr ""
+
+#: systemv/lpinfo.c:114
+msgid "lpinfo: Expected scheme list after \"--include-schemes\"."
+msgstr ""
+
+#: systemv/lpinfo.c:174
+msgid "lpinfo: Expected timeout after \"--timeout\"."
+msgstr ""
+
+#: systemv/lpmove.c:129
+#, c-format
+msgid "lpmove: Unable to connect to server: %s"
+msgstr ""
+
+#: systemv/lpmove.c:117
+#, c-format
+msgid "lpmove: Unknown argument \"%s\"."
+msgstr ""
+
+#: systemv/lpoptions.c:149 systemv/lpoptions.c:167 systemv/lpoptions.c:246
+msgid "lpoptions: No printers."
+msgstr ""
+
+#: systemv/lpoptions.c:223
+#, c-format
+msgid "lpoptions: Unable to add printer or instance: %s"
+msgstr ""
+
+#: systemv/lpoptions.c:492 systemv/lpoptions.c:501
+#, c-format
+msgid "lpoptions: Unable to get PPD file for %s: %s"
+msgstr ""
+
+#: systemv/lpoptions.c:511
+#, c-format
+msgid "lpoptions: Unable to open PPD file for %s."
+msgstr ""
+
+#: systemv/lpoptions.c:95
+msgid "lpoptions: Unknown printer or class."
+msgstr ""
+
+#: systemv/lpstat.c:1099
+#, c-format
+msgid "lpstat: error - %s environment variable names non-existent destination \"%s\"."
+msgstr ""
+
+#. TRANSLATORS: Amount of Material
+#: locale/ipp-strings.c:1120
+msgid "material-amount"
+msgstr ""
+
+#. TRANSLATORS: Amount Units
+#: locale/ipp-strings.c:1122
+msgid "material-amount-units"
+msgstr ""
+
+#. TRANSLATORS: Grams
+#: locale/ipp-strings.c:1124
+msgid "material-amount-units.g"
+msgstr ""
+
+#. TRANSLATORS: Kilograms
+#: locale/ipp-strings.c:1126
+msgid "material-amount-units.kg"
+msgstr ""
+
+#. TRANSLATORS: Liters
+#: locale/ipp-strings.c:1128
+msgid "material-amount-units.l"
+msgstr ""
+
+#. TRANSLATORS: Meters
+#: locale/ipp-strings.c:1130
+msgid "material-amount-units.m"
+msgstr ""
+
+#. TRANSLATORS: Milliliters
+#: locale/ipp-strings.c:1132
+msgid "material-amount-units.ml"
+msgstr ""
+
+#. TRANSLATORS: Millimeters
+#: locale/ipp-strings.c:1134
+msgid "material-amount-units.mm"
+msgstr ""
+
+#. TRANSLATORS: Material Color
+#: locale/ipp-strings.c:1136
+msgid "material-color"
+msgstr ""
+
+#. TRANSLATORS: Material Diameter
+#: locale/ipp-strings.c:1138
+msgid "material-diameter"
+msgstr ""
+
+#. TRANSLATORS: Material Diameter Tolerance
+#: locale/ipp-strings.c:1140
+msgid "material-diameter-tolerance"
+msgstr ""
+
+#. TRANSLATORS: Material Fill Density
+#: locale/ipp-strings.c:1142
+msgid "material-fill-density"
+msgstr ""
+
+#. TRANSLATORS: Material Name
+#: locale/ipp-strings.c:1144
+msgid "material-name"
+msgstr ""
+
+#. TRANSLATORS: Material Nozzle Diameter
+#: locale/ipp-strings.c:1146
+msgid "material-nozzle-diameter"
+msgstr ""
+
+#. TRANSLATORS: Use Material For
+#: locale/ipp-strings.c:1148
+msgid "material-purpose"
+msgstr ""
+
+#. TRANSLATORS: Everything
+#: locale/ipp-strings.c:1150
+msgid "material-purpose.all"
+msgstr ""
+
+#. TRANSLATORS: Base
+#: locale/ipp-strings.c:1152
+msgid "material-purpose.base"
+msgstr ""
+
+#. TRANSLATORS: In-fill
+#: locale/ipp-strings.c:1154
+msgid "material-purpose.in-fill"
+msgstr ""
+
+#. TRANSLATORS: Shell
+#: locale/ipp-strings.c:1156
+msgid "material-purpose.shell"
+msgstr ""
+
+#. TRANSLATORS: Supports
+#: locale/ipp-strings.c:1158
+msgid "material-purpose.support"
+msgstr ""
+
+#. TRANSLATORS: Feed Rate
+#: locale/ipp-strings.c:1160
+msgid "material-rate"
+msgstr ""
+
+#. TRANSLATORS: Feed Rate Units
+#: locale/ipp-strings.c:1162
+msgid "material-rate-units"
+msgstr ""
+
+#. TRANSLATORS: Milligrams per second
+#: locale/ipp-strings.c:1164
+msgid "material-rate-units.mg_second"
+msgstr ""
+
+#. TRANSLATORS: Milliliters per second
+#: locale/ipp-strings.c:1166
+msgid "material-rate-units.ml_second"
+msgstr ""
+
+#. TRANSLATORS: Millimeters per second
+#: locale/ipp-strings.c:1168
+msgid "material-rate-units.mm_second"
+msgstr ""
+
+#. TRANSLATORS: Material Retraction
+#: locale/ipp-strings.c:1170
+msgid "material-retraction"
+msgstr ""
+
+#. TRANSLATORS: Material Shell Thickness
+#: locale/ipp-strings.c:1172
+msgid "material-shell-thickness"
+msgstr ""
+
+#. TRANSLATORS: Material Temperature
+#: locale/ipp-strings.c:1174
+msgid "material-temperature"
+msgstr ""
+
+#. TRANSLATORS: Material Type
+#: locale/ipp-strings.c:1176
+msgid "material-type"
+msgstr ""
+
+#. TRANSLATORS: ABS
+#: locale/ipp-strings.c:1178
+msgid "material-type.abs"
+msgstr ""
+
+#. TRANSLATORS: Carbon Fiber ABS
+#: locale/ipp-strings.c:1180
+msgid "material-type.abs-carbon-fiber"
+msgstr ""
+
+#. TRANSLATORS: Carbon Nanotube ABS
+#: locale/ipp-strings.c:1182
+msgid "material-type.abs-carbon-nanotube"
+msgstr ""
+
+#. TRANSLATORS: Chocolate
+#: locale/ipp-strings.c:1184
+msgid "material-type.chocolate"
+msgstr ""
+
+#. TRANSLATORS: Gold
+#: locale/ipp-strings.c:1186
+msgid "material-type.gold"
+msgstr ""
+
+#. TRANSLATORS: Nylon
+#: locale/ipp-strings.c:1188
+msgid "material-type.nylon"
+msgstr ""
+
+#. TRANSLATORS: Pet
+#: locale/ipp-strings.c:1190
+msgid "material-type.pet"
+msgstr ""
+
+#. TRANSLATORS: Photopolymer
+#: locale/ipp-strings.c:1192
+msgid "material-type.photopolymer"
+msgstr ""
+
+#. TRANSLATORS: PLA
+#: locale/ipp-strings.c:1194
+msgid "material-type.pla"
+msgstr ""
+
+#. TRANSLATORS: Conductive PLA
+#: locale/ipp-strings.c:1196
+msgid "material-type.pla-conductive"
+msgstr ""
+
+#. TRANSLATORS: Pla Dissolvable
+#: locale/ipp-strings.c:1198
+msgid "material-type.pla-dissolvable"
+msgstr ""
+
+#. TRANSLATORS: Flexible PLA
+#: locale/ipp-strings.c:1200
+msgid "material-type.pla-flexible"
+msgstr ""
+
+#. TRANSLATORS: Magnetic PLA
+#: locale/ipp-strings.c:1202
+msgid "material-type.pla-magnetic"
+msgstr ""
+
+#. TRANSLATORS: Steel PLA
+#: locale/ipp-strings.c:1204
+msgid "material-type.pla-steel"
+msgstr ""
+
+#. TRANSLATORS: Stone PLA
+#: locale/ipp-strings.c:1206
+msgid "material-type.pla-stone"
+msgstr ""
+
+#. TRANSLATORS: Wood PLA
+#: locale/ipp-strings.c:1208
+msgid "material-type.pla-wood"
+msgstr ""
+
+#. TRANSLATORS: Polycarbonate
+#: locale/ipp-strings.c:1210
+msgid "material-type.polycarbonate"
+msgstr ""
+
+#. TRANSLATORS: Dissolvable PVA
+#: locale/ipp-strings.c:1212
+msgid "material-type.pva-dissolvable"
+msgstr ""
+
+#. TRANSLATORS: Silver
+#: locale/ipp-strings.c:1214
+msgid "material-type.silver"
+msgstr ""
+
+#. TRANSLATORS: Titanium
+#: locale/ipp-strings.c:1216
+msgid "material-type.titanium"
+msgstr ""
+
+#. TRANSLATORS: Wax
+#: locale/ipp-strings.c:1218
+msgid "material-type.wax"
+msgstr ""
+
+#. TRANSLATORS: Materials
+#: locale/ipp-strings.c:1220
+msgid "materials-col"
+msgstr ""
+
+#. TRANSLATORS: Media
+#: locale/ipp-strings.c:1222
+msgid "media"
+msgstr ""
+
+#. TRANSLATORS: Back Coating of Media
+#: locale/ipp-strings.c:1224
+msgid "media-back-coating"
+msgstr ""
+
+#. TRANSLATORS: Glossy
+#: locale/ipp-strings.c:1226
+msgid "media-back-coating.glossy"
+msgstr ""
+
+#. TRANSLATORS: High Gloss
+#: locale/ipp-strings.c:1228
+msgid "media-back-coating.high-gloss"
+msgstr ""
+
+#. TRANSLATORS: Matte
+#: locale/ipp-strings.c:1230
+msgid "media-back-coating.matte"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:1232
+msgid "media-back-coating.none"
+msgstr ""
+
+#. TRANSLATORS: Satin
+#: locale/ipp-strings.c:1234
+msgid "media-back-coating.satin"
+msgstr ""
+
+#. TRANSLATORS: Semi-gloss
+#: locale/ipp-strings.c:1236
+msgid "media-back-coating.semi-gloss"
+msgstr ""
+
+#. TRANSLATORS: Media Bottom Margin
+#: locale/ipp-strings.c:1238
+msgid "media-bottom-margin"
+msgstr ""
+
+#. TRANSLATORS: Media
+#: locale/ipp-strings.c:1240
+msgid "media-col"
+msgstr ""
+
+#. TRANSLATORS: Media Color
+#: locale/ipp-strings.c:1242
+msgid "media-color"
+msgstr ""
+
+#. TRANSLATORS: Black
+#: locale/ipp-strings.c:1244
+msgid "media-color.black"
+msgstr ""
+
+#. TRANSLATORS: Blue
+#: locale/ipp-strings.c:1246
+msgid "media-color.blue"
+msgstr ""
+
+#. TRANSLATORS: Brown
+#: locale/ipp-strings.c:1248
+msgid "media-color.brown"
+msgstr ""
+
+#. TRANSLATORS: Buff
+#: locale/ipp-strings.c:1250
+msgid "media-color.buff"
+msgstr ""
+
+#. TRANSLATORS: Clear Black
+#: locale/ipp-strings.c:1252
+msgid "media-color.clear-black"
+msgstr ""
+
+#. TRANSLATORS: Clear Blue
+#: locale/ipp-strings.c:1254
+msgid "media-color.clear-blue"
+msgstr ""
+
+#. TRANSLATORS: Clear Brown
+#: locale/ipp-strings.c:1256
+msgid "media-color.clear-brown"
+msgstr ""
+
+#. TRANSLATORS: Clear Buff
+#: locale/ipp-strings.c:1258
+msgid "media-color.clear-buff"
+msgstr ""
+
+#. TRANSLATORS: Clear Cyan
+#: locale/ipp-strings.c:1260
+msgid "media-color.clear-cyan"
+msgstr ""
+
+#. TRANSLATORS: Clear Gold
+#: locale/ipp-strings.c:1262
+msgid "media-color.clear-gold"
+msgstr ""
+
+#. TRANSLATORS: Clear Goldenrod
+#: locale/ipp-strings.c:1264
+msgid "media-color.clear-goldenrod"
+msgstr ""
+
+#. TRANSLATORS: Clear Gray
+#: locale/ipp-strings.c:1266
+msgid "media-color.clear-gray"
+msgstr ""
+
+#. TRANSLATORS: Clear Green
+#: locale/ipp-strings.c:1268
+msgid "media-color.clear-green"
+msgstr ""
+
+#. TRANSLATORS: Clear Ivory
+#: locale/ipp-strings.c:1270
+msgid "media-color.clear-ivory"
+msgstr ""
+
+#. TRANSLATORS: Clear Magenta
+#: locale/ipp-strings.c:1272
+msgid "media-color.clear-magenta"
+msgstr ""
+
+#. TRANSLATORS: Clear Multi Color
+#: locale/ipp-strings.c:1274
+msgid "media-color.clear-multi-color"
+msgstr ""
+
+#. TRANSLATORS: Clear Mustard
+#: locale/ipp-strings.c:1276
+msgid "media-color.clear-mustard"
+msgstr ""
+
+#. TRANSLATORS: Clear Orange
+#: locale/ipp-strings.c:1278
+msgid "media-color.clear-orange"
+msgstr ""
+
+#. TRANSLATORS: Clear Pink
+#: locale/ipp-strings.c:1280
+msgid "media-color.clear-pink"
+msgstr ""
+
+#. TRANSLATORS: Clear Red
+#: locale/ipp-strings.c:1282
+msgid "media-color.clear-red"
+msgstr ""
+
+#. TRANSLATORS: Clear Silver
+#: locale/ipp-strings.c:1284
+msgid "media-color.clear-silver"
+msgstr ""
+
+#. TRANSLATORS: Clear Turquoise
+#: locale/ipp-strings.c:1286
+msgid "media-color.clear-turquoise"
+msgstr ""
+
+#. TRANSLATORS: Clear Violet
+#: locale/ipp-strings.c:1288
+msgid "media-color.clear-violet"
+msgstr ""
+
+#. TRANSLATORS: Clear White
+#: locale/ipp-strings.c:1290
+msgid "media-color.clear-white"
+msgstr ""
+
+#. TRANSLATORS: Clear Yellow
+#: locale/ipp-strings.c:1292
+msgid "media-color.clear-yellow"
+msgstr ""
+
+#. TRANSLATORS: Cyan
+#: locale/ipp-strings.c:1294
+msgid "media-color.cyan"
+msgstr ""
+
+#. TRANSLATORS: Dark Blue
+#: locale/ipp-strings.c:1296
+msgid "media-color.dark-blue"
+msgstr ""
+
+#. TRANSLATORS: Dark Brown
+#: locale/ipp-strings.c:1298
+msgid "media-color.dark-brown"
+msgstr ""
+
+#. TRANSLATORS: Dark Buff
+#: locale/ipp-strings.c:1300
+msgid "media-color.dark-buff"
+msgstr ""
+
+#. TRANSLATORS: Dark Cyan
+#: locale/ipp-strings.c:1302
+msgid "media-color.dark-cyan"
+msgstr ""
+
+#. TRANSLATORS: Dark Gold
+#: locale/ipp-strings.c:1304
+msgid "media-color.dark-gold"
+msgstr ""
+
+#. TRANSLATORS: Dark Goldenrod
+#: locale/ipp-strings.c:1306
+msgid "media-color.dark-goldenrod"
+msgstr ""
+
+#. TRANSLATORS: Dark Gray
+#: locale/ipp-strings.c:1308
+msgid "media-color.dark-gray"
+msgstr ""
+
+#. TRANSLATORS: Dark Green
+#: locale/ipp-strings.c:1310
+msgid "media-color.dark-green"
+msgstr ""
+
+#. TRANSLATORS: Dark Ivory
+#: locale/ipp-strings.c:1312
+msgid "media-color.dark-ivory"
+msgstr ""
+
+#. TRANSLATORS: Dark Magenta
+#: locale/ipp-strings.c:1314
+msgid "media-color.dark-magenta"
+msgstr ""
+
+#. TRANSLATORS: Dark Mustard
+#: locale/ipp-strings.c:1316
+msgid "media-color.dark-mustard"
+msgstr ""
+
+#. TRANSLATORS: Dark Orange
+#: locale/ipp-strings.c:1318
+msgid "media-color.dark-orange"
+msgstr ""
+
+#. TRANSLATORS: Dark Pink
+#: locale/ipp-strings.c:1320
+msgid "media-color.dark-pink"
+msgstr ""
+
+#. TRANSLATORS: Dark Red
+#: locale/ipp-strings.c:1322
+msgid "media-color.dark-red"
+msgstr ""
+
+#. TRANSLATORS: Dark Silver
+#: locale/ipp-strings.c:1324
+msgid "media-color.dark-silver"
+msgstr ""
+
+#. TRANSLATORS: Dark Turquoise
+#: locale/ipp-strings.c:1326
+msgid "media-color.dark-turquoise"
+msgstr ""
+
+#. TRANSLATORS: Dark Violet
+#: locale/ipp-strings.c:1328
+msgid "media-color.dark-violet"
+msgstr ""
+
+#. TRANSLATORS: Dark Yellow
+#: locale/ipp-strings.c:1330
+msgid "media-color.dark-yellow"
+msgstr ""
+
+#. TRANSLATORS: Gold
+#: locale/ipp-strings.c:1332
+msgid "media-color.gold"
+msgstr ""
+
+#. TRANSLATORS: Goldenrod
+#: locale/ipp-strings.c:1334
+msgid "media-color.goldenrod"
+msgstr ""
+
+#. TRANSLATORS: Gray
+#: locale/ipp-strings.c:1336
+msgid "media-color.gray"
+msgstr ""
+
+#. TRANSLATORS: Green
+#: locale/ipp-strings.c:1338
+msgid "media-color.green"
+msgstr ""
+
+#. TRANSLATORS: Ivory
+#: locale/ipp-strings.c:1340
+msgid "media-color.ivory"
+msgstr ""
+
+#. TRANSLATORS: Light Black
+#: locale/ipp-strings.c:1342
+msgid "media-color.light-black"
+msgstr ""
+
+#. TRANSLATORS: Light Blue
+#: locale/ipp-strings.c:1344
+msgid "media-color.light-blue"
+msgstr ""
+
+#. TRANSLATORS: Light Brown
+#: locale/ipp-strings.c:1346
+msgid "media-color.light-brown"
+msgstr ""
+
+#. TRANSLATORS: Light Buff
+#: locale/ipp-strings.c:1348
+msgid "media-color.light-buff"
+msgstr ""
+
+#. TRANSLATORS: Light Cyan
+#: locale/ipp-strings.c:1350
+msgid "media-color.light-cyan"
+msgstr ""
+
+#. TRANSLATORS: Light Gold
+#: locale/ipp-strings.c:1352
+msgid "media-color.light-gold"
+msgstr ""
+
+#. TRANSLATORS: Light Goldenrod
+#: locale/ipp-strings.c:1354
+msgid "media-color.light-goldenrod"
+msgstr ""
+
+#. TRANSLATORS: Light Gray
+#: locale/ipp-strings.c:1356
+msgid "media-color.light-gray"
+msgstr ""
+
+#. TRANSLATORS: Light Green
+#: locale/ipp-strings.c:1358
+msgid "media-color.light-green"
+msgstr ""
+
+#. TRANSLATORS: Light Ivory
+#: locale/ipp-strings.c:1360
+msgid "media-color.light-ivory"
+msgstr ""
+
+#. TRANSLATORS: Light Magenta
+#: locale/ipp-strings.c:1362
+msgid "media-color.light-magenta"
+msgstr ""
+
+#. TRANSLATORS: Light Mustard
+#: locale/ipp-strings.c:1364
+msgid "media-color.light-mustard"
+msgstr ""
+
+#. TRANSLATORS: Light Orange
+#: locale/ipp-strings.c:1366
+msgid "media-color.light-orange"
+msgstr ""
+
+#. TRANSLATORS: Light Pink
+#: locale/ipp-strings.c:1368
+msgid "media-color.light-pink"
+msgstr ""
+
+#. TRANSLATORS: Light Red
+#: locale/ipp-strings.c:1370
+msgid "media-color.light-red"
+msgstr ""
+
+#. TRANSLATORS: Light Silver
+#: locale/ipp-strings.c:1372
+msgid "media-color.light-silver"
+msgstr ""
+
+#. TRANSLATORS: Light Turquoise
+#: locale/ipp-strings.c:1374
+msgid "media-color.light-turquoise"
+msgstr ""
+
+#. TRANSLATORS: Light Violet
+#: locale/ipp-strings.c:1376
+msgid "media-color.light-violet"
+msgstr ""
+
+#. TRANSLATORS: Light Yellow
+#: locale/ipp-strings.c:1378
+msgid "media-color.light-yellow"
+msgstr ""
+
+#. TRANSLATORS: Magenta
+#: locale/ipp-strings.c:1380
+msgid "media-color.magenta"
+msgstr ""
+
+#. TRANSLATORS: Multi-color
+#: locale/ipp-strings.c:1382
+msgid "media-color.multi-color"
+msgstr ""
+
+#. TRANSLATORS: Mustard
+#: locale/ipp-strings.c:1384
+msgid "media-color.mustard"
+msgstr ""
+
+#. TRANSLATORS: No Color
+#: locale/ipp-strings.c:1386
+msgid "media-color.no-color"
+msgstr ""
+
+#. TRANSLATORS: Orange
+#: locale/ipp-strings.c:1388
+msgid "media-color.orange"
+msgstr ""
+
+#. TRANSLATORS: Pink
+#: locale/ipp-strings.c:1390
+msgid "media-color.pink"
+msgstr ""
+
+#. TRANSLATORS: Red
+#: locale/ipp-strings.c:1392
+msgid "media-color.red"
+msgstr ""
+
+#. TRANSLATORS: Silver
+#: locale/ipp-strings.c:1394
+msgid "media-color.silver"
+msgstr ""
+
+#. TRANSLATORS: Turquoise
+#: locale/ipp-strings.c:1396
+msgid "media-color.turquoise"
+msgstr ""
+
+#. TRANSLATORS: Violet
+#: locale/ipp-strings.c:1398
+msgid "media-color.violet"
+msgstr ""
+
+#. TRANSLATORS: White
+#: locale/ipp-strings.c:1400
+msgid "media-color.white"
+msgstr ""
+
+#. TRANSLATORS: Yellow
+#: locale/ipp-strings.c:1402
+msgid "media-color.yellow"
+msgstr ""
+
+#. TRANSLATORS: Front Coating of Media
+#: locale/ipp-strings.c:1404
+msgid "media-front-coating"
+msgstr ""
+
+#. TRANSLATORS: Media Grain
+#: locale/ipp-strings.c:1406
+msgid "media-grain"
+msgstr ""
+
+#. TRANSLATORS: Cross-Feed Direction
+#: locale/ipp-strings.c:1408
+msgid "media-grain.x-direction"
+msgstr ""
+
+#. TRANSLATORS: Feed Direction
+#: locale/ipp-strings.c:1410
+msgid "media-grain.y-direction"
+msgstr ""
+
+#. TRANSLATORS: Media Hole Count
+#: locale/ipp-strings.c:1412
+msgid "media-hole-count"
+msgstr ""
+
+#. TRANSLATORS: Media Info
+#: locale/ipp-strings.c:1414
+msgid "media-info"
+msgstr ""
+
+#. TRANSLATORS: Force Media
+#: locale/ipp-strings.c:1416
+msgid "media-input-tray-check"
+msgstr ""
+
+#. TRANSLATORS: Media Left Margin
+#: locale/ipp-strings.c:1418
+msgid "media-left-margin"
+msgstr ""
+
+#. TRANSLATORS: Pre-printed Media
+#: locale/ipp-strings.c:1420
+msgid "media-pre-printed"
+msgstr ""
+
+#. TRANSLATORS: Blank
+#: locale/ipp-strings.c:1422
+msgid "media-pre-printed.blank"
+msgstr ""
+
+#. TRANSLATORS: Letterhead
+#: locale/ipp-strings.c:1424
+msgid "media-pre-printed.letter-head"
+msgstr ""
+
+#. TRANSLATORS: Pre-printed
+#: locale/ipp-strings.c:1426
+msgid "media-pre-printed.pre-printed"
+msgstr ""
+
+#. TRANSLATORS: Recycled Media
+#: locale/ipp-strings.c:1428
+msgid "media-recycled"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:1430
+msgid "media-recycled.none"
+msgstr ""
+
+#. TRANSLATORS: Standard
+#: locale/ipp-strings.c:1432
+msgid "media-recycled.standard"
+msgstr ""
+
+#. TRANSLATORS: Media Right Margin
+#: locale/ipp-strings.c:1434
+msgid "media-right-margin"
+msgstr ""
+
+#. TRANSLATORS: Media Dimensions
+#: locale/ipp-strings.c:1436
+msgid "media-size"
+msgstr ""
+
+#. TRANSLATORS: Media Name
+#: locale/ipp-strings.c:1438
+msgid "media-size-name"
+msgstr ""
+
+#. TRANSLATORS: Media Source
+#: locale/ipp-strings.c:1440
+msgid "media-source"
+msgstr ""
+
+#. TRANSLATORS: Alternate
+#: locale/ipp-strings.c:1442
+msgid "media-source.alternate"
+msgstr ""
+
+#. TRANSLATORS: Alternate Roll
+#: locale/ipp-strings.c:1444
+msgid "media-source.alternate-roll"
+msgstr ""
+
+#. TRANSLATORS: Automatic
+#: locale/ipp-strings.c:1446
+msgid "media-source.auto"
+msgstr ""
+
+#. TRANSLATORS: Bottom
+#: locale/ipp-strings.c:1448
+msgid "media-source.bottom"
+msgstr ""
+
+#. TRANSLATORS: By-pass Tray
+#: locale/ipp-strings.c:1450
+msgid "media-source.by-pass-tray"
+msgstr ""
+
+#. TRANSLATORS: Center
+#: locale/ipp-strings.c:1452
+msgid "media-source.center"
+msgstr ""
+
+#. TRANSLATORS: Disc
+#: locale/ipp-strings.c:1454
+msgid "media-source.disc"
+msgstr ""
+
+#. TRANSLATORS: Envelope
+#: locale/ipp-strings.c:1456
+msgid "media-source.envelope"
+msgstr ""
+
+#. TRANSLATORS: Hagaki
+#: locale/ipp-strings.c:1458
+msgid "media-source.hagaki"
+msgstr ""
+
+#. TRANSLATORS: Large Capacity
+#: locale/ipp-strings.c:1460
+msgid "media-source.large-capacity"
+msgstr ""
+
+#. TRANSLATORS: Left
+#: locale/ipp-strings.c:1462
+msgid "media-source.left"
+msgstr ""
+
+#. TRANSLATORS: Main
+#: locale/ipp-strings.c:1464
+msgid "media-source.main"
+msgstr ""
+
+#. TRANSLATORS: Main Roll
+#: locale/ipp-strings.c:1466
+msgid "media-source.main-roll"
+msgstr ""
+
+#. TRANSLATORS: Manual
+#: locale/ipp-strings.c:1468
+msgid "media-source.manual"
+msgstr ""
+
+#. TRANSLATORS: Middle
+#: locale/ipp-strings.c:1470
+msgid "media-source.middle"
+msgstr ""
+
+#. TRANSLATORS: Photo
+#: locale/ipp-strings.c:1472
+msgid "media-source.photo"
+msgstr ""
+
+#. TRANSLATORS: Rear
+#: locale/ipp-strings.c:1474
+msgid "media-source.rear"
+msgstr ""
+
+#. TRANSLATORS: Right
+#: locale/ipp-strings.c:1476
+msgid "media-source.right"
+msgstr ""
+
+#. TRANSLATORS: Roll 1
+#: locale/ipp-strings.c:1478
+msgid "media-source.roll-1"
+msgstr ""
+
+#. TRANSLATORS: Roll 10
+#: locale/ipp-strings.c:1480
+msgid "media-source.roll-10"
+msgstr ""
+
+#. TRANSLATORS: Roll 2
+#: locale/ipp-strings.c:1482
+msgid "media-source.roll-2"
+msgstr ""
+
+#. TRANSLATORS: Roll 3
+#: locale/ipp-strings.c:1484
+msgid "media-source.roll-3"
+msgstr ""
+
+#. TRANSLATORS: Roll 4
+#: locale/ipp-strings.c:1486
+msgid "media-source.roll-4"
+msgstr ""
+
+#. TRANSLATORS: Roll 5
+#: locale/ipp-strings.c:1488
+msgid "media-source.roll-5"
+msgstr ""
+
+#. TRANSLATORS: Roll 6
+#: locale/ipp-strings.c:1490
+msgid "media-source.roll-6"
+msgstr ""
+
+#. TRANSLATORS: Roll 7
+#: locale/ipp-strings.c:1492
+msgid "media-source.roll-7"
+msgstr ""
+
+#. TRANSLATORS: Roll 8
+#: locale/ipp-strings.c:1494
+msgid "media-source.roll-8"
+msgstr ""
+
+#. TRANSLATORS: Roll 9
+#: locale/ipp-strings.c:1496
+msgid "media-source.roll-9"
+msgstr ""
+
+#. TRANSLATORS: Side
+#: locale/ipp-strings.c:1498
+msgid "media-source.side"
+msgstr ""
+
+#. TRANSLATORS: Top
+#: locale/ipp-strings.c:1500
+msgid "media-source.top"
+msgstr ""
+
+#. TRANSLATORS: Tray 1
+#: locale/ipp-strings.c:1502
+msgid "media-source.tray-1"
+msgstr ""
+
+#. TRANSLATORS: Tray 10
+#: locale/ipp-strings.c:1504
+msgid "media-source.tray-10"
+msgstr ""
+
+#. TRANSLATORS: Tray 11
+#: locale/ipp-strings.c:1506
+msgid "media-source.tray-11"
+msgstr ""
+
+#. TRANSLATORS: Tray 12
+#: locale/ipp-strings.c:1508
+msgid "media-source.tray-12"
+msgstr ""
+
+#. TRANSLATORS: Tray 13
+#: locale/ipp-strings.c:1510
+msgid "media-source.tray-13"
+msgstr ""
+
+#. TRANSLATORS: Tray 14
+#: locale/ipp-strings.c:1512
+msgid "media-source.tray-14"
+msgstr ""
+
+#. TRANSLATORS: Tray 15
+#: locale/ipp-strings.c:1514
+msgid "media-source.tray-15"
+msgstr ""
+
+#. TRANSLATORS: Tray 16
+#: locale/ipp-strings.c:1516
+msgid "media-source.tray-16"
+msgstr ""
+
+#. TRANSLATORS: Tray 17
+#: locale/ipp-strings.c:1518
+msgid "media-source.tray-17"
+msgstr ""
+
+#. TRANSLATORS: Tray 18
+#: locale/ipp-strings.c:1520
+msgid "media-source.tray-18"
+msgstr ""
+
+#. TRANSLATORS: Tray 19
+#: locale/ipp-strings.c:1522
+msgid "media-source.tray-19"
+msgstr ""
+
+#. TRANSLATORS: Tray 2
+#: locale/ipp-strings.c:1524
+msgid "media-source.tray-2"
+msgstr ""
+
+#. TRANSLATORS: Tray 20
+#: locale/ipp-strings.c:1526
+msgid "media-source.tray-20"
+msgstr ""
+
+#. TRANSLATORS: Tray 3
+#: locale/ipp-strings.c:1528
+msgid "media-source.tray-3"
+msgstr ""
+
+#. TRANSLATORS: Tray 4
+#: locale/ipp-strings.c:1530
+msgid "media-source.tray-4"
+msgstr ""
+
+#. TRANSLATORS: Tray 5
+#: locale/ipp-strings.c:1532
+msgid "media-source.tray-5"
+msgstr ""
+
+#. TRANSLATORS: Tray 6
+#: locale/ipp-strings.c:1534
+msgid "media-source.tray-6"
+msgstr ""
+
+#. TRANSLATORS: Tray 7
+#: locale/ipp-strings.c:1536
+msgid "media-source.tray-7"
+msgstr ""
+
+#. TRANSLATORS: Tray 8
+#: locale/ipp-strings.c:1538
+msgid "media-source.tray-8"
+msgstr ""
+
+#. TRANSLATORS: Tray 9
+#: locale/ipp-strings.c:1540
+msgid "media-source.tray-9"
+msgstr ""
+
+#. TRANSLATORS: Media Thickness
+#: locale/ipp-strings.c:1542
+msgid "media-thickness"
+msgstr ""
+
+#. TRANSLATORS: Media Tooth (Texture)
+#: locale/ipp-strings.c:1544
+msgid "media-tooth"
+msgstr ""
+
+#. TRANSLATORS: Antique
+#: locale/ipp-strings.c:1546
+msgid "media-tooth.antique"
+msgstr ""
+
+#. TRANSLATORS: Extra Smooth
+#: locale/ipp-strings.c:1548
+msgid "media-tooth.calendared"
+msgstr ""
+
+#. TRANSLATORS: Coarse
+#: locale/ipp-strings.c:1550
+msgid "media-tooth.coarse"
+msgstr ""
+
+#. TRANSLATORS: Fine
+#: locale/ipp-strings.c:1552
+msgid "media-tooth.fine"
+msgstr ""
+
+#. TRANSLATORS: Linen
+#: locale/ipp-strings.c:1554
+msgid "media-tooth.linen"
+msgstr ""
+
+#. TRANSLATORS: Medium
+#: locale/ipp-strings.c:1556
+msgid "media-tooth.medium"
+msgstr ""
+
+#. TRANSLATORS: Smooth
+#: locale/ipp-strings.c:1558
+msgid "media-tooth.smooth"
+msgstr ""
+
+#. TRANSLATORS: Stipple
+#: locale/ipp-strings.c:1560
+msgid "media-tooth.stipple"
+msgstr ""
+
+#. TRANSLATORS: Rough
+#: locale/ipp-strings.c:1562
+msgid "media-tooth.uncalendared"
+msgstr ""
+
+#. TRANSLATORS: Vellum
+#: locale/ipp-strings.c:1564
+msgid "media-tooth.vellum"
+msgstr ""
+
+#. TRANSLATORS: Media Top Margin
+#: locale/ipp-strings.c:1566
+msgid "media-top-margin"
+msgstr ""
+
+#. TRANSLATORS: Media Type
+#: locale/ipp-strings.c:1568
+msgid "media-type"
+msgstr ""
+
+#. TRANSLATORS: Aluminum
+#: locale/ipp-strings.c:1570
+msgid "media-type.aluminum"
+msgstr ""
+
+#. TRANSLATORS: Automatic
+#: locale/ipp-strings.c:1572
+msgid "media-type.auto"
+msgstr ""
+
+#. TRANSLATORS: Back Print Film
+#: locale/ipp-strings.c:1574
+msgid "media-type.back-print-film"
+msgstr ""
+
+#. TRANSLATORS: Cardboard
+#: locale/ipp-strings.c:1576
+msgid "media-type.cardboard"
+msgstr ""
+
+#. TRANSLATORS: Cardstock
+#: locale/ipp-strings.c:1578
+msgid "media-type.cardstock"
+msgstr ""
+
+#. TRANSLATORS: CD
+#: locale/ipp-strings.c:1580
+msgid "media-type.cd"
+msgstr ""
+
+#. TRANSLATORS: Continuous
+#: locale/ipp-strings.c:1582
+msgid "media-type.continuous"
+msgstr ""
+
+#. TRANSLATORS: Continuous Long
+#: locale/ipp-strings.c:1584
+msgid "media-type.continuous-long"
+msgstr ""
+
+#. TRANSLATORS: Continuous Short
+#: locale/ipp-strings.c:1586
+msgid "media-type.continuous-short"
+msgstr ""
+
+#. TRANSLATORS: Corrugated Board
+#: locale/ipp-strings.c:1588
+msgid "media-type.corrugated-board"
+msgstr ""
+
+#. TRANSLATORS: Optical Disc
+#: locale/ipp-strings.c:1590
+msgid "media-type.disc"
+msgstr ""
+
+#. TRANSLATORS: Glossy Optical Disc
+#: locale/ipp-strings.c:1592
+msgid "media-type.disc-glossy"
+msgstr ""
+
+#. TRANSLATORS: High Gloss Optical Disc
+#: locale/ipp-strings.c:1594
+msgid "media-type.disc-high-gloss"
+msgstr ""
+
+#. TRANSLATORS: Matte Optical Disc
+#: locale/ipp-strings.c:1596
+msgid "media-type.disc-matte"
+msgstr ""
+
+#. TRANSLATORS: Satin Optical Disc
+#: locale/ipp-strings.c:1598
+msgid "media-type.disc-satin"
+msgstr ""
+
+#. TRANSLATORS: Semi-Gloss Optical Disc
+#: locale/ipp-strings.c:1600
+msgid "media-type.disc-semi-gloss"
+msgstr ""
+
+#. TRANSLATORS: Double Wall
+#: locale/ipp-strings.c:1602
+msgid "media-type.double-wall"
+msgstr ""
+
+#. TRANSLATORS: Dry Film
+#: locale/ipp-strings.c:1604
+msgid "media-type.dry-film"
+msgstr ""
+
+#. TRANSLATORS: DVD
+#: locale/ipp-strings.c:1606
+msgid "media-type.dvd"
+msgstr ""
+
+#. TRANSLATORS: Embossing Foil
+#: locale/ipp-strings.c:1608
+msgid "media-type.embossing-foil"
+msgstr ""
+
+#. TRANSLATORS: End Board
+#: locale/ipp-strings.c:1610
+msgid "media-type.end-board"
+msgstr ""
+
+#. TRANSLATORS: Envelope
+#: locale/ipp-strings.c:1612
+msgid "media-type.envelope"
+msgstr ""
+
+#. TRANSLATORS: Archival Envelope
+#: locale/ipp-strings.c:1614
+msgid "media-type.envelope-archival"
+msgstr ""
+
+#. TRANSLATORS: Bond Envelope
+#: locale/ipp-strings.c:1616
+msgid "media-type.envelope-bond"
+msgstr ""
+
+#. TRANSLATORS: Coated Envelope
+#: locale/ipp-strings.c:1618
+msgid "media-type.envelope-coated"
+msgstr ""
+
+#. TRANSLATORS: Cotton Envelope
+#: locale/ipp-strings.c:1620
+msgid "media-type.envelope-cotton"
+msgstr ""
+
+#. TRANSLATORS: Fine Envelope
+#: locale/ipp-strings.c:1622
+msgid "media-type.envelope-fine"
+msgstr ""
+
+#. TRANSLATORS: Heavyweight Envelope
+#: locale/ipp-strings.c:1624
+msgid "media-type.envelope-heavyweight"
+msgstr ""
+
+#. TRANSLATORS: Inkjet Envelope
+#: locale/ipp-strings.c:1626
+msgid "media-type.envelope-inkjet"
+msgstr ""
+
+#. TRANSLATORS: Lightweight Envelope
+#: locale/ipp-strings.c:1628
+msgid "media-type.envelope-lightweight"
+msgstr ""
+
+#. TRANSLATORS: Plain Envelope
+#: locale/ipp-strings.c:1630
+msgid "media-type.envelope-plain"
+msgstr ""
+
+#. TRANSLATORS: Preprinted Envelope
+#: locale/ipp-strings.c:1632
+msgid "media-type.envelope-preprinted"
+msgstr ""
+
+#. TRANSLATORS: Windowed Envelope
+#: locale/ipp-strings.c:1634
+msgid "media-type.envelope-window"
+msgstr ""
+
+#. TRANSLATORS: Fabric
+#: locale/ipp-strings.c:1636
+msgid "media-type.fabric"
+msgstr ""
+
+#. TRANSLATORS: Archival Fabric
+#: locale/ipp-strings.c:1638
+msgid "media-type.fabric-archival"
+msgstr ""
+
+#. TRANSLATORS: Glossy Fabric
+#: locale/ipp-strings.c:1640
+msgid "media-type.fabric-glossy"
+msgstr ""
+
+#. TRANSLATORS: High Gloss Fabric
+#: locale/ipp-strings.c:1642
+msgid "media-type.fabric-high-gloss"
+msgstr ""
+
+#. TRANSLATORS: Matte Fabric
+#: locale/ipp-strings.c:1644
+msgid "media-type.fabric-matte"
+msgstr ""
+
+#. TRANSLATORS: Semi-Gloss Fabric
+#: locale/ipp-strings.c:1646
+msgid "media-type.fabric-semi-gloss"
+msgstr ""
+
+#. TRANSLATORS: Waterproof Fabric
+#: locale/ipp-strings.c:1648
+msgid "media-type.fabric-waterproof"
+msgstr ""
+
+#. TRANSLATORS: Film
+#: locale/ipp-strings.c:1650
+msgid "media-type.film"
+msgstr ""
+
+#. TRANSLATORS: Flexo Base
+#: locale/ipp-strings.c:1652
+msgid "media-type.flexo-base"
+msgstr ""
+
+#. TRANSLATORS: Flexo Photo Polymer
+#: locale/ipp-strings.c:1654
+msgid "media-type.flexo-photo-polymer"
+msgstr ""
+
+#. TRANSLATORS: Flute
+#: locale/ipp-strings.c:1656
+msgid "media-type.flute"
+msgstr ""
+
+#. TRANSLATORS: Foil
+#: locale/ipp-strings.c:1658
+msgid "media-type.foil"
+msgstr ""
+
+#. TRANSLATORS: Full Cut Tabs
+#: locale/ipp-strings.c:1660
+msgid "media-type.full-cut-tabs"
+msgstr ""
+
+#. TRANSLATORS: Glass
+#: locale/ipp-strings.c:1662
+msgid "media-type.glass"
+msgstr ""
+
+#. TRANSLATORS: Glass Colored
+#: locale/ipp-strings.c:1664
+msgid "media-type.glass-colored"
+msgstr ""
+
+#. TRANSLATORS: Glass Opaque
+#: locale/ipp-strings.c:1666
+msgid "media-type.glass-opaque"
+msgstr ""
+
+#. TRANSLATORS: Glass Surfaced
+#: locale/ipp-strings.c:1668
+msgid "media-type.glass-surfaced"
+msgstr ""
+
+#. TRANSLATORS: Glass Textured
+#: locale/ipp-strings.c:1670
+msgid "media-type.glass-textured"
+msgstr ""
+
+#. TRANSLATORS: Gravure Cylinder
+#: locale/ipp-strings.c:1672
+msgid "media-type.gravure-cylinder"
+msgstr ""
+
+#. TRANSLATORS: Image Setter Paper
+#: locale/ipp-strings.c:1674
+msgid "media-type.image-setter-paper"
+msgstr ""
+
+#. TRANSLATORS: Imaging Cylinder
+#: locale/ipp-strings.c:1676
+msgid "media-type.imaging-cylinder"
+msgstr ""
+
+#. TRANSLATORS: Labels
+#: locale/ipp-strings.c:1678
+msgid "media-type.labels"
+msgstr ""
+
+#. TRANSLATORS: Colored Labels
+#: locale/ipp-strings.c:1680
+msgid "media-type.labels-colored"
+msgstr ""
+
+#. TRANSLATORS: Glossy Labels
+#: locale/ipp-strings.c:1682
+msgid "media-type.labels-glossy"
+msgstr ""
+
+#. TRANSLATORS: High Gloss Labels
+#: locale/ipp-strings.c:1684
+msgid "media-type.labels-high-gloss"
+msgstr ""
+
+#. TRANSLATORS: Inkjet Labels
+#: locale/ipp-strings.c:1686
+msgid "media-type.labels-inkjet"
+msgstr ""
+
+#. TRANSLATORS: Matte Labels
+#: locale/ipp-strings.c:1688
+msgid "media-type.labels-matte"
+msgstr ""
+
+#. TRANSLATORS: Permanent Labels
+#: locale/ipp-strings.c:1690
+msgid "media-type.labels-permanent"
+msgstr ""
+
+#. TRANSLATORS: Satin Labels
+#: locale/ipp-strings.c:1692
+msgid "media-type.labels-satin"
+msgstr ""
+
+#. TRANSLATORS: Security Labels
+#: locale/ipp-strings.c:1694
+msgid "media-type.labels-security"
+msgstr ""
+
+#. TRANSLATORS: Semi-Gloss Labels
+#: locale/ipp-strings.c:1696
+msgid "media-type.labels-semi-gloss"
+msgstr ""
+
+#. TRANSLATORS: Laminating Foil
+#: locale/ipp-strings.c:1698
+msgid "media-type.laminating-foil"
+msgstr ""
+
+#. TRANSLATORS: Letterhead
+#: locale/ipp-strings.c:1700
+msgid "media-type.letterhead"
+msgstr ""
+
+#. TRANSLATORS: Metal
+#: locale/ipp-strings.c:1702
+msgid "media-type.metal"
+msgstr ""
+
+#. TRANSLATORS: Metal Glossy
+#: locale/ipp-strings.c:1704
+msgid "media-type.metal-glossy"
+msgstr ""
+
+#. TRANSLATORS: Metal High Gloss
+#: locale/ipp-strings.c:1706
+msgid "media-type.metal-high-gloss"
+msgstr ""
+
+#. TRANSLATORS: Metal Matte
+#: locale/ipp-strings.c:1708
+msgid "media-type.metal-matte"
+msgstr ""
+
+#. TRANSLATORS: Metal Satin
+#: locale/ipp-strings.c:1710
+msgid "media-type.metal-satin"
+msgstr ""
+
+#. TRANSLATORS: Metal Semi Gloss
+#: locale/ipp-strings.c:1712
+msgid "media-type.metal-semi-gloss"
+msgstr ""
+
+#. TRANSLATORS: Mounting Tape
+#: locale/ipp-strings.c:1714
+msgid "media-type.mounting-tape"
+msgstr ""
+
+#. TRANSLATORS: Multi Layer
+#: locale/ipp-strings.c:1716
+msgid "media-type.multi-layer"
+msgstr ""
+
+#. TRANSLATORS: Multi Part Form
+#: locale/ipp-strings.c:1718
+msgid "media-type.multi-part-form"
+msgstr ""
+
+#. TRANSLATORS: Other
+#: locale/ipp-strings.c:1720
+msgid "media-type.other"
+msgstr ""
+
+#. TRANSLATORS: Paper
+#: locale/ipp-strings.c:1722
+msgid "media-type.paper"
+msgstr ""
+
+#. TRANSLATORS: Photo Paper
+#: locale/ipp-strings.c:1724
+msgid "media-type.photographic"
+msgstr ""
+
+#. TRANSLATORS: Photographic Archival
+#: locale/ipp-strings.c:1726
+msgid "media-type.photographic-archival"
+msgstr ""
+
+#. TRANSLATORS: Photo Film
+#: locale/ipp-strings.c:1728
+msgid "media-type.photographic-film"
+msgstr ""
+
+#. TRANSLATORS: Glossy Photo Paper
+#: locale/ipp-strings.c:1730
+msgid "media-type.photographic-glossy"
+msgstr ""
+
+#. TRANSLATORS: High Gloss Photo Paper
+#: locale/ipp-strings.c:1732
+msgid "media-type.photographic-high-gloss"
+msgstr ""
+
+#. TRANSLATORS: Matte Photo Paper
+#: locale/ipp-strings.c:1734
+msgid "media-type.photographic-matte"
+msgstr ""
+
+#. TRANSLATORS: Satin Photo Paper
+#: locale/ipp-strings.c:1736
+msgid "media-type.photographic-satin"
+msgstr ""
+
+#. TRANSLATORS: Semi-Gloss Photo Paper
+#: locale/ipp-strings.c:1738
+msgid "media-type.photographic-semi-gloss"
+msgstr ""
+
+#. TRANSLATORS: Plastic
+#: locale/ipp-strings.c:1740
+msgid "media-type.plastic"
+msgstr ""
+
+#. TRANSLATORS: Plastic Archival
+#: locale/ipp-strings.c:1742
+msgid "media-type.plastic-archival"
+msgstr ""
+
+#. TRANSLATORS: Plastic Colored
+#: locale/ipp-strings.c:1744
+msgid "media-type.plastic-colored"
+msgstr ""
+
+#. TRANSLATORS: Plastic Glossy
+#: locale/ipp-strings.c:1746
+msgid "media-type.plastic-glossy"
+msgstr ""
+
+#. TRANSLATORS: Plastic High Gloss
+#: locale/ipp-strings.c:1748
+msgid "media-type.plastic-high-gloss"
+msgstr ""
+
+#. TRANSLATORS: Plastic Matte
+#: locale/ipp-strings.c:1750
+msgid "media-type.plastic-matte"
+msgstr ""
+
+#. TRANSLATORS: Plastic Satin
+#: locale/ipp-strings.c:1752
+msgid "media-type.plastic-satin"
+msgstr ""
+
+#. TRANSLATORS: Plastic Semi Gloss
+#: locale/ipp-strings.c:1754
+msgid "media-type.plastic-semi-gloss"
+msgstr ""
+
+#. TRANSLATORS: Plate
+#: locale/ipp-strings.c:1756
+msgid "media-type.plate"
+msgstr ""
+
+#. TRANSLATORS: Polyester
+#: locale/ipp-strings.c:1758
+msgid "media-type.polyester"
+msgstr ""
+
+#. TRANSLATORS: Pre Cut Tabs
+#: locale/ipp-strings.c:1760
+msgid "media-type.pre-cut-tabs"
+msgstr ""
+
+#. TRANSLATORS: Roll
+#: locale/ipp-strings.c:1762
+msgid "media-type.roll"
+msgstr ""
+
+#. TRANSLATORS: Screen
+#: locale/ipp-strings.c:1764
+msgid "media-type.screen"
+msgstr ""
+
+#. TRANSLATORS: Screen Paged
+#: locale/ipp-strings.c:1766
+msgid "media-type.screen-paged"
+msgstr ""
+
+#. TRANSLATORS: Self Adhesive
+#: locale/ipp-strings.c:1768
+msgid "media-type.self-adhesive"
+msgstr ""
+
+#. TRANSLATORS: Self Adhesive Film
+#: locale/ipp-strings.c:1770
+msgid "media-type.self-adhesive-film"
+msgstr ""
+
+#. TRANSLATORS: Shrink Foil
+#: locale/ipp-strings.c:1772
+msgid "media-type.shrink-foil"
+msgstr ""
+
+#. TRANSLATORS: Single Face
+#: locale/ipp-strings.c:1774
+msgid "media-type.single-face"
+msgstr ""
+
+#. TRANSLATORS: Single Wall
+#: locale/ipp-strings.c:1776
+msgid "media-type.single-wall"
+msgstr ""
+
+#. TRANSLATORS: Sleeve
+#: locale/ipp-strings.c:1778
+msgid "media-type.sleeve"
+msgstr ""
+
+#. TRANSLATORS: Stationery
+#: locale/ipp-strings.c:1780
+msgid "media-type.stationery"
+msgstr ""
+
+#. TRANSLATORS: Stationery Archival
+#: locale/ipp-strings.c:1782
+msgid "media-type.stationery-archival"
+msgstr ""
+
+#. TRANSLATORS: Coated Paper
+#: locale/ipp-strings.c:1784
+msgid "media-type.stationery-coated"
+msgstr ""
+
+#. TRANSLATORS: Stationery Cotton
+#: locale/ipp-strings.c:1786
+msgid "media-type.stationery-cotton"
+msgstr ""
+
+#. TRANSLATORS: Vellum Paper
+#: locale/ipp-strings.c:1788
+msgid "media-type.stationery-fine"
+msgstr ""
+
+#. TRANSLATORS: Heavyweight Paper
+#: locale/ipp-strings.c:1790
+msgid "media-type.stationery-heavyweight"
+msgstr ""
+
+#. TRANSLATORS: Stationery Heavyweight Coated
+#: locale/ipp-strings.c:1792
+msgid "media-type.stationery-heavyweight-coated"
+msgstr ""
+
+#. TRANSLATORS: Stationery Inkjet Paper
+#: locale/ipp-strings.c:1794
+msgid "media-type.stationery-inkjet"
+msgstr ""
+
+#. TRANSLATORS: Letterhead
+#: locale/ipp-strings.c:1796
+msgid "media-type.stationery-letterhead"
+msgstr ""
+
+#. TRANSLATORS: Lightweight Paper
+#: locale/ipp-strings.c:1798
+msgid "media-type.stationery-lightweight"
+msgstr ""
+
+#. TRANSLATORS: Preprinted Paper
+#: locale/ipp-strings.c:1800
+msgid "media-type.stationery-preprinted"
+msgstr ""
+
+#. TRANSLATORS: Punched Paper
+#: locale/ipp-strings.c:1802
+msgid "media-type.stationery-prepunched"
+msgstr ""
+
+#. TRANSLATORS: Tab Stock
+#: locale/ipp-strings.c:1804
+msgid "media-type.tab-stock"
+msgstr ""
+
+#. TRANSLATORS: Tractor
+#: locale/ipp-strings.c:1806
+msgid "media-type.tractor"
+msgstr ""
+
+#. TRANSLATORS: Transfer
+#: locale/ipp-strings.c:1808
+msgid "media-type.transfer"
+msgstr ""
+
+#. TRANSLATORS: Transparency
+#: locale/ipp-strings.c:1810
+msgid "media-type.transparency"
+msgstr ""
+
+#. TRANSLATORS: Triple Wall
+#: locale/ipp-strings.c:1812
+msgid "media-type.triple-wall"
+msgstr ""
+
+#. TRANSLATORS: Wet Film
+#: locale/ipp-strings.c:1814
+msgid "media-type.wet-film"
+msgstr ""
+
+#. TRANSLATORS: Media Weight (grams per m²)
+#: locale/ipp-strings.c:1816
+msgid "media-weight-metric"
+msgstr ""
+
+#. TRANSLATORS: 28 x 40″
+#: locale/ipp-strings.c:1818
+msgid "media.asme_f_28x40in"
+msgstr ""
+
+#. TRANSLATORS: A4 or US Letter
+#: locale/ipp-strings.c:1820
+msgid "media.choice_iso_a4_210x297mm_na_letter_8.5x11in"
+msgstr ""
+
+#. TRANSLATORS: 2a0
+#: locale/ipp-strings.c:1822
+msgid "media.iso_2a0_1189x1682mm"
+msgstr ""
+
+#. TRANSLATORS: A0
+#: locale/ipp-strings.c:1824
+msgid "media.iso_a0_841x1189mm"
+msgstr ""
+
+#. TRANSLATORS: A0x3
+#: locale/ipp-strings.c:1826
+msgid "media.iso_a0x3_1189x2523mm"
+msgstr ""
+
+#. TRANSLATORS: A10
+#: locale/ipp-strings.c:1828
+msgid "media.iso_a10_26x37mm"
+msgstr ""
+
+#. TRANSLATORS: A1
+#: locale/ipp-strings.c:1830
+msgid "media.iso_a1_594x841mm"
+msgstr ""
+
+#. TRANSLATORS: A1x3
+#: locale/ipp-strings.c:1832
+msgid "media.iso_a1x3_841x1783mm"
+msgstr ""
+
+#. TRANSLATORS: A1x4
+#: locale/ipp-strings.c:1834
+msgid "media.iso_a1x4_841x2378mm"
+msgstr ""
+
+#. TRANSLATORS: A2
+#: locale/ipp-strings.c:1836
+msgid "media.iso_a2_420x594mm"
+msgstr ""
+
+#. TRANSLATORS: A2x3
+#: locale/ipp-strings.c:1838
+msgid "media.iso_a2x3_594x1261mm"
+msgstr ""
+
+#. TRANSLATORS: A2x4
+#: locale/ipp-strings.c:1840
+msgid "media.iso_a2x4_594x1682mm"
+msgstr ""
+
+#. TRANSLATORS: A2x5
+#: locale/ipp-strings.c:1842
+msgid "media.iso_a2x5_594x2102mm"
+msgstr ""
+
+#. TRANSLATORS: A3 (Extra)
+#: locale/ipp-strings.c:1844
+msgid "media.iso_a3-extra_322x445mm"
+msgstr ""
+
+#. TRANSLATORS: A3
+#: locale/ipp-strings.c:1846
+msgid "media.iso_a3_297x420mm"
+msgstr ""
+
+#. TRANSLATORS: A3x3
+#: locale/ipp-strings.c:1848
+msgid "media.iso_a3x3_420x891mm"
+msgstr ""
+
+#. TRANSLATORS: A3x4
+#: locale/ipp-strings.c:1850
+msgid "media.iso_a3x4_420x1189mm"
+msgstr ""
+
+#. TRANSLATORS: A3x5
+#: locale/ipp-strings.c:1852
+msgid "media.iso_a3x5_420x1486mm"
+msgstr ""
+
+#. TRANSLATORS: A3x6
+#: locale/ipp-strings.c:1854
+msgid "media.iso_a3x6_420x1783mm"
+msgstr ""
+
+#. TRANSLATORS: A3x7
+#: locale/ipp-strings.c:1856
+msgid "media.iso_a3x7_420x2080mm"
+msgstr ""
+
+#. TRANSLATORS: A4 (Extra)
+#: locale/ipp-strings.c:1858
+msgid "media.iso_a4-extra_235.5x322.3mm"
+msgstr ""
+
+#. TRANSLATORS: A4 (Tab)
+#: locale/ipp-strings.c:1860
+msgid "media.iso_a4-tab_225x297mm"
+msgstr ""
+
+#. TRANSLATORS: A4
+#: locale/ipp-strings.c:1862
+msgid "media.iso_a4_210x297mm"
+msgstr ""
+
+#. TRANSLATORS: A4x3
+#: locale/ipp-strings.c:1864
+msgid "media.iso_a4x3_297x630mm"
+msgstr ""
+
+#. TRANSLATORS: A4x4
+#: locale/ipp-strings.c:1866
+msgid "media.iso_a4x4_297x841mm"
+msgstr ""
+
+#. TRANSLATORS: A4x5
+#: locale/ipp-strings.c:1868
+msgid "media.iso_a4x5_297x1051mm"
+msgstr ""
+
+#. TRANSLATORS: A4x6
+#: locale/ipp-strings.c:1870
+msgid "media.iso_a4x6_297x1261mm"
+msgstr ""
+
+#. TRANSLATORS: A4x7
+#: locale/ipp-strings.c:1872
+msgid "media.iso_a4x7_297x1471mm"
+msgstr ""
+
+#. TRANSLATORS: A4x8
+#: locale/ipp-strings.c:1874
+msgid "media.iso_a4x8_297x1682mm"
+msgstr ""
+
+#. TRANSLATORS: A4x9
+#: locale/ipp-strings.c:1876
+msgid "media.iso_a4x9_297x1892mm"
+msgstr ""
+
+#. TRANSLATORS: A5 (Extra)
+#: locale/ipp-strings.c:1878
+msgid "media.iso_a5-extra_174x235mm"
+msgstr ""
+
+#. TRANSLATORS: A5
+#: locale/ipp-strings.c:1880
+msgid "media.iso_a5_148x210mm"
+msgstr ""
+
+#. TRANSLATORS: A6
+#: locale/ipp-strings.c:1882
+msgid "media.iso_a6_105x148mm"
+msgstr ""
+
+#. TRANSLATORS: A7
+#: locale/ipp-strings.c:1884
+msgid "media.iso_a7_74x105mm"
+msgstr ""
+
+#. TRANSLATORS: A8
+#: locale/ipp-strings.c:1886
+msgid "media.iso_a8_52x74mm"
+msgstr ""
+
+#. TRANSLATORS: A9
+#: locale/ipp-strings.c:1888
+msgid "media.iso_a9_37x52mm"
+msgstr ""
+
+#. TRANSLATORS: B0
+#: locale/ipp-strings.c:1890
+msgid "media.iso_b0_1000x1414mm"
+msgstr ""
+
+#. TRANSLATORS: B10
+#: locale/ipp-strings.c:1892
+msgid "media.iso_b10_31x44mm"
+msgstr ""
+
+#. TRANSLATORS: B1
+#: locale/ipp-strings.c:1894
+msgid "media.iso_b1_707x1000mm"
+msgstr ""
+
+#. TRANSLATORS: B2
+#: locale/ipp-strings.c:1896
+msgid "media.iso_b2_500x707mm"
+msgstr ""
+
+#. TRANSLATORS: B3
+#: locale/ipp-strings.c:1898
+msgid "media.iso_b3_353x500mm"
+msgstr ""
+
+#. TRANSLATORS: B4
+#: locale/ipp-strings.c:1900
+msgid "media.iso_b4_250x353mm"
+msgstr ""
+
+#. TRANSLATORS: B5 (Extra)
+#: locale/ipp-strings.c:1902
+msgid "media.iso_b5-extra_201x276mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope B5
+#: locale/ipp-strings.c:1904
+msgid "media.iso_b5_176x250mm"
+msgstr ""
+
+#. TRANSLATORS: B6
+#: locale/ipp-strings.c:1906
+msgid "media.iso_b6_125x176mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope B6/C4
+#: locale/ipp-strings.c:1908
+msgid "media.iso_b6c4_125x324mm"
+msgstr ""
+
+#. TRANSLATORS: B7
+#: locale/ipp-strings.c:1910
+msgid "media.iso_b7_88x125mm"
+msgstr ""
+
+#. TRANSLATORS: B8
+#: locale/ipp-strings.c:1912
+msgid "media.iso_b8_62x88mm"
+msgstr ""
+
+#. TRANSLATORS: B9
+#: locale/ipp-strings.c:1914
+msgid "media.iso_b9_44x62mm"
+msgstr ""
+
+#. TRANSLATORS: CEnvelope 0
+#: locale/ipp-strings.c:1916
+msgid "media.iso_c0_917x1297mm"
+msgstr ""
+
+#. TRANSLATORS: CEnvelope 10
+#: locale/ipp-strings.c:1918
+msgid "media.iso_c10_28x40mm"
+msgstr ""
+
+#. TRANSLATORS: CEnvelope 1
+#: locale/ipp-strings.c:1920
+msgid "media.iso_c1_648x917mm"
+msgstr ""
+
+#. TRANSLATORS: CEnvelope 2
+#: locale/ipp-strings.c:1922
+msgid "media.iso_c2_458x648mm"
+msgstr ""
+
+#. TRANSLATORS: CEnvelope 3
+#: locale/ipp-strings.c:1924
+msgid "media.iso_c3_324x458mm"
+msgstr ""
+
+#. TRANSLATORS: CEnvelope 4
+#: locale/ipp-strings.c:1926
+msgid "media.iso_c4_229x324mm"
+msgstr ""
+
+#. TRANSLATORS: CEnvelope 5
+#: locale/ipp-strings.c:1928
+msgid "media.iso_c5_162x229mm"
+msgstr ""
+
+#. TRANSLATORS: CEnvelope 6
+#: locale/ipp-strings.c:1930
+msgid "media.iso_c6_114x162mm"
+msgstr ""
+
+#. TRANSLATORS: CEnvelope 6c5
+#: locale/ipp-strings.c:1932
+msgid "media.iso_c6c5_114x229mm"
+msgstr ""
+
+#. TRANSLATORS: CEnvelope 7
+#: locale/ipp-strings.c:1934
+msgid "media.iso_c7_81x114mm"
+msgstr ""
+
+#. TRANSLATORS: CEnvelope 7c6
+#: locale/ipp-strings.c:1936
+msgid "media.iso_c7c6_81x162mm"
+msgstr ""
+
+#. TRANSLATORS: CEnvelope 8
+#: locale/ipp-strings.c:1938
+msgid "media.iso_c8_57x81mm"
+msgstr ""
+
+#. TRANSLATORS: CEnvelope 9
+#: locale/ipp-strings.c:1940
+msgid "media.iso_c9_40x57mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope DL
+#: locale/ipp-strings.c:1942
+msgid "media.iso_dl_110x220mm"
+msgstr ""
+
+#. TRANSLATORS: Id-1
+#: locale/ipp-strings.c:1944
+msgid "media.iso_id-1_53.98x85.6mm"
+msgstr ""
+
+#. TRANSLATORS: Id-3
+#: locale/ipp-strings.c:1946
+msgid "media.iso_id-3_88x125mm"
+msgstr ""
+
+#. TRANSLATORS: ISO RA0
+#: locale/ipp-strings.c:1948
+msgid "media.iso_ra0_860x1220mm"
+msgstr ""
+
+#. TRANSLATORS: ISO RA1
+#: locale/ipp-strings.c:1950
+msgid "media.iso_ra1_610x860mm"
+msgstr ""
+
+#. TRANSLATORS: ISO RA2
+#: locale/ipp-strings.c:1952
+msgid "media.iso_ra2_430x610mm"
+msgstr ""
+
+#. TRANSLATORS: ISO RA3
+#: locale/ipp-strings.c:1954
+msgid "media.iso_ra3_305x430mm"
+msgstr ""
+
+#. TRANSLATORS: ISO RA4
+#: locale/ipp-strings.c:1956
+msgid "media.iso_ra4_215x305mm"
+msgstr ""
+
+#. TRANSLATORS: ISO SRA0
+#: locale/ipp-strings.c:1958
+msgid "media.iso_sra0_900x1280mm"
+msgstr ""
+
+#. TRANSLATORS: ISO SRA1
+#: locale/ipp-strings.c:1960
+msgid "media.iso_sra1_640x900mm"
+msgstr ""
+
+#. TRANSLATORS: ISO SRA2
+#: locale/ipp-strings.c:1962
+msgid "media.iso_sra2_450x640mm"
+msgstr ""
+
+#. TRANSLATORS: ISO SRA3
+#: locale/ipp-strings.c:1964
+msgid "media.iso_sra3_320x450mm"
+msgstr ""
+
+#. TRANSLATORS: ISO SRA4
+#: locale/ipp-strings.c:1966
+msgid "media.iso_sra4_225x320mm"
+msgstr ""
+
+#. TRANSLATORS: JIS B0
+#: locale/ipp-strings.c:1968
+msgid "media.jis_b0_1030x1456mm"
+msgstr ""
+
+#. TRANSLATORS: JIS B10
+#: locale/ipp-strings.c:1970
+msgid "media.jis_b10_32x45mm"
+msgstr ""
+
+#. TRANSLATORS: JIS B1
+#: locale/ipp-strings.c:1972
+msgid "media.jis_b1_728x1030mm"
+msgstr ""
+
+#. TRANSLATORS: JIS B2
+#: locale/ipp-strings.c:1974
+msgid "media.jis_b2_515x728mm"
+msgstr ""
+
+#. TRANSLATORS: JIS B3
+#: locale/ipp-strings.c:1976
+msgid "media.jis_b3_364x515mm"
+msgstr ""
+
+#. TRANSLATORS: JIS B4
+#: locale/ipp-strings.c:1978
+msgid "media.jis_b4_257x364mm"
+msgstr ""
+
+#. TRANSLATORS: JIS B5
+#: locale/ipp-strings.c:1980
+msgid "media.jis_b5_182x257mm"
+msgstr ""
+
+#. TRANSLATORS: JIS B6
+#: locale/ipp-strings.c:1982
+msgid "media.jis_b6_128x182mm"
+msgstr ""
+
+#. TRANSLATORS: JIS B7
+#: locale/ipp-strings.c:1984
+msgid "media.jis_b7_91x128mm"
+msgstr ""
+
+#. TRANSLATORS: JIS B8
+#: locale/ipp-strings.c:1986
+msgid "media.jis_b8_64x91mm"
+msgstr ""
+
+#. TRANSLATORS: JIS B9
+#: locale/ipp-strings.c:1988
+msgid "media.jis_b9_45x64mm"
+msgstr ""
+
+#. TRANSLATORS: JIS Executive
+#: locale/ipp-strings.c:1990
+msgid "media.jis_exec_216x330mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Chou 2
+#: locale/ipp-strings.c:1992
+msgid "media.jpn_chou2_111.1x146mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Chou 3
+#: locale/ipp-strings.c:1994
+msgid "media.jpn_chou3_120x235mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Chou 40
+#: locale/ipp-strings.c:1996
+msgid "media.jpn_chou40_90x225mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Chou 4
+#: locale/ipp-strings.c:1998
+msgid "media.jpn_chou4_90x205mm"
+msgstr ""
+
+#. TRANSLATORS: Hagaki
+#: locale/ipp-strings.c:2000
+msgid "media.jpn_hagaki_100x148mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Kahu
+#: locale/ipp-strings.c:2002
+msgid "media.jpn_kahu_240x322.1mm"
+msgstr ""
+
+#. TRANSLATORS: 270 x 382mm
+#: locale/ipp-strings.c:2004
+msgid "media.jpn_kaku1_270x382mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Kahu 2
+#: locale/ipp-strings.c:2006
+msgid "media.jpn_kaku2_240x332mm"
+msgstr ""
+
+#. TRANSLATORS: 216 x 277mm
+#: locale/ipp-strings.c:2008
+msgid "media.jpn_kaku3_216x277mm"
+msgstr ""
+
+#. TRANSLATORS: 197 x 267mm
+#: locale/ipp-strings.c:2010
+msgid "media.jpn_kaku4_197x267mm"
+msgstr ""
+
+#. TRANSLATORS: 190 x 240mm
+#: locale/ipp-strings.c:2012
+msgid "media.jpn_kaku5_190x240mm"
+msgstr ""
+
+#. TRANSLATORS: 142 x 205mm
+#: locale/ipp-strings.c:2014
+msgid "media.jpn_kaku7_142x205mm"
+msgstr ""
+
+#. TRANSLATORS: 119 x 197mm
+#: locale/ipp-strings.c:2016
+msgid "media.jpn_kaku8_119x197mm"
+msgstr ""
+
+#. TRANSLATORS: Oufuku Reply Postcard
+#: locale/ipp-strings.c:2018
+msgid "media.jpn_oufuku_148x200mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope You 4
+#: locale/ipp-strings.c:2020
+msgid "media.jpn_you4_105x235mm"
+msgstr ""
+
+#. TRANSLATORS: 10 x 11″
+#: locale/ipp-strings.c:2022
+msgid "media.na_10x11_10x11in"
+msgstr ""
+
+#. TRANSLATORS: 10 x 13″
+#: locale/ipp-strings.c:2024
+msgid "media.na_10x13_10x13in"
+msgstr ""
+
+#. TRANSLATORS: 10 x 14″
+#: locale/ipp-strings.c:2026
+msgid "media.na_10x14_10x14in"
+msgstr ""
+
+#. TRANSLATORS: 10 x 15″
+#: locale/ipp-strings.c:2028
+msgid "media.na_10x15_10x15in"
+msgstr ""
+
+#. TRANSLATORS: 11 x 12″
+#: locale/ipp-strings.c:2030
+msgid "media.na_11x12_11x12in"
+msgstr ""
+
+#. TRANSLATORS: 11 x 15″
+#: locale/ipp-strings.c:2032
+msgid "media.na_11x15_11x15in"
+msgstr ""
+
+#. TRANSLATORS: 12 x 19″
+#: locale/ipp-strings.c:2034
+msgid "media.na_12x19_12x19in"
+msgstr ""
+
+#. TRANSLATORS: 5 x 7″
+#: locale/ipp-strings.c:2036
+msgid "media.na_5x7_5x7in"
+msgstr ""
+
+#. TRANSLATORS: 6 x 9″
+#: locale/ipp-strings.c:2038
+msgid "media.na_6x9_6x9in"
+msgstr ""
+
+#. TRANSLATORS: 7 x 9″
+#: locale/ipp-strings.c:2040
+msgid "media.na_7x9_7x9in"
+msgstr ""
+
+#. TRANSLATORS: 9 x 11″
+#: locale/ipp-strings.c:2042
+msgid "media.na_9x11_9x11in"
+msgstr ""
+
+#. TRANSLATORS: Envelope A2
+#: locale/ipp-strings.c:2044
+msgid "media.na_a2_4.375x5.75in"
+msgstr ""
+
+#. TRANSLATORS: 9 x 12″
+#: locale/ipp-strings.c:2046
+msgid "media.na_arch-a_9x12in"
+msgstr ""
+
+#. TRANSLATORS: 12 x 18″
+#: locale/ipp-strings.c:2048
+msgid "media.na_arch-b_12x18in"
+msgstr ""
+
+#. TRANSLATORS: 18 x 24″
+#: locale/ipp-strings.c:2050
+msgid "media.na_arch-c_18x24in"
+msgstr ""
+
+#. TRANSLATORS: 24 x 36″
+#: locale/ipp-strings.c:2052
+msgid "media.na_arch-d_24x36in"
+msgstr ""
+
+#. TRANSLATORS: 26 x 38″
+#: locale/ipp-strings.c:2054
+msgid "media.na_arch-e2_26x38in"
+msgstr ""
+
+#. TRANSLATORS: 27 x 39″
+#: locale/ipp-strings.c:2056
+msgid "media.na_arch-e3_27x39in"
+msgstr ""
+
+#. TRANSLATORS: 36 x 48″
+#: locale/ipp-strings.c:2058
+msgid "media.na_arch-e_36x48in"
+msgstr ""
+
+#. TRANSLATORS: 12 x 19.17″
+#: locale/ipp-strings.c:2060
+msgid "media.na_b-plus_12x19.17in"
+msgstr ""
+
+#. TRANSLATORS: Envelope C5
+#: locale/ipp-strings.c:2062
+msgid "media.na_c5_6.5x9.5in"
+msgstr ""
+
+#. TRANSLATORS: 17 x 22″
+#: locale/ipp-strings.c:2064
+msgid "media.na_c_17x22in"
+msgstr ""
+
+#. TRANSLATORS: 22 x 34″
+#: locale/ipp-strings.c:2066
+msgid "media.na_d_22x34in"
+msgstr ""
+
+#. TRANSLATORS: 34 x 44″
+#: locale/ipp-strings.c:2068
+msgid "media.na_e_34x44in"
+msgstr ""
+
+#. TRANSLATORS: 11 x 14″
+#: locale/ipp-strings.c:2070
+msgid "media.na_edp_11x14in"
+msgstr ""
+
+#. TRANSLATORS: 12 x 14″
+#: locale/ipp-strings.c:2072
+msgid "media.na_eur-edp_12x14in"
+msgstr ""
+
+#. TRANSLATORS: Executive
+#: locale/ipp-strings.c:2074
+msgid "media.na_executive_7.25x10.5in"
+msgstr ""
+
+#. TRANSLATORS: 44 x 68″
+#: locale/ipp-strings.c:2076
+msgid "media.na_f_44x68in"
+msgstr ""
+
+#. TRANSLATORS: European Fanfold
+#: locale/ipp-strings.c:2078
+msgid "media.na_fanfold-eur_8.5x12in"
+msgstr ""
+
+#. TRANSLATORS: US Fanfold
+#: locale/ipp-strings.c:2080
+msgid "media.na_fanfold-us_11x14.875in"
+msgstr ""
+
+#. TRANSLATORS: Foolscap
+#: locale/ipp-strings.c:2082
+msgid "media.na_foolscap_8.5x13in"
+msgstr ""
+
+#. TRANSLATORS: 8 x 13″
+#: locale/ipp-strings.c:2084
+msgid "media.na_govt-legal_8x13in"
+msgstr ""
+
+#. TRANSLATORS: 8 x 10″
+#: locale/ipp-strings.c:2086
+msgid "media.na_govt-letter_8x10in"
+msgstr ""
+
+#. TRANSLATORS: 3 x 5″
+#: locale/ipp-strings.c:2088
+msgid "media.na_index-3x5_3x5in"
+msgstr ""
+
+#. TRANSLATORS: 6 x 8″
+#: locale/ipp-strings.c:2090
+msgid "media.na_index-4x6-ext_6x8in"
+msgstr ""
+
+#. TRANSLATORS: 4 x 6″
+#: locale/ipp-strings.c:2092
+msgid "media.na_index-4x6_4x6in"
+msgstr ""
+
+#. TRANSLATORS: 5 x 8″
+#: locale/ipp-strings.c:2094
+msgid "media.na_index-5x8_5x8in"
+msgstr ""
+
+#. TRANSLATORS: Statement
+#: locale/ipp-strings.c:2096
+msgid "media.na_invoice_5.5x8.5in"
+msgstr ""
+
+#. TRANSLATORS: 11 x 17″
+#: locale/ipp-strings.c:2098
+msgid "media.na_ledger_11x17in"
+msgstr ""
+
+#. TRANSLATORS: US Legal (Extra)
+#: locale/ipp-strings.c:2100
+msgid "media.na_legal-extra_9.5x15in"
+msgstr ""
+
+#. TRANSLATORS: US Legal
+#: locale/ipp-strings.c:2102
+msgid "media.na_legal_8.5x14in"
+msgstr ""
+
+#. TRANSLATORS: US Letter (Extra)
+#: locale/ipp-strings.c:2104
+msgid "media.na_letter-extra_9.5x12in"
+msgstr ""
+
+#. TRANSLATORS: US Letter (Plus)
+#: locale/ipp-strings.c:2106
+msgid "media.na_letter-plus_8.5x12.69in"
+msgstr ""
+
+#. TRANSLATORS: US Letter
+#: locale/ipp-strings.c:2108
+msgid "media.na_letter_8.5x11in"
+msgstr ""
+
+#. TRANSLATORS: Envelope Monarch
+#: locale/ipp-strings.c:2110
+msgid "media.na_monarch_3.875x7.5in"
+msgstr ""
+
+#. TRANSLATORS: Envelope #10
+#: locale/ipp-strings.c:2112
+msgid "media.na_number-10_4.125x9.5in"
+msgstr ""
+
+#. TRANSLATORS: Envelope #11
+#: locale/ipp-strings.c:2114
+msgid "media.na_number-11_4.5x10.375in"
+msgstr ""
+
+#. TRANSLATORS: Envelope #12
+#: locale/ipp-strings.c:2116
+msgid "media.na_number-12_4.75x11in"
+msgstr ""
+
+#. TRANSLATORS: Envelope #14
+#: locale/ipp-strings.c:2118
+msgid "media.na_number-14_5x11.5in"
+msgstr ""
+
+#. TRANSLATORS: Envelope #9
+#: locale/ipp-strings.c:2120
+msgid "media.na_number-9_3.875x8.875in"
+msgstr ""
+
+#. TRANSLATORS: 8.5 x 13.4″
+#: locale/ipp-strings.c:2122
+msgid "media.na_oficio_8.5x13.4in"
+msgstr ""
+
+#. TRANSLATORS: Envelope Personal
+#: locale/ipp-strings.c:2124
+msgid "media.na_personal_3.625x6.5in"
+msgstr ""
+
+#. TRANSLATORS: Quarto
+#: locale/ipp-strings.c:2126
+msgid "media.na_quarto_8.5x10.83in"
+msgstr ""
+
+#. TRANSLATORS: 8.94 x 14″
+#: locale/ipp-strings.c:2128
+msgid "media.na_super-a_8.94x14in"
+msgstr ""
+
+#. TRANSLATORS: 13 x 19″
+#: locale/ipp-strings.c:2130
+msgid "media.na_super-b_13x19in"
+msgstr ""
+
+#. TRANSLATORS: 30 x 42″
+#: locale/ipp-strings.c:2132
+msgid "media.na_wide-format_30x42in"
+msgstr ""
+
+#. TRANSLATORS: 12 x 16″
+#: locale/ipp-strings.c:2134
+msgid "media.oe_12x16_12x16in"
+msgstr ""
+
+#. TRANSLATORS: 14 x 17″
+#: locale/ipp-strings.c:2136
+msgid "media.oe_14x17_14x17in"
+msgstr ""
+
+#. TRANSLATORS: 18 x 22″
+#: locale/ipp-strings.c:2138
+msgid "media.oe_18x22_18x22in"
+msgstr ""
+
+#. TRANSLATORS: 17 x 24″
+#: locale/ipp-strings.c:2140
+msgid "media.oe_a2plus_17x24in"
+msgstr ""
+
+#. TRANSLATORS: 2 x 3.5″
+#: locale/ipp-strings.c:2142
+msgid "media.oe_business-card_2x3.5in"
+msgstr ""
+
+#. TRANSLATORS: 10 x 12″
+#: locale/ipp-strings.c:2144
+msgid "media.oe_photo-10r_10x12in"
+msgstr ""
+
+#. TRANSLATORS: 20 x 24″
+#: locale/ipp-strings.c:2146
+msgid "media.oe_photo-20r_20x24in"
+msgstr ""
+
+#. TRANSLATORS: 3.5 x 5″
+#: locale/ipp-strings.c:2148
+msgid "media.oe_photo-l_3.5x5in"
+msgstr ""
+
+#. TRANSLATORS: 10 x 15″
+#: locale/ipp-strings.c:2150
+msgid "media.oe_photo-s10r_10x15in"
+msgstr ""
+
+#. TRANSLATORS: 4 x 4″
+#: locale/ipp-strings.c:2152
+msgid "media.oe_square-photo_4x4in"
+msgstr ""
+
+#. TRANSLATORS: 5 x 5″
+#: locale/ipp-strings.c:2154
+msgid "media.oe_square-photo_5x5in"
+msgstr ""
+
+#. TRANSLATORS: 184 x 260mm
+#: locale/ipp-strings.c:2156
+msgid "media.om_16k_184x260mm"
+msgstr ""
+
+#. TRANSLATORS: 195 x 270mm
+#: locale/ipp-strings.c:2158
+msgid "media.om_16k_195x270mm"
+msgstr ""
+
+#. TRANSLATORS: 55 x 85mm
+#: locale/ipp-strings.c:2160
+msgid "media.om_business-card_55x85mm"
+msgstr ""
+
+#. TRANSLATORS: 55 x 91mm
+#: locale/ipp-strings.c:2162
+msgid "media.om_business-card_55x91mm"
+msgstr ""
+
+#. TRANSLATORS: 54 x 86mm
+#: locale/ipp-strings.c:2164
+msgid "media.om_card_54x86mm"
+msgstr ""
+
+#. TRANSLATORS: 275 x 395mm
+#: locale/ipp-strings.c:2166
+msgid "media.om_dai-pa-kai_275x395mm"
+msgstr ""
+
+#. TRANSLATORS: 89 x 119mm
+#: locale/ipp-strings.c:2168
+msgid "media.om_dsc-photo_89x119mm"
+msgstr ""
+
+#. TRANSLATORS: Folio
+#: locale/ipp-strings.c:2170
+msgid "media.om_folio-sp_215x315mm"
+msgstr ""
+
+#. TRANSLATORS: Folio (Special)
+#: locale/ipp-strings.c:2172
+msgid "media.om_folio_210x330mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Invitation
+#: locale/ipp-strings.c:2174
+msgid "media.om_invite_220x220mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Italian
+#: locale/ipp-strings.c:2176
+msgid "media.om_italian_110x230mm"
+msgstr ""
+
+#. TRANSLATORS: 198 x 275mm
+#: locale/ipp-strings.c:2178
+msgid "media.om_juuro-ku-kai_198x275mm"
+msgstr ""
+
+#. TRANSLATORS: 200 x 300
+#: locale/ipp-strings.c:2180
+msgid "media.om_large-photo_200x300"
+msgstr ""
+
+#. TRANSLATORS: 130 x 180mm
+#: locale/ipp-strings.c:2182
+msgid "media.om_medium-photo_130x180mm"
+msgstr ""
+
+#. TRANSLATORS: 267 x 389mm
+#: locale/ipp-strings.c:2184
+msgid "media.om_pa-kai_267x389mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Postfix
+#: locale/ipp-strings.c:2186
+msgid "media.om_postfix_114x229mm"
+msgstr ""
+
+#. TRANSLATORS: 100 x 150mm
+#: locale/ipp-strings.c:2188
+msgid "media.om_small-photo_100x150mm"
+msgstr ""
+
+#. TRANSLATORS: 89 x 89mm
+#: locale/ipp-strings.c:2190
+msgid "media.om_square-photo_89x89mm"
+msgstr ""
+
+#. TRANSLATORS: 100 x 200mm
+#: locale/ipp-strings.c:2192
+msgid "media.om_wide-photo_100x200mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Chinese #10
+#: locale/ipp-strings.c:2194
+msgid "media.prc_10_324x458mm"
+msgstr ""
+
+#. TRANSLATORS: Chinese 16k
+#: locale/ipp-strings.c:2196
+msgid "media.prc_16k_146x215mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Chinese #1
+#: locale/ipp-strings.c:2198
+msgid "media.prc_1_102x165mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Chinese #2
+#: locale/ipp-strings.c:2200
+msgid "media.prc_2_102x176mm"
+msgstr ""
+
+#. TRANSLATORS: Chinese 32k
+#: locale/ipp-strings.c:2202
+msgid "media.prc_32k_97x151mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Chinese #3
+#: locale/ipp-strings.c:2204
+msgid "media.prc_3_125x176mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Chinese #4
+#: locale/ipp-strings.c:2206
+msgid "media.prc_4_110x208mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Chinese #5
+#: locale/ipp-strings.c:2208
+msgid "media.prc_5_110x220mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Chinese #6
+#: locale/ipp-strings.c:2210
+msgid "media.prc_6_120x320mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Chinese #7
+#: locale/ipp-strings.c:2212
+msgid "media.prc_7_160x230mm"
+msgstr ""
+
+#. TRANSLATORS: Envelope Chinese #8
+#: locale/ipp-strings.c:2214
+msgid "media.prc_8_120x309mm"
+msgstr ""
+
+#. TRANSLATORS: ROC 16k
+#: locale/ipp-strings.c:2216
+msgid "media.roc_16k_7.75x10.75in"
+msgstr ""
+
+#. TRANSLATORS: ROC 8k
+#: locale/ipp-strings.c:2218
+msgid "media.roc_8k_10.75x15.5in"
+msgstr ""
+
+#: systemv/lpstat.c:1035
+#, c-format
+msgid "members of class %s:"
+msgstr ""
+
+#. TRANSLATORS: Multiple Document Handling
+#: locale/ipp-strings.c:2220
+msgid "multiple-document-handling"
+msgstr ""
+
+#. TRANSLATORS: Separate Documents Collated Copies
+#: locale/ipp-strings.c:2222
+msgid "multiple-document-handling.separate-documents-collated-copies"
+msgstr ""
+
+#. TRANSLATORS: Separate Documents Uncollated Copies
+#: locale/ipp-strings.c:2224
+msgid "multiple-document-handling.separate-documents-uncollated-copies"
+msgstr ""
+
+#. TRANSLATORS: Single Document
+#: locale/ipp-strings.c:2226
+msgid "multiple-document-handling.single-document"
+msgstr ""
+
+#. TRANSLATORS: Single Document New Sheet
+#: locale/ipp-strings.c:2228
+msgid "multiple-document-handling.single-document-new-sheet"
+msgstr ""
+
+#. TRANSLATORS: Multiple Object Handling
+#: locale/ipp-strings.c:2230
+msgid "multiple-object-handling"
+msgstr ""
+
+#. TRANSLATORS: Multiple Object Handling Actual
+#: locale/ipp-strings.c:2232
+msgid "multiple-object-handling-actual"
+msgstr ""
+
+#. TRANSLATORS: Automatic
+#: locale/ipp-strings.c:2234
+msgid "multiple-object-handling.auto"
+msgstr ""
+
+#. TRANSLATORS: Best Fit
+#: locale/ipp-strings.c:2236
+msgid "multiple-object-handling.best-fit"
+msgstr ""
+
+#. TRANSLATORS: Best Quality
+#: locale/ipp-strings.c:2238
+msgid "multiple-object-handling.best-quality"
+msgstr ""
+
+#. TRANSLATORS: Best Speed
+#: locale/ipp-strings.c:2240
+msgid "multiple-object-handling.best-speed"
+msgstr ""
+
+#. TRANSLATORS: One At A Time
+#: locale/ipp-strings.c:2242
+msgid "multiple-object-handling.one-at-a-time"
+msgstr ""
+
+#. TRANSLATORS: On Timeout
+#: locale/ipp-strings.c:2244
+msgid "multiple-operation-time-out-action"
+msgstr ""
+
+#. TRANSLATORS: Abort Job
+#: locale/ipp-strings.c:2246
+msgid "multiple-operation-time-out-action.abort-job"
+msgstr ""
+
+#. TRANSLATORS: Hold Job
+#: locale/ipp-strings.c:2248
+msgid "multiple-operation-time-out-action.hold-job"
+msgstr ""
+
+#. TRANSLATORS: Process Job
+#: locale/ipp-strings.c:2250
+msgid "multiple-operation-time-out-action.process-job"
+msgstr ""
+
+#: berkeley/lpq.c:554
+msgid "no entries"
+msgstr ""
+
+#: systemv/lpstat.c:1103
+msgid "no system default destination"
+msgstr ""
+
+#. TRANSLATORS: Noise Removal
+#: locale/ipp-strings.c:2252
+msgid "noise-removal"
+msgstr ""
+
+#. TRANSLATORS: Notify Attributes
+#: locale/ipp-strings.c:2254
+msgid "notify-attributes"
+msgstr ""
+
+#. TRANSLATORS: Notify Charset
+#: locale/ipp-strings.c:2256
+msgid "notify-charset"
+msgstr ""
+
+#. TRANSLATORS: Notify Events
+#: locale/ipp-strings.c:2258
+msgid "notify-events"
+msgstr ""
+
+#: scheduler/ipp.c:5872
+msgid "notify-events not specified."
+msgstr ""
+
+#. TRANSLATORS: Document Completed
+#: locale/ipp-strings.c:2260
+msgid "notify-events.document-completed"
+msgstr ""
+
+#. TRANSLATORS: Document Config Changed
+#: locale/ipp-strings.c:2262
+msgid "notify-events.document-config-changed"
+msgstr ""
+
+#. TRANSLATORS: Document Created
+#: locale/ipp-strings.c:2264
+msgid "notify-events.document-created"
+msgstr ""
+
+#. TRANSLATORS: Document Fetchable
+#: locale/ipp-strings.c:2266
+msgid "notify-events.document-fetchable"
+msgstr ""
+
+#. TRANSLATORS: Document State Changed
+#: locale/ipp-strings.c:2268
+msgid "notify-events.document-state-changed"
+msgstr ""
+
+#. TRANSLATORS: Document Stopped
+#: locale/ipp-strings.c:2270
+msgid "notify-events.document-stopped"
+msgstr ""
+
+#. TRANSLATORS: Job Completed
+#: locale/ipp-strings.c:2272
+msgid "notify-events.job-completed"
+msgstr ""
+
+#. TRANSLATORS: Job Config Changed
+#: locale/ipp-strings.c:2274
+msgid "notify-events.job-config-changed"
+msgstr ""
+
+#. TRANSLATORS: Job Created
+#: locale/ipp-strings.c:2276
+msgid "notify-events.job-created"
+msgstr ""
+
+#. TRANSLATORS: Job Fetchable
+#: locale/ipp-strings.c:2278
+msgid "notify-events.job-fetchable"
+msgstr ""
+
+#. TRANSLATORS: Job Progress
+#: locale/ipp-strings.c:2280
+msgid "notify-events.job-progress"
+msgstr ""
+
+#. TRANSLATORS: Job State Changed
+#: locale/ipp-strings.c:2282
+msgid "notify-events.job-state-changed"
+msgstr ""
+
+#. TRANSLATORS: Job Stopped
+#: locale/ipp-strings.c:2284
+msgid "notify-events.job-stopped"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:2286
+msgid "notify-events.none"
+msgstr ""
+
+#. TRANSLATORS: Printer Config Changed
+#: locale/ipp-strings.c:2288
+msgid "notify-events.printer-config-changed"
+msgstr ""
+
+#. TRANSLATORS: Printer Finishings Changed
+#: locale/ipp-strings.c:2290
+msgid "notify-events.printer-finishings-changed"
+msgstr ""
+
+#. TRANSLATORS: Printer Media Changed
+#: locale/ipp-strings.c:2292
+msgid "notify-events.printer-media-changed"
+msgstr ""
+
+#. TRANSLATORS: Printer Queue Order Changed
+#: locale/ipp-strings.c:2294
+msgid "notify-events.printer-queue-order-changed"
+msgstr ""
+
+#. TRANSLATORS: Printer Restarted
+#: locale/ipp-strings.c:2296
+msgid "notify-events.printer-restarted"
+msgstr ""
+
+#. TRANSLATORS: Printer Shutdown
+#: locale/ipp-strings.c:2298
+msgid "notify-events.printer-shutdown"
+msgstr ""
+
+#. TRANSLATORS: Printer State Changed
+#: locale/ipp-strings.c:2300
+msgid "notify-events.printer-state-changed"
+msgstr ""
+
+#. TRANSLATORS: Printer Stopped
+#: locale/ipp-strings.c:2302
+msgid "notify-events.printer-stopped"
+msgstr ""
+
+#. TRANSLATORS: Notify Get Interval
+#: locale/ipp-strings.c:2304
+msgid "notify-get-interval"
+msgstr ""
+
+#. TRANSLATORS: Notify Lease Duration
+#: locale/ipp-strings.c:2306
+msgid "notify-lease-duration"
+msgstr ""
+
+#. TRANSLATORS: Notify Natural Language
+#: locale/ipp-strings.c:2308
+msgid "notify-natural-language"
+msgstr ""
+
+#. TRANSLATORS: Notify Pull Method
+#: locale/ipp-strings.c:2310
+msgid "notify-pull-method"
+msgstr ""
+
+#. TRANSLATORS: Notify Recipient
+#: locale/ipp-strings.c:2312
+msgid "notify-recipient-uri"
+msgstr ""
+
+#: scheduler/ipp.c:2034 scheduler/ipp.c:5758
+#, c-format
+msgid "notify-recipient-uri URI \"%s\" is already used."
+msgstr ""
+
+#: scheduler/ipp.c:2024 scheduler/ipp.c:5748
+#, c-format
+msgid "notify-recipient-uri URI \"%s\" uses unknown scheme."
+msgstr ""
+
+#. TRANSLATORS: Notify Sequence Numbers
+#: locale/ipp-strings.c:2314
+msgid "notify-sequence-numbers"
+msgstr ""
+
+#. TRANSLATORS: Notify Subscription Ids
+#: locale/ipp-strings.c:2316
+msgid "notify-subscription-ids"
+msgstr ""
+
+#. TRANSLATORS: Notify Time Interval
+#: locale/ipp-strings.c:2318
+msgid "notify-time-interval"
+msgstr ""
+
+#. TRANSLATORS: Notify User Data
+#: locale/ipp-strings.c:2320
+msgid "notify-user-data"
+msgstr ""
+
+#. TRANSLATORS: Notify Wait
+#: locale/ipp-strings.c:2322
+msgid "notify-wait"
+msgstr ""
+
+#. TRANSLATORS: Number Of Retries
+#: locale/ipp-strings.c:2324
+msgid "number-of-retries"
+msgstr ""
+
+#. TRANSLATORS: Number-Up
+#: locale/ipp-strings.c:2326
+msgid "number-up"
+msgstr ""
+
+#. TRANSLATORS: Object Offset
+#: locale/ipp-strings.c:2328
+msgid "object-offset"
+msgstr ""
+
+#. TRANSLATORS: Object Size
+#: locale/ipp-strings.c:2330
+msgid "object-size"
+msgstr ""
+
+#. TRANSLATORS: Organization Name
+#: locale/ipp-strings.c:2332
+msgid "organization-name"
+msgstr ""
+
+#. TRANSLATORS: Orientation
+#: locale/ipp-strings.c:2334
+msgid "orientation-requested"
+msgstr ""
+
+#. TRANSLATORS: Portrait
+#: locale/ipp-strings.c:2336
+msgid "orientation-requested.3"
+msgstr ""
+
+#. TRANSLATORS: Landscape
+#: locale/ipp-strings.c:2338
+msgid "orientation-requested.4"
+msgstr ""
+
+#. TRANSLATORS: Reverse Landscape
+#: locale/ipp-strings.c:2340
+msgid "orientation-requested.5"
+msgstr ""
+
+#. TRANSLATORS: Reverse Portrait
+#: locale/ipp-strings.c:2342
+msgid "orientation-requested.6"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:2344
+msgid "orientation-requested.7"
+msgstr ""
+
+#. TRANSLATORS: Scanned Image Options
+#: locale/ipp-strings.c:2346
+msgid "output-attributes"
+msgstr ""
+
+#. TRANSLATORS: Output Tray
+#: locale/ipp-strings.c:2348
+msgid "output-bin"
+msgstr ""
+
+#. TRANSLATORS: Automatic
+#: locale/ipp-strings.c:2350
+msgid "output-bin.auto"
+msgstr ""
+
+#. TRANSLATORS: Bottom
+#: locale/ipp-strings.c:2352
+msgid "output-bin.bottom"
+msgstr ""
+
+#. TRANSLATORS: Center
+#: locale/ipp-strings.c:2354
+msgid "output-bin.center"
+msgstr ""
+
+#. TRANSLATORS: Face Down
+#: locale/ipp-strings.c:2356
+msgid "output-bin.face-down"
+msgstr ""
+
+#. TRANSLATORS: Face Up
+#: locale/ipp-strings.c:2358
+msgid "output-bin.face-up"
+msgstr ""
+
+#. TRANSLATORS: Large Capacity
+#: locale/ipp-strings.c:2360
+msgid "output-bin.large-capacity"
+msgstr ""
+
+#. TRANSLATORS: Left
+#: locale/ipp-strings.c:2362
+msgid "output-bin.left"
+msgstr ""
+
+#. TRANSLATORS: Mailbox 1
+#: locale/ipp-strings.c:2364
+msgid "output-bin.mailbox-1"
+msgstr ""
+
+#. TRANSLATORS: Mailbox 10
+#: locale/ipp-strings.c:2366
+msgid "output-bin.mailbox-10"
+msgstr ""
+
+#. TRANSLATORS: Mailbox 2
+#: locale/ipp-strings.c:2368
+msgid "output-bin.mailbox-2"
+msgstr ""
+
+#. TRANSLATORS: Mailbox 3
+#: locale/ipp-strings.c:2370
+msgid "output-bin.mailbox-3"
+msgstr ""
+
+#. TRANSLATORS: Mailbox 4
+#: locale/ipp-strings.c:2372
+msgid "output-bin.mailbox-4"
+msgstr ""
+
+#. TRANSLATORS: Mailbox 5
+#: locale/ipp-strings.c:2374
+msgid "output-bin.mailbox-5"
+msgstr ""
+
+#. TRANSLATORS: Mailbox 6
+#: locale/ipp-strings.c:2376
+msgid "output-bin.mailbox-6"
+msgstr ""
+
+#. TRANSLATORS: Mailbox 7
+#: locale/ipp-strings.c:2378
+msgid "output-bin.mailbox-7"
+msgstr ""
+
+#. TRANSLATORS: Mailbox 8
+#: locale/ipp-strings.c:2380
+msgid "output-bin.mailbox-8"
+msgstr ""
+
+#. TRANSLATORS: Mailbox 9
+#: locale/ipp-strings.c:2382
+msgid "output-bin.mailbox-9"
+msgstr ""
+
+#. TRANSLATORS: Middle
+#: locale/ipp-strings.c:2384
+msgid "output-bin.middle"
+msgstr ""
+
+#. TRANSLATORS: My Mailbox
+#: locale/ipp-strings.c:2386
+msgid "output-bin.my-mailbox"
+msgstr ""
+
+#. TRANSLATORS: Rear
+#: locale/ipp-strings.c:2388
+msgid "output-bin.rear"
+msgstr ""
+
+#. TRANSLATORS: Right
+#: locale/ipp-strings.c:2390
+msgid "output-bin.right"
+msgstr ""
+
+#. TRANSLATORS: Side
+#: locale/ipp-strings.c:2392
+msgid "output-bin.side"
+msgstr ""
+
+#. TRANSLATORS: Stacker 1
+#: locale/ipp-strings.c:2394
+msgid "output-bin.stacker-1"
+msgstr ""
+
+#. TRANSLATORS: Stacker 10
+#: locale/ipp-strings.c:2396
+msgid "output-bin.stacker-10"
+msgstr ""
+
+#. TRANSLATORS: Stacker 2
+#: locale/ipp-strings.c:2398
+msgid "output-bin.stacker-2"
+msgstr ""
+
+#. TRANSLATORS: Stacker 3
+#: locale/ipp-strings.c:2400
+msgid "output-bin.stacker-3"
+msgstr ""
+
+#. TRANSLATORS: Stacker 4
+#: locale/ipp-strings.c:2402
+msgid "output-bin.stacker-4"
+msgstr ""
+
+#. TRANSLATORS: Stacker 5
+#: locale/ipp-strings.c:2404
+msgid "output-bin.stacker-5"
+msgstr ""
+
+#. TRANSLATORS: Stacker 6
+#: locale/ipp-strings.c:2406
+msgid "output-bin.stacker-6"
+msgstr ""
+
+#. TRANSLATORS: Stacker 7
+#: locale/ipp-strings.c:2408
+msgid "output-bin.stacker-7"
+msgstr ""
+
+#. TRANSLATORS: Stacker 8
+#: locale/ipp-strings.c:2410
+msgid "output-bin.stacker-8"
+msgstr ""
+
+#. TRANSLATORS: Stacker 9
+#: locale/ipp-strings.c:2412
+msgid "output-bin.stacker-9"
+msgstr ""
+
+#. TRANSLATORS: Top
+#: locale/ipp-strings.c:2414
+msgid "output-bin.top"
+msgstr ""
+
+#. TRANSLATORS: Tray 1
+#: locale/ipp-strings.c:2416
+msgid "output-bin.tray-1"
+msgstr ""
+
+#. TRANSLATORS: Tray 10
+#: locale/ipp-strings.c:2418
+msgid "output-bin.tray-10"
+msgstr ""
+
+#. TRANSLATORS: Tray 2
+#: locale/ipp-strings.c:2420
+msgid "output-bin.tray-2"
+msgstr ""
+
+#. TRANSLATORS: Tray 3
+#: locale/ipp-strings.c:2422
+msgid "output-bin.tray-3"
+msgstr ""
+
+#. TRANSLATORS: Tray 4
+#: locale/ipp-strings.c:2424
+msgid "output-bin.tray-4"
+msgstr ""
+
+#. TRANSLATORS: Tray 5
+#: locale/ipp-strings.c:2426
+msgid "output-bin.tray-5"
+msgstr ""
+
+#. TRANSLATORS: Tray 6
+#: locale/ipp-strings.c:2428
+msgid "output-bin.tray-6"
+msgstr ""
+
+#. TRANSLATORS: Tray 7
+#: locale/ipp-strings.c:2430
+msgid "output-bin.tray-7"
+msgstr ""
+
+#. TRANSLATORS: Tray 8
+#: locale/ipp-strings.c:2432
+msgid "output-bin.tray-8"
+msgstr ""
+
+#. TRANSLATORS: Tray 9
+#: locale/ipp-strings.c:2434
+msgid "output-bin.tray-9"
+msgstr ""
+
+#. TRANSLATORS: Scanned Image Quality
+#: locale/ipp-strings.c:2436
+msgid "output-compression-quality-factor"
+msgstr ""
+
+#. TRANSLATORS: Page Delivery
+#: locale/ipp-strings.c:2438
+msgid "page-delivery"
+msgstr ""
+
+#. TRANSLATORS: Reverse Order Face-down
+#: locale/ipp-strings.c:2440
+msgid "page-delivery.reverse-order-face-down"
+msgstr ""
+
+#. TRANSLATORS: Reverse Order Face-up
+#: locale/ipp-strings.c:2442
+msgid "page-delivery.reverse-order-face-up"
+msgstr ""
+
+#. TRANSLATORS: Same Order Face-down
+#: locale/ipp-strings.c:2444
+msgid "page-delivery.same-order-face-down"
+msgstr ""
+
+#. TRANSLATORS: Same Order Face-up
+#: locale/ipp-strings.c:2446
+msgid "page-delivery.same-order-face-up"
+msgstr ""
+
+#. TRANSLATORS: System Specified
+#: locale/ipp-strings.c:2448
+msgid "page-delivery.system-specified"
+msgstr ""
+
+#. TRANSLATORS: Page Order Received
+#: locale/ipp-strings.c:2450
+msgid "page-order-received"
+msgstr ""
+
+#. TRANSLATORS: 1 To N
+#: locale/ipp-strings.c:2452
+msgid "page-order-received.1-to-n-order"
+msgstr ""
+
+#. TRANSLATORS: N To 1
+#: locale/ipp-strings.c:2454
+msgid "page-order-received.n-to-1-order"
+msgstr ""
+
+#. TRANSLATORS: Page Ranges
+#: locale/ipp-strings.c:2456
+msgid "page-ranges"
+msgstr ""
+
+#. TRANSLATORS: Pages
+#: locale/ipp-strings.c:2458
+msgid "pages"
+msgstr ""
+
+#. TRANSLATORS: Pages Per Subset
+#: locale/ipp-strings.c:2460
+msgid "pages-per-subset"
+msgstr ""
+
+#. TRANSLATORS: Pclm Raster Back Side
+#: locale/ipp-strings.c:2462
+msgid "pclm-raster-back-side"
+msgstr ""
+
+#. TRANSLATORS: Flipped
+#: locale/ipp-strings.c:2464
+msgid "pclm-raster-back-side.flipped"
+msgstr ""
+
+#. TRANSLATORS: Normal
+#: locale/ipp-strings.c:2466
+msgid "pclm-raster-back-side.normal"
+msgstr ""
+
+#. TRANSLATORS: Rotated
+#: locale/ipp-strings.c:2468
+msgid "pclm-raster-back-side.rotated"
+msgstr ""
+
+#. TRANSLATORS: Pclm Source Resolution
+#: locale/ipp-strings.c:2470
+msgid "pclm-source-resolution"
+msgstr ""
+
+#: cups/notify.c:74
+msgid "pending"
+msgstr ""
+
+#. TRANSLATORS: Platform Shape
+#: locale/ipp-strings.c:2472
+msgid "platform-shape"
+msgstr ""
+
+#. TRANSLATORS: Round
+#: locale/ipp-strings.c:2474
+msgid "platform-shape.ellipse"
+msgstr ""
+
+#. TRANSLATORS: Rectangle
+#: locale/ipp-strings.c:2476
+msgid "platform-shape.rectangle"
+msgstr ""
+
+#. TRANSLATORS: Platform Temperature
+#: locale/ipp-strings.c:2478
+msgid "platform-temperature"
+msgstr ""
+
+#. TRANSLATORS: Post-dial String
+#: locale/ipp-strings.c:2480
+msgid "post-dial-string"
+msgstr ""
+
+#: ppdc/ppdc.cxx:102 ppdc/ppdpo.cxx:81
+#, c-format
+msgid "ppdc: Adding include directory \"%s\"."
+msgstr ""
+
+#: ppdc/ppdpo.cxx:124
+#, c-format
+msgid "ppdc: Adding/updating UI text from %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:362
+#, c-format
+msgid "ppdc: Bad boolean value (%s) on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-import.cxx:253
+#, c-format
+msgid "ppdc: Bad font attribute: %s"
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1748
+#, c-format
+msgid "ppdc: Bad resolution name \"%s\" on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1065
+#, c-format
+msgid "ppdc: Bad status keyword %s on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1985
+#, c-format
+msgid "ppdc: Bad variable substitution ($%c) on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:2671
+#, c-format
+msgid "ppdc: Choice found on line %d of %s with no Option."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1650
+#, c-format
+msgid "ppdc: Duplicate #po for locale %s on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:884
+#, c-format
+msgid "ppdc: Expected a filter definition on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:907
+#, c-format
+msgid "ppdc: Expected a program name on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:346
+#, c-format
+msgid "ppdc: Expected boolean value on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1045
+#, c-format
+msgid "ppdc: Expected charset after Font on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:399
+#, c-format
+msgid "ppdc: Expected choice code on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:387
+#, c-format
+msgid "ppdc: Expected choice name/text on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:455
+#, c-format
+msgid "ppdc: Expected color order for ColorModel on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:444
+#, c-format
+msgid "ppdc: Expected colorspace for ColorModel on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:466
+#, c-format
+msgid "ppdc: Expected compression for ColorModel on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:647
+#, c-format
+msgid "ppdc: Expected constraints string for UIConstraints on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:2857
+#, c-format
+msgid "ppdc: Expected driver type keyword following DriverType on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:778
+#, c-format
+msgid "ppdc: Expected duplex type after Duplex on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1029
+#, c-format
+msgid "ppdc: Expected encoding after Font on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1641
+#, c-format
+msgid "ppdc: Expected filename after #po %s on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1157
+#, c-format
+msgid "ppdc: Expected group name/text on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:2570
+#, c-format
+msgid "ppdc: Expected include filename on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1454
+#, c-format
+msgid "ppdc: Expected integer on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1633
+#, c-format
+msgid "ppdc: Expected locale after #po on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:305
+#, c-format
+msgid "ppdc: Expected name after %s on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:3229
+#, c-format
+msgid "ppdc: Expected name after FileName on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1010
+#, c-format
+msgid "ppdc: Expected name after Font on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:3060
+#, c-format
+msgid "ppdc: Expected name after Manufacturer on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:3093
+#, c-format
+msgid "ppdc: Expected name after MediaSize on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:3183
+#, c-format
+msgid "ppdc: Expected name after ModelName on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:3246
+#, c-format
+msgid "ppdc: Expected name after PCFileName on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1108
+#, c-format
+msgid "ppdc: Expected name/text after %s on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1197
+#, c-format
+msgid "ppdc: Expected name/text after Installable on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1734
+#, c-format
+msgid "ppdc: Expected name/text after Resolution on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:431
+#, c-format
+msgid "ppdc: Expected name/text combination for ColorModel on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1526
+#, c-format
+msgid "ppdc: Expected option name/text on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1560
+#, c-format
+msgid "ppdc: Expected option section on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1538
+#, c-format
+msgid "ppdc: Expected option type on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1717
+#, c-format
+msgid "ppdc: Expected override field after Resolution on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-catalog.cxx:385 ppdc/ppdc-catalog.cxx:397
+#, c-format
+msgid "ppdc: Expected quoted string on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:956
+#, c-format
+msgid "ppdc: Expected real number on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:524
+#, c-format
+msgid "ppdc: Expected resolution/mediatype following ColorProfile on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1815
+#, c-format
+msgid "ppdc: Expected resolution/mediatype following SimpleColorProfile on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:313
+#, c-format
+msgid "ppdc: Expected selector after %s on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1053
+#, c-format
+msgid "ppdc: Expected status after Font on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:2746
+#, c-format
+msgid "ppdc: Expected string after Copyright on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:3349
+#, c-format
+msgid "ppdc: Expected string after Version on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:680
+#, c-format
+msgid "ppdc: Expected two option names on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:324
+#, c-format
+msgid "ppdc: Expected value after %s on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1037
+#, c-format
+msgid "ppdc: Expected version after Font on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:179
+#, c-format
+msgid "ppdc: Invalid #include/#po filename \"%s\"."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:924
+#, c-format
+msgid "ppdc: Invalid cost for filter on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:916
+#, c-format
+msgid "ppdc: Invalid empty MIME type for filter on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:932
+#, c-format
+msgid "ppdc: Invalid empty program name for filter on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1580
+#, c-format
+msgid "ppdc: Invalid option section \"%s\" on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1552
+#, c-format
+msgid "ppdc: Invalid option type \"%s\" on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc.cxx:240 ppdc/ppdpo.cxx:111
+#, c-format
+msgid "ppdc: Loading driver information file \"%s\"."
+msgstr ""
+
+#: ppdc/ppdc.cxx:176
+#, c-format
+msgid "ppdc: Loading messages for locale \"%s\"."
+msgstr ""
+
+#: ppdc/ppdc.cxx:115
+#, c-format
+msgid "ppdc: Loading messages from \"%s\"."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:2363 ppdc/ppdc-source.cxx:2595
+#, c-format
+msgid "ppdc: Missing #endif at end of \"%s\"."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:2464 ppdc/ppdc-source.cxx:2499
+#: ppdc/ppdc-source.cxx:2529
+#, c-format
+msgid "ppdc: Missing #if on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-catalog.cxx:462
+#, c-format
+msgid "ppdc: Need a msgid line before any translation strings on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-driver.cxx:707
+#, c-format
+msgid "ppdc: No message catalog provided for locale %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1603 ppdc/ppdc-source.cxx:2834
+#: ppdc/ppdc-source.cxx:2920 ppdc/ppdc-source.cxx:3013
+#: ppdc/ppdc-source.cxx:3146 ppdc/ppdc-source.cxx:3279
+#, c-format
+msgid "ppdc: Option %s defined in two different groups on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1596
+#, c-format
+msgid "ppdc: Option %s redefined with a different type on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:657
+#, c-format
+msgid "ppdc: Option constraint must *name on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:2446
+#, c-format
+msgid "ppdc: Too many nested #if's on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc.cxx:363
+#, c-format
+msgid "ppdc: Unable to create PPD file \"%s\" - %s."
+msgstr ""
+
+#: ppdc/ppdc.cxx:255
+#, c-format
+msgid "ppdc: Unable to create output directory %s: %s"
+msgstr ""
+
+#: ppdc/ppdc.cxx:276
+#, c-format
+msgid "ppdc: Unable to create output pipes: %s"
+msgstr ""
+
+#: ppdc/ppdc.cxx:292 ppdc/ppdc.cxx:298
+#, c-format
+msgid "ppdc: Unable to execute cupstestppd: %s"
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:1682
+#, c-format
+msgid "ppdc: Unable to find #po file %s on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:2602
+#, c-format
+msgid "ppdc: Unable to find include file \"%s\" on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc.cxx:187
+#, c-format
+msgid "ppdc: Unable to find localization for \"%s\" - %s"
+msgstr ""
+
+#: ppdc/ppdc.cxx:124
+#, c-format
+msgid "ppdc: Unable to load localization file \"%s\" - %s"
+msgstr ""
+
+#: ppdc/ppdc-file.cxx:37
+#, c-format
+msgid "ppdc: Unable to open %s: %s"
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:2006
+#, c-format
+msgid "ppdc: Undefined variable (%s) on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-catalog.cxx:479
+#, c-format
+msgid "ppdc: Unexpected text on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:2876
+#, c-format
+msgid "ppdc: Unknown driver type %s on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:858
+#, c-format
+msgid "ppdc: Unknown duplex type \"%s\" on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:3106
+#, c-format
+msgid "ppdc: Unknown media size \"%s\" on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-catalog.cxx:507
+#, c-format
+msgid "ppdc: Unknown message catalog format for \"%s\"."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:3360
+#, c-format
+msgid "ppdc: Unknown token \"%s\" seen on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:966
+#, c-format
+msgid "ppdc: Unknown trailing characters in real number \"%s\" on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc-source.cxx:2116
+#, c-format
+msgid "ppdc: Unterminated string starting with %c on line %d of %s."
+msgstr ""
+
+#: ppdc/ppdc.cxx:354
+#, c-format
+msgid "ppdc: Warning - overlapping filename \"%s\"."
+msgstr ""
+
+#: ppdc/ppdc.cxx:369
+#, c-format
+msgid "ppdc: Writing %s."
+msgstr ""
+
+#: ppdc/ppdc.cxx:137
+#, c-format
+msgid "ppdc: Writing PPD files to directory \"%s\"."
+msgstr ""
+
+#: ppdc/ppdmerge.cxx:126
+#, c-format
+msgid "ppdmerge: Bad LanguageVersion \"%s\" in %s."
+msgstr ""
+
+#: ppdc/ppdmerge.cxx:163
+#, c-format
+msgid "ppdmerge: Ignoring PPD file %s."
+msgstr ""
+
+#: ppdc/ppdmerge.cxx:147
+#, c-format
+msgid "ppdmerge: Unable to backup %s to %s - %s"
+msgstr ""
+
+#. TRANSLATORS: Pre-dial String
+#: locale/ipp-strings.c:2482
+msgid "pre-dial-string"
+msgstr ""
+
+#. TRANSLATORS: Number-Up Layout
+#: locale/ipp-strings.c:2484
+msgid "presentation-direction-number-up"
+msgstr ""
+
+#. TRANSLATORS: Top-bottom, Right-left
+#: locale/ipp-strings.c:2486
+msgid "presentation-direction-number-up.tobottom-toleft"
+msgstr ""
+
+#. TRANSLATORS: Top-bottom, Left-right
+#: locale/ipp-strings.c:2488
+msgid "presentation-direction-number-up.tobottom-toright"
+msgstr ""
+
+#. TRANSLATORS: Right-left, Top-bottom
+#: locale/ipp-strings.c:2490
+msgid "presentation-direction-number-up.toleft-tobottom"
+msgstr ""
+
+#. TRANSLATORS: Right-left, Bottom-top
+#: locale/ipp-strings.c:2492
+msgid "presentation-direction-number-up.toleft-totop"
+msgstr ""
+
+#. TRANSLATORS: Left-right, Top-bottom
+#: locale/ipp-strings.c:2494
+msgid "presentation-direction-number-up.toright-tobottom"
+msgstr ""
+
+#. TRANSLATORS: Left-right, Bottom-top
+#: locale/ipp-strings.c:2496
+msgid "presentation-direction-number-up.toright-totop"
+msgstr ""
+
+#. TRANSLATORS: Bottom-top, Right-left
+#: locale/ipp-strings.c:2498
+msgid "presentation-direction-number-up.totop-toleft"
+msgstr ""
+
+#. TRANSLATORS: Bottom-top, Left-right
+#: locale/ipp-strings.c:2500
+msgid "presentation-direction-number-up.totop-toright"
+msgstr ""
+
+#. TRANSLATORS: Print Accuracy
+#: locale/ipp-strings.c:2502
+msgid "print-accuracy"
+msgstr ""
+
+#. TRANSLATORS: Print Base
+#: locale/ipp-strings.c:2504
+msgid "print-base"
+msgstr ""
+
+#. TRANSLATORS: Print Base Actual
+#: locale/ipp-strings.c:2506
+msgid "print-base-actual"
+msgstr ""
+
+#. TRANSLATORS: Brim
+#: locale/ipp-strings.c:2508
+msgid "print-base.brim"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:2510
+msgid "print-base.none"
+msgstr ""
+
+#. TRANSLATORS: Raft
+#: locale/ipp-strings.c:2512
+msgid "print-base.raft"
+msgstr ""
+
+#. TRANSLATORS: Skirt
+#: locale/ipp-strings.c:2514
+msgid "print-base.skirt"
+msgstr ""
+
+#. TRANSLATORS: Standard
+#: locale/ipp-strings.c:2516
+msgid "print-base.standard"
+msgstr ""
+
+#. TRANSLATORS: Print Color Mode
+#: locale/ipp-strings.c:2518
+msgid "print-color-mode"
+msgstr ""
+
+#. TRANSLATORS: Automatic
+#: locale/ipp-strings.c:2520
+msgid "print-color-mode.auto"
+msgstr ""
+
+#. TRANSLATORS: Auto Monochrome
+#: locale/ipp-strings.c:2522
+msgid "print-color-mode.auto-monochrome"
+msgstr ""
+
+#. TRANSLATORS: Text
+#: locale/ipp-strings.c:2524
+msgid "print-color-mode.bi-level"
+msgstr ""
+
+#. TRANSLATORS: Color
+#: locale/ipp-strings.c:2526
+msgid "print-color-mode.color"
+msgstr ""
+
+#. TRANSLATORS: Highlight
+#: locale/ipp-strings.c:2528
+msgid "print-color-mode.highlight"
+msgstr ""
+
+#. TRANSLATORS: Monochrome
+#: locale/ipp-strings.c:2530
+msgid "print-color-mode.monochrome"
+msgstr ""
+
+#. TRANSLATORS: Process Text
+#: locale/ipp-strings.c:2532
+msgid "print-color-mode.process-bi-level"
+msgstr ""
+
+#. TRANSLATORS: Process Monochrome
+#: locale/ipp-strings.c:2534
+msgid "print-color-mode.process-monochrome"
+msgstr ""
+
+#. TRANSLATORS: Print Optimization
+#: locale/ipp-strings.c:2536
+msgid "print-content-optimize"
+msgstr ""
+
+#. TRANSLATORS: Print Content Optimize Actual
+#: locale/ipp-strings.c:2538
+msgid "print-content-optimize-actual"
+msgstr ""
+
+#. TRANSLATORS: Automatic
+#: locale/ipp-strings.c:2540
+msgid "print-content-optimize.auto"
+msgstr ""
+
+#. TRANSLATORS: Graphics
+#: locale/ipp-strings.c:2542
+msgid "print-content-optimize.graphic"
+msgstr ""
+
+#. TRANSLATORS: Graphics
+#: locale/ipp-strings.c:2544
+msgid "print-content-optimize.graphics"
+msgstr ""
+
+#. TRANSLATORS: Photo
+#: locale/ipp-strings.c:2546
+msgid "print-content-optimize.photo"
+msgstr ""
+
+#. TRANSLATORS: Text
+#: locale/ipp-strings.c:2548
+msgid "print-content-optimize.text"
+msgstr ""
+
+#. TRANSLATORS: Text and Graphics
+#: locale/ipp-strings.c:2550
+msgid "print-content-optimize.text-and-graphic"
+msgstr ""
+
+#. TRANSLATORS: Text And Graphics
+#: locale/ipp-strings.c:2552
+msgid "print-content-optimize.text-and-graphics"
+msgstr ""
+
+#. TRANSLATORS: Print Objects
+#: locale/ipp-strings.c:2554
+msgid "print-objects"
+msgstr ""
+
+#. TRANSLATORS: Print Quality
+#: locale/ipp-strings.c:2556
+msgid "print-quality"
+msgstr ""
+
+#. TRANSLATORS: Draft
+#: locale/ipp-strings.c:2558
+msgid "print-quality.3"
+msgstr ""
+
+#. TRANSLATORS: Normal
+#: locale/ipp-strings.c:2560
+msgid "print-quality.4"
+msgstr ""
+
+#. TRANSLATORS: High
+#: locale/ipp-strings.c:2562
+msgid "print-quality.5"
+msgstr ""
+
+#. TRANSLATORS: Print Rendering Intent
+#: locale/ipp-strings.c:2564
+msgid "print-rendering-intent"
+msgstr ""
+
+#. TRANSLATORS: Absolute
+#: locale/ipp-strings.c:2566
+msgid "print-rendering-intent.absolute"
+msgstr ""
+
+#. TRANSLATORS: Automatic
+#: locale/ipp-strings.c:2568
+msgid "print-rendering-intent.auto"
+msgstr ""
+
+#. TRANSLATORS: Perceptual
+#: locale/ipp-strings.c:2570
+msgid "print-rendering-intent.perceptual"
+msgstr ""
+
+#. TRANSLATORS: Relative
+#: locale/ipp-strings.c:2572
+msgid "print-rendering-intent.relative"
+msgstr ""
+
+#. TRANSLATORS: Relative w/Black Point Compensation
+#: locale/ipp-strings.c:2574
+msgid "print-rendering-intent.relative-bpc"
+msgstr ""
+
+#. TRANSLATORS: Saturation
+#: locale/ipp-strings.c:2576
+msgid "print-rendering-intent.saturation"
+msgstr ""
+
+#. TRANSLATORS: Print Scaling
+#: locale/ipp-strings.c:2578
+msgid "print-scaling"
+msgstr ""
+
+#. TRANSLATORS: Automatic
+#: locale/ipp-strings.c:2580
+msgid "print-scaling.auto"
+msgstr ""
+
+#. TRANSLATORS: Auto-fit
+#: locale/ipp-strings.c:2582
+msgid "print-scaling.auto-fit"
+msgstr ""
+
+#. TRANSLATORS: Fill
+#: locale/ipp-strings.c:2584
+msgid "print-scaling.fill"
+msgstr ""
+
+#. TRANSLATORS: Fit
+#: locale/ipp-strings.c:2586
+msgid "print-scaling.fit"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:2588
+msgid "print-scaling.none"
+msgstr ""
+
+#. TRANSLATORS: Print Supports
+#: locale/ipp-strings.c:2590
+msgid "print-supports"
+msgstr ""
+
+#. TRANSLATORS: Print Supports Actual
+#: locale/ipp-strings.c:2592
+msgid "print-supports-actual"
+msgstr ""
+
+#. TRANSLATORS: With Specified Material
+#: locale/ipp-strings.c:2594
+msgid "print-supports.material"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:2596
+msgid "print-supports.none"
+msgstr ""
+
+#. TRANSLATORS: Standard
+#: locale/ipp-strings.c:2598
+msgid "print-supports.standard"
+msgstr ""
+
+#: systemv/lpstat.c:1786
+#, c-format
+msgid "printer %s disabled since %s -"
+msgstr ""
+
+#: systemv/lpstat.c:1778
+#, c-format
+msgid "printer %s is holding new jobs.  enabled since %s"
+msgstr ""
+
+#: systemv/lpstat.c:1780
+#, c-format
+msgid "printer %s is idle.  enabled since %s"
+msgstr ""
+
+#: systemv/lpstat.c:1783
+#, c-format
+msgid "printer %s now printing %s-%d.  enabled since %s"
+msgstr ""
+
+#: systemv/lpstat.c:1904
+#, c-format
+msgid "printer %s/%s disabled since %s -"
+msgstr ""
+
+#: systemv/lpstat.c:1890
+#, c-format
+msgid "printer %s/%s is idle.  enabled since %s"
+msgstr ""
+
+#: systemv/lpstat.c:1897
+#, c-format
+msgid "printer %s/%s now printing %s-%d.  enabled since %s"
+msgstr ""
+
+#. TRANSLATORS: Printer Kind
+#: locale/ipp-strings.c:2600
+msgid "printer-kind"
+msgstr ""
+
+#. TRANSLATORS: Disc
+#: locale/ipp-strings.c:2602
+msgid "printer-kind.disc"
+msgstr ""
+
+#. TRANSLATORS: Document
+#: locale/ipp-strings.c:2604
+msgid "printer-kind.document"
+msgstr ""
+
+#. TRANSLATORS: Envelope
+#: locale/ipp-strings.c:2606
+msgid "printer-kind.envelope"
+msgstr ""
+
+#. TRANSLATORS: Label
+#: locale/ipp-strings.c:2608
+msgid "printer-kind.label"
+msgstr ""
+
+#. TRANSLATORS: Large Format
+#: locale/ipp-strings.c:2610
+msgid "printer-kind.large-format"
+msgstr ""
+
+#. TRANSLATORS: Photo
+#: locale/ipp-strings.c:2612
+msgid "printer-kind.photo"
+msgstr ""
+
+#. TRANSLATORS: Postcard
+#: locale/ipp-strings.c:2614
+msgid "printer-kind.postcard"
+msgstr ""
+
+#. TRANSLATORS: Receipt
+#: locale/ipp-strings.c:2616
+msgid "printer-kind.receipt"
+msgstr ""
+
+#. TRANSLATORS: Roll
+#: locale/ipp-strings.c:2618
+msgid "printer-kind.roll"
+msgstr ""
+
+#. TRANSLATORS: Message From Operator
+#: locale/ipp-strings.c:2620
+msgid "printer-message-from-operator"
+msgstr ""
+
+#. TRANSLATORS: Print Resolution
+#: locale/ipp-strings.c:2622
+msgid "printer-resolution"
+msgstr ""
+
+#. TRANSLATORS: Printer State
+#: locale/ipp-strings.c:2624
+msgid "printer-state"
+msgstr ""
+
+#. TRANSLATORS: Detailed Printer State
+#: locale/ipp-strings.c:2626
+msgid "printer-state-reasons"
+msgstr ""
+
+#. TRANSLATORS: Old Alerts Have Been Removed
+#: locale/ipp-strings.c:2628
+msgid "printer-state-reasons.alert-removal-of-binary-change-entry"
+msgstr ""
+
+#. TRANSLATORS: Bander Added
+#: locale/ipp-strings.c:2630
+msgid "printer-state-reasons.bander-added"
+msgstr ""
+
+#. TRANSLATORS: Bander Almost Empty
+#: locale/ipp-strings.c:2632
+msgid "printer-state-reasons.bander-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Bander Almost Full
+#: locale/ipp-strings.c:2634
+msgid "printer-state-reasons.bander-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Bander At Limit
+#: locale/ipp-strings.c:2636
+msgid "printer-state-reasons.bander-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Bander Closed
+#: locale/ipp-strings.c:2638
+msgid "printer-state-reasons.bander-closed"
+msgstr ""
+
+#. TRANSLATORS: Bander Configuration Change
+#: locale/ipp-strings.c:2640
+msgid "printer-state-reasons.bander-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Bander Cover Closed
+#: locale/ipp-strings.c:2642
+msgid "printer-state-reasons.bander-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Bander Cover Open
+#: locale/ipp-strings.c:2644
+msgid "printer-state-reasons.bander-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Bander Empty
+#: locale/ipp-strings.c:2646
+msgid "printer-state-reasons.bander-empty"
+msgstr ""
+
+#. TRANSLATORS: Bander Full
+#: locale/ipp-strings.c:2648
+msgid "printer-state-reasons.bander-full"
+msgstr ""
+
+#. TRANSLATORS: Bander Interlock Closed
+#: locale/ipp-strings.c:2650
+msgid "printer-state-reasons.bander-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Bander Interlock Open
+#: locale/ipp-strings.c:2652
+msgid "printer-state-reasons.bander-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Bander Jam
+#: locale/ipp-strings.c:2654
+msgid "printer-state-reasons.bander-jam"
+msgstr ""
+
+#. TRANSLATORS: Bander Life Almost Over
+#: locale/ipp-strings.c:2656
+msgid "printer-state-reasons.bander-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Bander Life Over
+#: locale/ipp-strings.c:2658
+msgid "printer-state-reasons.bander-life-over"
+msgstr ""
+
+#. TRANSLATORS: Bander Memory Exhausted
+#: locale/ipp-strings.c:2660
+msgid "printer-state-reasons.bander-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Bander Missing
+#: locale/ipp-strings.c:2662
+msgid "printer-state-reasons.bander-missing"
+msgstr ""
+
+#. TRANSLATORS: Bander Motor Failure
+#: locale/ipp-strings.c:2664
+msgid "printer-state-reasons.bander-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Bander Near Limit
+#: locale/ipp-strings.c:2666
+msgid "printer-state-reasons.bander-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Bander Offline
+#: locale/ipp-strings.c:2668
+msgid "printer-state-reasons.bander-offline"
+msgstr ""
+
+#. TRANSLATORS: Bander Opened
+#: locale/ipp-strings.c:2670
+msgid "printer-state-reasons.bander-opened"
+msgstr ""
+
+#. TRANSLATORS: Bander Over Temperature
+#: locale/ipp-strings.c:2672
+msgid "printer-state-reasons.bander-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Bander Power Saver
+#: locale/ipp-strings.c:2674
+msgid "printer-state-reasons.bander-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Bander Recoverable Failure
+#: locale/ipp-strings.c:2676
+msgid "printer-state-reasons.bander-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Bander Recoverable Storage
+#: locale/ipp-strings.c:2678
+msgid "printer-state-reasons.bander-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Bander Removed
+#: locale/ipp-strings.c:2680
+msgid "printer-state-reasons.bander-removed"
+msgstr ""
+
+#. TRANSLATORS: Bander Resource Added
+#: locale/ipp-strings.c:2682
+msgid "printer-state-reasons.bander-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Bander Resource Removed
+#: locale/ipp-strings.c:2684
+msgid "printer-state-reasons.bander-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Bander Thermistor Failure
+#: locale/ipp-strings.c:2686
+msgid "printer-state-reasons.bander-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Bander Timing Failure
+#: locale/ipp-strings.c:2688
+msgid "printer-state-reasons.bander-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Bander Turned Off
+#: locale/ipp-strings.c:2690
+msgid "printer-state-reasons.bander-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Bander Turned On
+#: locale/ipp-strings.c:2692
+msgid "printer-state-reasons.bander-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Bander Under Temperature
+#: locale/ipp-strings.c:2694
+msgid "printer-state-reasons.bander-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Bander Unrecoverable Failure
+#: locale/ipp-strings.c:2696
+msgid "printer-state-reasons.bander-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Bander Unrecoverable Storage Error
+#: locale/ipp-strings.c:2698
+msgid "printer-state-reasons.bander-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Bander Warming Up
+#: locale/ipp-strings.c:2700
+msgid "printer-state-reasons.bander-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Binder Added
+#: locale/ipp-strings.c:2702
+msgid "printer-state-reasons.binder-added"
+msgstr ""
+
+#. TRANSLATORS: Binder Almost Empty
+#: locale/ipp-strings.c:2704
+msgid "printer-state-reasons.binder-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Binder Almost Full
+#: locale/ipp-strings.c:2706
+msgid "printer-state-reasons.binder-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Binder At Limit
+#: locale/ipp-strings.c:2708
+msgid "printer-state-reasons.binder-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Binder Closed
+#: locale/ipp-strings.c:2710
+msgid "printer-state-reasons.binder-closed"
+msgstr ""
+
+#. TRANSLATORS: Binder Configuration Change
+#: locale/ipp-strings.c:2712
+msgid "printer-state-reasons.binder-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Binder Cover Closed
+#: locale/ipp-strings.c:2714
+msgid "printer-state-reasons.binder-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Binder Cover Open
+#: locale/ipp-strings.c:2716
+msgid "printer-state-reasons.binder-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Binder Empty
+#: locale/ipp-strings.c:2718
+msgid "printer-state-reasons.binder-empty"
+msgstr ""
+
+#. TRANSLATORS: Binder Full
+#: locale/ipp-strings.c:2720
+msgid "printer-state-reasons.binder-full"
+msgstr ""
+
+#. TRANSLATORS: Binder Interlock Closed
+#: locale/ipp-strings.c:2722
+msgid "printer-state-reasons.binder-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Binder Interlock Open
+#: locale/ipp-strings.c:2724
+msgid "printer-state-reasons.binder-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Binder Jam
+#: locale/ipp-strings.c:2726
+msgid "printer-state-reasons.binder-jam"
+msgstr ""
+
+#. TRANSLATORS: Binder Life Almost Over
+#: locale/ipp-strings.c:2728
+msgid "printer-state-reasons.binder-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Binder Life Over
+#: locale/ipp-strings.c:2730
+msgid "printer-state-reasons.binder-life-over"
+msgstr ""
+
+#. TRANSLATORS: Binder Memory Exhausted
+#: locale/ipp-strings.c:2732
+msgid "printer-state-reasons.binder-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Binder Missing
+#: locale/ipp-strings.c:2734
+msgid "printer-state-reasons.binder-missing"
+msgstr ""
+
+#. TRANSLATORS: Binder Motor Failure
+#: locale/ipp-strings.c:2736
+msgid "printer-state-reasons.binder-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Binder Near Limit
+#: locale/ipp-strings.c:2738
+msgid "printer-state-reasons.binder-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Binder Offline
+#: locale/ipp-strings.c:2740
+msgid "printer-state-reasons.binder-offline"
+msgstr ""
+
+#. TRANSLATORS: Binder Opened
+#: locale/ipp-strings.c:2742
+msgid "printer-state-reasons.binder-opened"
+msgstr ""
+
+#. TRANSLATORS: Binder Over Temperature
+#: locale/ipp-strings.c:2744
+msgid "printer-state-reasons.binder-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Binder Power Saver
+#: locale/ipp-strings.c:2746
+msgid "printer-state-reasons.binder-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Binder Recoverable Failure
+#: locale/ipp-strings.c:2748
+msgid "printer-state-reasons.binder-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Binder Recoverable Storage
+#: locale/ipp-strings.c:2750
+msgid "printer-state-reasons.binder-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Binder Removed
+#: locale/ipp-strings.c:2752
+msgid "printer-state-reasons.binder-removed"
+msgstr ""
+
+#. TRANSLATORS: Binder Resource Added
+#: locale/ipp-strings.c:2754
+msgid "printer-state-reasons.binder-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Binder Resource Removed
+#: locale/ipp-strings.c:2756
+msgid "printer-state-reasons.binder-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Binder Thermistor Failure
+#: locale/ipp-strings.c:2758
+msgid "printer-state-reasons.binder-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Binder Timing Failure
+#: locale/ipp-strings.c:2760
+msgid "printer-state-reasons.binder-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Binder Turned Off
+#: locale/ipp-strings.c:2762
+msgid "printer-state-reasons.binder-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Binder Turned On
+#: locale/ipp-strings.c:2764
+msgid "printer-state-reasons.binder-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Binder Under Temperature
+#: locale/ipp-strings.c:2766
+msgid "printer-state-reasons.binder-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Binder Unrecoverable Failure
+#: locale/ipp-strings.c:2768
+msgid "printer-state-reasons.binder-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Binder Unrecoverable Storage Error
+#: locale/ipp-strings.c:2770
+msgid "printer-state-reasons.binder-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Binder Warming Up
+#: locale/ipp-strings.c:2772
+msgid "printer-state-reasons.binder-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Camera Failure
+#: locale/ipp-strings.c:2774
+msgid "printer-state-reasons.camera-failure"
+msgstr ""
+
+#. TRANSLATORS: Chamber Cooling
+#: locale/ipp-strings.c:2776
+msgid "printer-state-reasons.chamber-cooling"
+msgstr ""
+
+#. TRANSLATORS: Chamber Failure
+#: locale/ipp-strings.c:2778
+msgid "printer-state-reasons.chamber-failure"
+msgstr ""
+
+#. TRANSLATORS: Chamber Heating
+#: locale/ipp-strings.c:2780
+msgid "printer-state-reasons.chamber-heating"
+msgstr ""
+
+#. TRANSLATORS: Chamber Temperature High
+#: locale/ipp-strings.c:2782
+msgid "printer-state-reasons.chamber-temperature-high"
+msgstr ""
+
+#. TRANSLATORS: Chamber Temperature Low
+#: locale/ipp-strings.c:2784
+msgid "printer-state-reasons.chamber-temperature-low"
+msgstr ""
+
+#. TRANSLATORS: Cleaner Life Almost Over
+#: locale/ipp-strings.c:2786
+msgid "printer-state-reasons.cleaner-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Cleaner Life Over
+#: locale/ipp-strings.c:2788
+msgid "printer-state-reasons.cleaner-life-over"
+msgstr ""
+
+#. TRANSLATORS: Configuration Change
+#: locale/ipp-strings.c:2790
+msgid "printer-state-reasons.configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Connecting To Device
+#: locale/ipp-strings.c:2792
+msgid "printer-state-reasons.connecting-to-device"
+msgstr ""
+
+#. TRANSLATORS: Cover Open
+#: locale/ipp-strings.c:2794
+msgid "printer-state-reasons.cover-open"
+msgstr ""
+
+#. TRANSLATORS: Deactivated
+#: locale/ipp-strings.c:2796
+msgid "printer-state-reasons.deactivated"
+msgstr ""
+
+#. TRANSLATORS: Developer Empty
+#: locale/ipp-strings.c:2798
+msgid "printer-state-reasons.developer-empty"
+msgstr ""
+
+#. TRANSLATORS: Developer Low
+#: locale/ipp-strings.c:2800
+msgid "printer-state-reasons.developer-low"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Added
+#: locale/ipp-strings.c:2802
+msgid "printer-state-reasons.die-cutter-added"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Almost Empty
+#: locale/ipp-strings.c:2804
+msgid "printer-state-reasons.die-cutter-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Almost Full
+#: locale/ipp-strings.c:2806
+msgid "printer-state-reasons.die-cutter-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter At Limit
+#: locale/ipp-strings.c:2808
+msgid "printer-state-reasons.die-cutter-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Closed
+#: locale/ipp-strings.c:2810
+msgid "printer-state-reasons.die-cutter-closed"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Configuration Change
+#: locale/ipp-strings.c:2812
+msgid "printer-state-reasons.die-cutter-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Cover Closed
+#: locale/ipp-strings.c:2814
+msgid "printer-state-reasons.die-cutter-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Cover Open
+#: locale/ipp-strings.c:2816
+msgid "printer-state-reasons.die-cutter-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Empty
+#: locale/ipp-strings.c:2818
+msgid "printer-state-reasons.die-cutter-empty"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Full
+#: locale/ipp-strings.c:2820
+msgid "printer-state-reasons.die-cutter-full"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Interlock Closed
+#: locale/ipp-strings.c:2822
+msgid "printer-state-reasons.die-cutter-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Interlock Open
+#: locale/ipp-strings.c:2824
+msgid "printer-state-reasons.die-cutter-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Jam
+#: locale/ipp-strings.c:2826
+msgid "printer-state-reasons.die-cutter-jam"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Life Almost Over
+#: locale/ipp-strings.c:2828
+msgid "printer-state-reasons.die-cutter-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Life Over
+#: locale/ipp-strings.c:2830
+msgid "printer-state-reasons.die-cutter-life-over"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Memory Exhausted
+#: locale/ipp-strings.c:2832
+msgid "printer-state-reasons.die-cutter-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Missing
+#: locale/ipp-strings.c:2834
+msgid "printer-state-reasons.die-cutter-missing"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Motor Failure
+#: locale/ipp-strings.c:2836
+msgid "printer-state-reasons.die-cutter-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Near Limit
+#: locale/ipp-strings.c:2838
+msgid "printer-state-reasons.die-cutter-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Offline
+#: locale/ipp-strings.c:2840
+msgid "printer-state-reasons.die-cutter-offline"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Opened
+#: locale/ipp-strings.c:2842
+msgid "printer-state-reasons.die-cutter-opened"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Over Temperature
+#: locale/ipp-strings.c:2844
+msgid "printer-state-reasons.die-cutter-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Power Saver
+#: locale/ipp-strings.c:2846
+msgid "printer-state-reasons.die-cutter-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Recoverable Failure
+#: locale/ipp-strings.c:2848
+msgid "printer-state-reasons.die-cutter-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Recoverable Storage
+#: locale/ipp-strings.c:2850
+msgid "printer-state-reasons.die-cutter-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Removed
+#: locale/ipp-strings.c:2852
+msgid "printer-state-reasons.die-cutter-removed"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Resource Added
+#: locale/ipp-strings.c:2854
+msgid "printer-state-reasons.die-cutter-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Resource Removed
+#: locale/ipp-strings.c:2856
+msgid "printer-state-reasons.die-cutter-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Thermistor Failure
+#: locale/ipp-strings.c:2858
+msgid "printer-state-reasons.die-cutter-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Timing Failure
+#: locale/ipp-strings.c:2860
+msgid "printer-state-reasons.die-cutter-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Turned Off
+#: locale/ipp-strings.c:2862
+msgid "printer-state-reasons.die-cutter-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Turned On
+#: locale/ipp-strings.c:2864
+msgid "printer-state-reasons.die-cutter-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Under Temperature
+#: locale/ipp-strings.c:2866
+msgid "printer-state-reasons.die-cutter-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Unrecoverable Failure
+#: locale/ipp-strings.c:2868
+msgid "printer-state-reasons.die-cutter-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Unrecoverable Storage Error
+#: locale/ipp-strings.c:2870
+msgid "printer-state-reasons.die-cutter-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Die Cutter Warming Up
+#: locale/ipp-strings.c:2872
+msgid "printer-state-reasons.die-cutter-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Door Open
+#: locale/ipp-strings.c:2874
+msgid "printer-state-reasons.door-open"
+msgstr ""
+
+#. TRANSLATORS: Extruder Cooling
+#: locale/ipp-strings.c:2876
+msgid "printer-state-reasons.extruder-cooling"
+msgstr ""
+
+#. TRANSLATORS: Extruder Failure
+#: locale/ipp-strings.c:2878
+msgid "printer-state-reasons.extruder-failure"
+msgstr ""
+
+#. TRANSLATORS: Extruder Heating
+#: locale/ipp-strings.c:2880
+msgid "printer-state-reasons.extruder-heating"
+msgstr ""
+
+#. TRANSLATORS: Extruder Jam
+#: locale/ipp-strings.c:2882
+msgid "printer-state-reasons.extruder-jam"
+msgstr ""
+
+#. TRANSLATORS: Extruder Temperature High
+#: locale/ipp-strings.c:2884
+msgid "printer-state-reasons.extruder-temperature-high"
+msgstr ""
+
+#. TRANSLATORS: Extruder Temperature Low
+#: locale/ipp-strings.c:2886
+msgid "printer-state-reasons.extruder-temperature-low"
+msgstr ""
+
+#. TRANSLATORS: Fan Failure
+#: locale/ipp-strings.c:2888
+msgid "printer-state-reasons.fan-failure"
+msgstr ""
+
+#. TRANSLATORS: Fax Modem Life Almost Over
+#: locale/ipp-strings.c:2890
+msgid "printer-state-reasons.fax-modem-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Fax Modem Life Over
+#: locale/ipp-strings.c:2892
+msgid "printer-state-reasons.fax-modem-life-over"
+msgstr ""
+
+#. TRANSLATORS: Fax Modem Missing
+#: locale/ipp-strings.c:2894
+msgid "printer-state-reasons.fax-modem-missing"
+msgstr ""
+
+#. TRANSLATORS: Fax Modem Turned Off
+#: locale/ipp-strings.c:2896
+msgid "printer-state-reasons.fax-modem-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Fax Modem Turned On
+#: locale/ipp-strings.c:2898
+msgid "printer-state-reasons.fax-modem-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Folder Added
+#: locale/ipp-strings.c:2900
+msgid "printer-state-reasons.folder-added"
+msgstr ""
+
+#. TRANSLATORS: Folder Almost Empty
+#: locale/ipp-strings.c:2902
+msgid "printer-state-reasons.folder-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Folder Almost Full
+#: locale/ipp-strings.c:2904
+msgid "printer-state-reasons.folder-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Folder At Limit
+#: locale/ipp-strings.c:2906
+msgid "printer-state-reasons.folder-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Folder Closed
+#: locale/ipp-strings.c:2908
+msgid "printer-state-reasons.folder-closed"
+msgstr ""
+
+#. TRANSLATORS: Folder Configuration Change
+#: locale/ipp-strings.c:2910
+msgid "printer-state-reasons.folder-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Folder Cover Closed
+#: locale/ipp-strings.c:2912
+msgid "printer-state-reasons.folder-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Folder Cover Open
+#: locale/ipp-strings.c:2914
+msgid "printer-state-reasons.folder-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Folder Empty
+#: locale/ipp-strings.c:2916
+msgid "printer-state-reasons.folder-empty"
+msgstr ""
+
+#. TRANSLATORS: Folder Full
+#: locale/ipp-strings.c:2918
+msgid "printer-state-reasons.folder-full"
+msgstr ""
+
+#. TRANSLATORS: Folder Interlock Closed
+#: locale/ipp-strings.c:2920
+msgid "printer-state-reasons.folder-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Folder Interlock Open
+#: locale/ipp-strings.c:2922
+msgid "printer-state-reasons.folder-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Folder Jam
+#: locale/ipp-strings.c:2924
+msgid "printer-state-reasons.folder-jam"
+msgstr ""
+
+#. TRANSLATORS: Folder Life Almost Over
+#: locale/ipp-strings.c:2926
+msgid "printer-state-reasons.folder-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Folder Life Over
+#: locale/ipp-strings.c:2928
+msgid "printer-state-reasons.folder-life-over"
+msgstr ""
+
+#. TRANSLATORS: Folder Memory Exhausted
+#: locale/ipp-strings.c:2930
+msgid "printer-state-reasons.folder-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Folder Missing
+#: locale/ipp-strings.c:2932
+msgid "printer-state-reasons.folder-missing"
+msgstr ""
+
+#. TRANSLATORS: Folder Motor Failure
+#: locale/ipp-strings.c:2934
+msgid "printer-state-reasons.folder-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Folder Near Limit
+#: locale/ipp-strings.c:2936
+msgid "printer-state-reasons.folder-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Folder Offline
+#: locale/ipp-strings.c:2938
+msgid "printer-state-reasons.folder-offline"
+msgstr ""
+
+#. TRANSLATORS: Folder Opened
+#: locale/ipp-strings.c:2940
+msgid "printer-state-reasons.folder-opened"
+msgstr ""
+
+#. TRANSLATORS: Folder Over Temperature
+#: locale/ipp-strings.c:2942
+msgid "printer-state-reasons.folder-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Folder Power Saver
+#: locale/ipp-strings.c:2944
+msgid "printer-state-reasons.folder-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Folder Recoverable Failure
+#: locale/ipp-strings.c:2946
+msgid "printer-state-reasons.folder-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Folder Recoverable Storage
+#: locale/ipp-strings.c:2948
+msgid "printer-state-reasons.folder-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Folder Removed
+#: locale/ipp-strings.c:2950
+msgid "printer-state-reasons.folder-removed"
+msgstr ""
+
+#. TRANSLATORS: Folder Resource Added
+#: locale/ipp-strings.c:2952
+msgid "printer-state-reasons.folder-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Folder Resource Removed
+#: locale/ipp-strings.c:2954
+msgid "printer-state-reasons.folder-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Folder Thermistor Failure
+#: locale/ipp-strings.c:2956
+msgid "printer-state-reasons.folder-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Folder Timing Failure
+#: locale/ipp-strings.c:2958
+msgid "printer-state-reasons.folder-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Folder Turned Off
+#: locale/ipp-strings.c:2960
+msgid "printer-state-reasons.folder-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Folder Turned On
+#: locale/ipp-strings.c:2962
+msgid "printer-state-reasons.folder-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Folder Under Temperature
+#: locale/ipp-strings.c:2964
+msgid "printer-state-reasons.folder-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Folder Unrecoverable Failure
+#: locale/ipp-strings.c:2966
+msgid "printer-state-reasons.folder-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Folder Unrecoverable Storage Error
+#: locale/ipp-strings.c:2968
+msgid "printer-state-reasons.folder-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Folder Warming Up
+#: locale/ipp-strings.c:2970
+msgid "printer-state-reasons.folder-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Fuser temperature high
+#: locale/ipp-strings.c:2972
+msgid "printer-state-reasons.fuser-over-temp"
+msgstr ""
+
+#. TRANSLATORS: Fuser temperature low
+#: locale/ipp-strings.c:2974
+msgid "printer-state-reasons.fuser-under-temp"
+msgstr ""
+
+#. TRANSLATORS: Hold New Jobs
+#: locale/ipp-strings.c:2976
+msgid "printer-state-reasons.hold-new-jobs"
+msgstr ""
+
+#. TRANSLATORS: Identify Printer
+#: locale/ipp-strings.c:2978
+msgid "printer-state-reasons.identify-printer-requested"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Added
+#: locale/ipp-strings.c:2980
+msgid "printer-state-reasons.imprinter-added"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Almost Empty
+#: locale/ipp-strings.c:2982
+msgid "printer-state-reasons.imprinter-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Almost Full
+#: locale/ipp-strings.c:2984
+msgid "printer-state-reasons.imprinter-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Imprinter At Limit
+#: locale/ipp-strings.c:2986
+msgid "printer-state-reasons.imprinter-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Closed
+#: locale/ipp-strings.c:2988
+msgid "printer-state-reasons.imprinter-closed"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Configuration Change
+#: locale/ipp-strings.c:2990
+msgid "printer-state-reasons.imprinter-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Cover Closed
+#: locale/ipp-strings.c:2992
+msgid "printer-state-reasons.imprinter-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Cover Open
+#: locale/ipp-strings.c:2994
+msgid "printer-state-reasons.imprinter-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Empty
+#: locale/ipp-strings.c:2996
+msgid "printer-state-reasons.imprinter-empty"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Full
+#: locale/ipp-strings.c:2998
+msgid "printer-state-reasons.imprinter-full"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Interlock Closed
+#: locale/ipp-strings.c:3000
+msgid "printer-state-reasons.imprinter-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Interlock Open
+#: locale/ipp-strings.c:3002
+msgid "printer-state-reasons.imprinter-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Jam
+#: locale/ipp-strings.c:3004
+msgid "printer-state-reasons.imprinter-jam"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Life Almost Over
+#: locale/ipp-strings.c:3006
+msgid "printer-state-reasons.imprinter-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Life Over
+#: locale/ipp-strings.c:3008
+msgid "printer-state-reasons.imprinter-life-over"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Memory Exhausted
+#: locale/ipp-strings.c:3010
+msgid "printer-state-reasons.imprinter-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Missing
+#: locale/ipp-strings.c:3012
+msgid "printer-state-reasons.imprinter-missing"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Motor Failure
+#: locale/ipp-strings.c:3014
+msgid "printer-state-reasons.imprinter-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Near Limit
+#: locale/ipp-strings.c:3016
+msgid "printer-state-reasons.imprinter-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Offline
+#: locale/ipp-strings.c:3018
+msgid "printer-state-reasons.imprinter-offline"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Opened
+#: locale/ipp-strings.c:3020
+msgid "printer-state-reasons.imprinter-opened"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Over Temperature
+#: locale/ipp-strings.c:3022
+msgid "printer-state-reasons.imprinter-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Power Saver
+#: locale/ipp-strings.c:3024
+msgid "printer-state-reasons.imprinter-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Recoverable Failure
+#: locale/ipp-strings.c:3026
+msgid "printer-state-reasons.imprinter-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Recoverable Storage
+#: locale/ipp-strings.c:3028
+msgid "printer-state-reasons.imprinter-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Removed
+#: locale/ipp-strings.c:3030
+msgid "printer-state-reasons.imprinter-removed"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Resource Added
+#: locale/ipp-strings.c:3032
+msgid "printer-state-reasons.imprinter-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Resource Removed
+#: locale/ipp-strings.c:3034
+msgid "printer-state-reasons.imprinter-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Thermistor Failure
+#: locale/ipp-strings.c:3036
+msgid "printer-state-reasons.imprinter-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Timing Failure
+#: locale/ipp-strings.c:3038
+msgid "printer-state-reasons.imprinter-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Turned Off
+#: locale/ipp-strings.c:3040
+msgid "printer-state-reasons.imprinter-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Turned On
+#: locale/ipp-strings.c:3042
+msgid "printer-state-reasons.imprinter-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Under Temperature
+#: locale/ipp-strings.c:3044
+msgid "printer-state-reasons.imprinter-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Unrecoverable Failure
+#: locale/ipp-strings.c:3046
+msgid "printer-state-reasons.imprinter-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Unrecoverable Storage Error
+#: locale/ipp-strings.c:3048
+msgid "printer-state-reasons.imprinter-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Imprinter Warming Up
+#: locale/ipp-strings.c:3050
+msgid "printer-state-reasons.imprinter-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Input Cannot Feed Size Selected
+#: locale/ipp-strings.c:3052
+msgid "printer-state-reasons.input-cannot-feed-size-selected"
+msgstr ""
+
+#. TRANSLATORS: Input Manual Input Request
+#: locale/ipp-strings.c:3054
+msgid "printer-state-reasons.input-manual-input-request"
+msgstr ""
+
+#. TRANSLATORS: Input Media Color Change
+#: locale/ipp-strings.c:3056
+msgid "printer-state-reasons.input-media-color-change"
+msgstr ""
+
+#. TRANSLATORS: Input Media Form Parts Change
+#: locale/ipp-strings.c:3058
+msgid "printer-state-reasons.input-media-form-parts-change"
+msgstr ""
+
+#. TRANSLATORS: Input Media Size Change
+#: locale/ipp-strings.c:3060
+msgid "printer-state-reasons.input-media-size-change"
+msgstr ""
+
+#. TRANSLATORS: Input Media Tray Failure
+#: locale/ipp-strings.c:3062
+msgid "printer-state-reasons.input-media-tray-failure"
+msgstr ""
+
+#. TRANSLATORS: Input Media Tray Feed Error
+#: locale/ipp-strings.c:3064
+msgid "printer-state-reasons.input-media-tray-feed-error"
+msgstr ""
+
+#. TRANSLATORS: Input Media Tray Jam
+#: locale/ipp-strings.c:3066
+msgid "printer-state-reasons.input-media-tray-jam"
+msgstr ""
+
+#. TRANSLATORS: Input Media Type Change
+#: locale/ipp-strings.c:3068
+msgid "printer-state-reasons.input-media-type-change"
+msgstr ""
+
+#. TRANSLATORS: Input Media Weight Change
+#: locale/ipp-strings.c:3070
+msgid "printer-state-reasons.input-media-weight-change"
+msgstr ""
+
+#. TRANSLATORS: Input Pick Roller Failure
+#: locale/ipp-strings.c:3072
+msgid "printer-state-reasons.input-pick-roller-failure"
+msgstr ""
+
+#. TRANSLATORS: Input Pick Roller Life Over
+#: locale/ipp-strings.c:3074
+msgid "printer-state-reasons.input-pick-roller-life-over"
+msgstr ""
+
+#. TRANSLATORS: Input Pick Roller Life Warn
+#: locale/ipp-strings.c:3076
+msgid "printer-state-reasons.input-pick-roller-life-warn"
+msgstr ""
+
+#. TRANSLATORS: Input Pick Roller Missing
+#: locale/ipp-strings.c:3078
+msgid "printer-state-reasons.input-pick-roller-missing"
+msgstr ""
+
+#. TRANSLATORS: Input Tray Elevation Failure
+#: locale/ipp-strings.c:3080
+msgid "printer-state-reasons.input-tray-elevation-failure"
+msgstr ""
+
+#. TRANSLATORS: Paper tray is missing
+#: locale/ipp-strings.c:3082
+msgid "printer-state-reasons.input-tray-missing"
+msgstr ""
+
+#. TRANSLATORS: Input Tray Position Failure
+#: locale/ipp-strings.c:3084
+msgid "printer-state-reasons.input-tray-position-failure"
+msgstr ""
+
+#. TRANSLATORS: Inserter Added
+#: locale/ipp-strings.c:3086
+msgid "printer-state-reasons.inserter-added"
+msgstr ""
+
+#. TRANSLATORS: Inserter Almost Empty
+#: locale/ipp-strings.c:3088
+msgid "printer-state-reasons.inserter-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Inserter Almost Full
+#: locale/ipp-strings.c:3090
+msgid "printer-state-reasons.inserter-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Inserter At Limit
+#: locale/ipp-strings.c:3092
+msgid "printer-state-reasons.inserter-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Inserter Closed
+#: locale/ipp-strings.c:3094
+msgid "printer-state-reasons.inserter-closed"
+msgstr ""
+
+#. TRANSLATORS: Inserter Configuration Change
+#: locale/ipp-strings.c:3096
+msgid "printer-state-reasons.inserter-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Inserter Cover Closed
+#: locale/ipp-strings.c:3098
+msgid "printer-state-reasons.inserter-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Inserter Cover Open
+#: locale/ipp-strings.c:3100
+msgid "printer-state-reasons.inserter-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Inserter Empty
+#: locale/ipp-strings.c:3102
+msgid "printer-state-reasons.inserter-empty"
+msgstr ""
+
+#. TRANSLATORS: Inserter Full
+#: locale/ipp-strings.c:3104
+msgid "printer-state-reasons.inserter-full"
+msgstr ""
+
+#. TRANSLATORS: Inserter Interlock Closed
+#: locale/ipp-strings.c:3106
+msgid "printer-state-reasons.inserter-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Inserter Interlock Open
+#: locale/ipp-strings.c:3108
+msgid "printer-state-reasons.inserter-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Inserter Jam
+#: locale/ipp-strings.c:3110
+msgid "printer-state-reasons.inserter-jam"
+msgstr ""
+
+#. TRANSLATORS: Inserter Life Almost Over
+#: locale/ipp-strings.c:3112
+msgid "printer-state-reasons.inserter-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Inserter Life Over
+#: locale/ipp-strings.c:3114
+msgid "printer-state-reasons.inserter-life-over"
+msgstr ""
+
+#. TRANSLATORS: Inserter Memory Exhausted
+#: locale/ipp-strings.c:3116
+msgid "printer-state-reasons.inserter-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Inserter Missing
+#: locale/ipp-strings.c:3118
+msgid "printer-state-reasons.inserter-missing"
+msgstr ""
+
+#. TRANSLATORS: Inserter Motor Failure
+#: locale/ipp-strings.c:3120
+msgid "printer-state-reasons.inserter-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Inserter Near Limit
+#: locale/ipp-strings.c:3122
+msgid "printer-state-reasons.inserter-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Inserter Offline
+#: locale/ipp-strings.c:3124
+msgid "printer-state-reasons.inserter-offline"
+msgstr ""
+
+#. TRANSLATORS: Inserter Opened
+#: locale/ipp-strings.c:3126
+msgid "printer-state-reasons.inserter-opened"
+msgstr ""
+
+#. TRANSLATORS: Inserter Over Temperature
+#: locale/ipp-strings.c:3128
+msgid "printer-state-reasons.inserter-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Inserter Power Saver
+#: locale/ipp-strings.c:3130
+msgid "printer-state-reasons.inserter-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Inserter Recoverable Failure
+#: locale/ipp-strings.c:3132
+msgid "printer-state-reasons.inserter-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Inserter Recoverable Storage
+#: locale/ipp-strings.c:3134
+msgid "printer-state-reasons.inserter-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Inserter Removed
+#: locale/ipp-strings.c:3136
+msgid "printer-state-reasons.inserter-removed"
+msgstr ""
+
+#. TRANSLATORS: Inserter Resource Added
+#: locale/ipp-strings.c:3138
+msgid "printer-state-reasons.inserter-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Inserter Resource Removed
+#: locale/ipp-strings.c:3140
+msgid "printer-state-reasons.inserter-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Inserter Thermistor Failure
+#: locale/ipp-strings.c:3142
+msgid "printer-state-reasons.inserter-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Inserter Timing Failure
+#: locale/ipp-strings.c:3144
+msgid "printer-state-reasons.inserter-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Inserter Turned Off
+#: locale/ipp-strings.c:3146
+msgid "printer-state-reasons.inserter-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Inserter Turned On
+#: locale/ipp-strings.c:3148
+msgid "printer-state-reasons.inserter-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Inserter Under Temperature
+#: locale/ipp-strings.c:3150
+msgid "printer-state-reasons.inserter-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Inserter Unrecoverable Failure
+#: locale/ipp-strings.c:3152
+msgid "printer-state-reasons.inserter-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Inserter Unrecoverable Storage Error
+#: locale/ipp-strings.c:3154
+msgid "printer-state-reasons.inserter-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Inserter Warming Up
+#: locale/ipp-strings.c:3156
+msgid "printer-state-reasons.inserter-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Interlock Closed
+#: locale/ipp-strings.c:3158
+msgid "printer-state-reasons.interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Interlock Open
+#: locale/ipp-strings.c:3160
+msgid "printer-state-reasons.interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Interpreter Cartridge Added
+#: locale/ipp-strings.c:3162
+msgid "printer-state-reasons.interpreter-cartridge-added"
+msgstr ""
+
+#. TRANSLATORS: Interpreter Cartridge Removed
+#: locale/ipp-strings.c:3164
+msgid "printer-state-reasons.interpreter-cartridge-deleted"
+msgstr ""
+
+#. TRANSLATORS: Interpreter Complex Page Encountered
+#: locale/ipp-strings.c:3166
+msgid "printer-state-reasons.interpreter-complex-page-encountered"
+msgstr ""
+
+#. TRANSLATORS: Interpreter Memory Decrease
+#: locale/ipp-strings.c:3168
+msgid "printer-state-reasons.interpreter-memory-decrease"
+msgstr ""
+
+#. TRANSLATORS: Interpreter Memory Increase
+#: locale/ipp-strings.c:3170
+msgid "printer-state-reasons.interpreter-memory-increase"
+msgstr ""
+
+#. TRANSLATORS: Interpreter Resource Added
+#: locale/ipp-strings.c:3172
+msgid "printer-state-reasons.interpreter-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Interpreter Resource Deleted
+#: locale/ipp-strings.c:3174
+msgid "printer-state-reasons.interpreter-resource-deleted"
+msgstr ""
+
+#. TRANSLATORS: Printer resource unavailable
+#: locale/ipp-strings.c:3176
+msgid "printer-state-reasons.interpreter-resource-unavailable"
+msgstr ""
+
+#. TRANSLATORS: Lamp At End of Life
+#: locale/ipp-strings.c:3178
+msgid "printer-state-reasons.lamp-at-eol"
+msgstr ""
+
+#. TRANSLATORS: Lamp Failure
+#: locale/ipp-strings.c:3180
+msgid "printer-state-reasons.lamp-failure"
+msgstr ""
+
+#. TRANSLATORS: Lamp Near End of Life
+#: locale/ipp-strings.c:3182
+msgid "printer-state-reasons.lamp-near-eol"
+msgstr ""
+
+#. TRANSLATORS: Laser At End of Life
+#: locale/ipp-strings.c:3184
+msgid "printer-state-reasons.laser-at-eol"
+msgstr ""
+
+#. TRANSLATORS: Laser Failure
+#: locale/ipp-strings.c:3186
+msgid "printer-state-reasons.laser-failure"
+msgstr ""
+
+#. TRANSLATORS: Laser Near End of Life
+#: locale/ipp-strings.c:3188
+msgid "printer-state-reasons.laser-near-eol"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Added
+#: locale/ipp-strings.c:3190
+msgid "printer-state-reasons.make-envelope-added"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Almost Empty
+#: locale/ipp-strings.c:3192
+msgid "printer-state-reasons.make-envelope-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Almost Full
+#: locale/ipp-strings.c:3194
+msgid "printer-state-reasons.make-envelope-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker At Limit
+#: locale/ipp-strings.c:3196
+msgid "printer-state-reasons.make-envelope-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Closed
+#: locale/ipp-strings.c:3198
+msgid "printer-state-reasons.make-envelope-closed"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Configuration Change
+#: locale/ipp-strings.c:3200
+msgid "printer-state-reasons.make-envelope-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Cover Closed
+#: locale/ipp-strings.c:3202
+msgid "printer-state-reasons.make-envelope-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Cover Open
+#: locale/ipp-strings.c:3204
+msgid "printer-state-reasons.make-envelope-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Empty
+#: locale/ipp-strings.c:3206
+msgid "printer-state-reasons.make-envelope-empty"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Full
+#: locale/ipp-strings.c:3208
+msgid "printer-state-reasons.make-envelope-full"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Interlock Closed
+#: locale/ipp-strings.c:3210
+msgid "printer-state-reasons.make-envelope-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Interlock Open
+#: locale/ipp-strings.c:3212
+msgid "printer-state-reasons.make-envelope-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Jam
+#: locale/ipp-strings.c:3214
+msgid "printer-state-reasons.make-envelope-jam"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Life Almost Over
+#: locale/ipp-strings.c:3216
+msgid "printer-state-reasons.make-envelope-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Life Over
+#: locale/ipp-strings.c:3218
+msgid "printer-state-reasons.make-envelope-life-over"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Memory Exhausted
+#: locale/ipp-strings.c:3220
+msgid "printer-state-reasons.make-envelope-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Missing
+#: locale/ipp-strings.c:3222
+msgid "printer-state-reasons.make-envelope-missing"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Motor Failure
+#: locale/ipp-strings.c:3224
+msgid "printer-state-reasons.make-envelope-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Near Limit
+#: locale/ipp-strings.c:3226
+msgid "printer-state-reasons.make-envelope-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Offline
+#: locale/ipp-strings.c:3228
+msgid "printer-state-reasons.make-envelope-offline"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Opened
+#: locale/ipp-strings.c:3230
+msgid "printer-state-reasons.make-envelope-opened"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Over Temperature
+#: locale/ipp-strings.c:3232
+msgid "printer-state-reasons.make-envelope-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Power Saver
+#: locale/ipp-strings.c:3234
+msgid "printer-state-reasons.make-envelope-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Recoverable Failure
+#: locale/ipp-strings.c:3236
+msgid "printer-state-reasons.make-envelope-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Recoverable Storage
+#: locale/ipp-strings.c:3238
+msgid "printer-state-reasons.make-envelope-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Removed
+#: locale/ipp-strings.c:3240
+msgid "printer-state-reasons.make-envelope-removed"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Resource Added
+#: locale/ipp-strings.c:3242
+msgid "printer-state-reasons.make-envelope-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Resource Removed
+#: locale/ipp-strings.c:3244
+msgid "printer-state-reasons.make-envelope-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Thermistor Failure
+#: locale/ipp-strings.c:3246
+msgid "printer-state-reasons.make-envelope-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Timing Failure
+#: locale/ipp-strings.c:3248
+msgid "printer-state-reasons.make-envelope-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Turned Off
+#: locale/ipp-strings.c:3250
+msgid "printer-state-reasons.make-envelope-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Turned On
+#: locale/ipp-strings.c:3252
+msgid "printer-state-reasons.make-envelope-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Under Temperature
+#: locale/ipp-strings.c:3254
+msgid "printer-state-reasons.make-envelope-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Unrecoverable Failure
+#: locale/ipp-strings.c:3256
+msgid "printer-state-reasons.make-envelope-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Unrecoverable Storage Error
+#: locale/ipp-strings.c:3258
+msgid "printer-state-reasons.make-envelope-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Envelope Maker Warming Up
+#: locale/ipp-strings.c:3260
+msgid "printer-state-reasons.make-envelope-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Marker Adjusting Print Quality
+#: locale/ipp-strings.c:3262
+msgid "printer-state-reasons.marker-adjusting-print-quality"
+msgstr ""
+
+#. TRANSLATORS: Marker Cleaner Missing
+#: locale/ipp-strings.c:3264
+msgid "printer-state-reasons.marker-cleaner-missing"
+msgstr ""
+
+#. TRANSLATORS: Marker Developer Almost Empty
+#: locale/ipp-strings.c:3266
+msgid "printer-state-reasons.marker-developer-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Marker Developer Empty
+#: locale/ipp-strings.c:3268
+msgid "printer-state-reasons.marker-developer-empty"
+msgstr ""
+
+#. TRANSLATORS: Marker Developer Missing
+#: locale/ipp-strings.c:3270
+msgid "printer-state-reasons.marker-developer-missing"
+msgstr ""
+
+#. TRANSLATORS: Marker Fuser Missing
+#: locale/ipp-strings.c:3272
+msgid "printer-state-reasons.marker-fuser-missing"
+msgstr ""
+
+#. TRANSLATORS: Marker Fuser Thermistor Failure
+#: locale/ipp-strings.c:3274
+msgid "printer-state-reasons.marker-fuser-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Marker Fuser Timing Failure
+#: locale/ipp-strings.c:3276
+msgid "printer-state-reasons.marker-fuser-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Marker Ink Almost Empty
+#: locale/ipp-strings.c:3278
+msgid "printer-state-reasons.marker-ink-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Marker Ink Empty
+#: locale/ipp-strings.c:3280
+msgid "printer-state-reasons.marker-ink-empty"
+msgstr ""
+
+#. TRANSLATORS: Marker Ink Missing
+#: locale/ipp-strings.c:3282
+msgid "printer-state-reasons.marker-ink-missing"
+msgstr ""
+
+#. TRANSLATORS: Marker Opc Missing
+#: locale/ipp-strings.c:3284
+msgid "printer-state-reasons.marker-opc-missing"
+msgstr ""
+
+#. TRANSLATORS: Marker Print Ribbon Almost Empty
+#: locale/ipp-strings.c:3286
+msgid "printer-state-reasons.marker-print-ribbon-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Marker Print Ribbon Empty
+#: locale/ipp-strings.c:3288
+msgid "printer-state-reasons.marker-print-ribbon-empty"
+msgstr ""
+
+#. TRANSLATORS: Marker Print Ribbon Missing
+#: locale/ipp-strings.c:3290
+msgid "printer-state-reasons.marker-print-ribbon-missing"
+msgstr ""
+
+#. TRANSLATORS: Marker Supply Almost Empty
+#: locale/ipp-strings.c:3292
+msgid "printer-state-reasons.marker-supply-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Ink/toner empty
+#: locale/ipp-strings.c:3294
+msgid "printer-state-reasons.marker-supply-empty"
+msgstr ""
+
+#. TRANSLATORS: Ink/toner low
+#: locale/ipp-strings.c:3296
+msgid "printer-state-reasons.marker-supply-low"
+msgstr ""
+
+#. TRANSLATORS: Marker Supply Missing
+#: locale/ipp-strings.c:3298
+msgid "printer-state-reasons.marker-supply-missing"
+msgstr ""
+
+#. TRANSLATORS: Marker Toner Cartridge Missing
+#: locale/ipp-strings.c:3300
+msgid "printer-state-reasons.marker-toner-cartridge-missing"
+msgstr ""
+
+#. TRANSLATORS: Marker Toner Missing
+#: locale/ipp-strings.c:3302
+msgid "printer-state-reasons.marker-toner-missing"
+msgstr ""
+
+#. TRANSLATORS: Ink/toner waste bin almost full
+#: locale/ipp-strings.c:3304
+msgid "printer-state-reasons.marker-waste-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Ink/toner waste bin full
+#: locale/ipp-strings.c:3306
+msgid "printer-state-reasons.marker-waste-full"
+msgstr ""
+
+#. TRANSLATORS: Marker Waste Ink Receptacle Almost Full
+#: locale/ipp-strings.c:3308
+msgid "printer-state-reasons.marker-waste-ink-receptacle-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Marker Waste Ink Receptacle Full
+#: locale/ipp-strings.c:3310
+msgid "printer-state-reasons.marker-waste-ink-receptacle-full"
+msgstr ""
+
+#. TRANSLATORS: Marker Waste Ink Receptacle Missing
+#: locale/ipp-strings.c:3312
+msgid "printer-state-reasons.marker-waste-ink-receptacle-missing"
+msgstr ""
+
+#. TRANSLATORS: Marker Waste Missing
+#: locale/ipp-strings.c:3314
+msgid "printer-state-reasons.marker-waste-missing"
+msgstr ""
+
+#. TRANSLATORS: Marker Waste Toner Receptacle Almost Full
+#: locale/ipp-strings.c:3316
+msgid "printer-state-reasons.marker-waste-toner-receptacle-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Marker Waste Toner Receptacle Full
+#: locale/ipp-strings.c:3318
+msgid "printer-state-reasons.marker-waste-toner-receptacle-full"
+msgstr ""
+
+#. TRANSLATORS: Marker Waste Toner Receptacle Missing
+#: locale/ipp-strings.c:3320
+msgid "printer-state-reasons.marker-waste-toner-receptacle-missing"
+msgstr ""
+
+#. TRANSLATORS: Material Empty
+#: locale/ipp-strings.c:3322
+msgid "printer-state-reasons.material-empty"
+msgstr ""
+
+#. TRANSLATORS: Material Low
+#: locale/ipp-strings.c:3324
+msgid "printer-state-reasons.material-low"
+msgstr ""
+
+#. TRANSLATORS: Material Needed
+#: locale/ipp-strings.c:3326
+msgid "printer-state-reasons.material-needed"
+msgstr ""
+
+#. TRANSLATORS: Media Drying
+#: locale/ipp-strings.c:3328
+msgid "printer-state-reasons.media-drying"
+msgstr ""
+
+#. TRANSLATORS: Paper tray is empty
+#: locale/ipp-strings.c:3330
+msgid "printer-state-reasons.media-empty"
+msgstr ""
+
+#. TRANSLATORS: Paper jam
+#: locale/ipp-strings.c:3332
+msgid "printer-state-reasons.media-jam"
+msgstr ""
+
+#. TRANSLATORS: Paper tray is almost empty
+#: locale/ipp-strings.c:3334
+msgid "printer-state-reasons.media-low"
+msgstr ""
+
+#. TRANSLATORS: Load paper
+#: locale/ipp-strings.c:3336
+msgid "printer-state-reasons.media-needed"
+msgstr ""
+
+#. TRANSLATORS: Media Path Cannot Do 2-Sided Printing
+#: locale/ipp-strings.c:3338
+msgid "printer-state-reasons.media-path-cannot-duplex-media-selected"
+msgstr ""
+
+#. TRANSLATORS: Media Path Failure
+#: locale/ipp-strings.c:3340
+msgid "printer-state-reasons.media-path-failure"
+msgstr ""
+
+#. TRANSLATORS: Media Path Input Empty
+#: locale/ipp-strings.c:3342
+msgid "printer-state-reasons.media-path-input-empty"
+msgstr ""
+
+#. TRANSLATORS: Media Path Input Feed Error
+#: locale/ipp-strings.c:3344
+msgid "printer-state-reasons.media-path-input-feed-error"
+msgstr ""
+
+#. TRANSLATORS: Media Path Input Jam
+#: locale/ipp-strings.c:3346
+msgid "printer-state-reasons.media-path-input-jam"
+msgstr ""
+
+#. TRANSLATORS: Media Path Input Request
+#: locale/ipp-strings.c:3348
+msgid "printer-state-reasons.media-path-input-request"
+msgstr ""
+
+#. TRANSLATORS: Media Path Jam
+#: locale/ipp-strings.c:3350
+msgid "printer-state-reasons.media-path-jam"
+msgstr ""
+
+#. TRANSLATORS: Media Path Media Tray Almost Full
+#: locale/ipp-strings.c:3352
+msgid "printer-state-reasons.media-path-media-tray-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Media Path Media Tray Full
+#: locale/ipp-strings.c:3354
+msgid "printer-state-reasons.media-path-media-tray-full"
+msgstr ""
+
+#. TRANSLATORS: Media Path Media Tray Missing
+#: locale/ipp-strings.c:3356
+msgid "printer-state-reasons.media-path-media-tray-missing"
+msgstr ""
+
+#. TRANSLATORS: Media Path Output Feed Error
+#: locale/ipp-strings.c:3358
+msgid "printer-state-reasons.media-path-output-feed-error"
+msgstr ""
+
+#. TRANSLATORS: Media Path Output Full
+#: locale/ipp-strings.c:3360
+msgid "printer-state-reasons.media-path-output-full"
+msgstr ""
+
+#. TRANSLATORS: Media Path Output Jam
+#: locale/ipp-strings.c:3362
+msgid "printer-state-reasons.media-path-output-jam"
+msgstr ""
+
+#. TRANSLATORS: Media Path Pick Roller Failure
+#: locale/ipp-strings.c:3364
+msgid "printer-state-reasons.media-path-pick-roller-failure"
+msgstr ""
+
+#. TRANSLATORS: Media Path Pick Roller Life Over
+#: locale/ipp-strings.c:3366
+msgid "printer-state-reasons.media-path-pick-roller-life-over"
+msgstr ""
+
+#. TRANSLATORS: Media Path Pick Roller Life Warn
+#: locale/ipp-strings.c:3368
+msgid "printer-state-reasons.media-path-pick-roller-life-warn"
+msgstr ""
+
+#. TRANSLATORS: Media Path Pick Roller Missing
+#: locale/ipp-strings.c:3370
+msgid "printer-state-reasons.media-path-pick-roller-missing"
+msgstr ""
+
+#. TRANSLATORS: Motor Failure
+#: locale/ipp-strings.c:3372
+msgid "printer-state-reasons.motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Printer going offline
+#: locale/ipp-strings.c:3374
+msgid "printer-state-reasons.moving-to-paused"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:3376
+msgid "printer-state-reasons.none"
+msgstr ""
+
+#. TRANSLATORS: Optical Photoconductor Life Over
+#: locale/ipp-strings.c:3378
+msgid "printer-state-reasons.opc-life-over"
+msgstr ""
+
+#. TRANSLATORS: OPC almost at end-of-life
+#: locale/ipp-strings.c:3380
+msgid "printer-state-reasons.opc-near-eol"
+msgstr ""
+
+#. TRANSLATORS: Check the printer for errors
+#: locale/ipp-strings.c:3382
+msgid "printer-state-reasons.other"
+msgstr ""
+
+#. TRANSLATORS: Output bin is almost full
+#: locale/ipp-strings.c:3384
+msgid "printer-state-reasons.output-area-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Output bin is full
+#: locale/ipp-strings.c:3386
+msgid "printer-state-reasons.output-area-full"
+msgstr ""
+
+#. TRANSLATORS: Output Mailbox Select Failure
+#: locale/ipp-strings.c:3388
+msgid "printer-state-reasons.output-mailbox-select-failure"
+msgstr ""
+
+#. TRANSLATORS: Output Media Tray Failure
+#: locale/ipp-strings.c:3390
+msgid "printer-state-reasons.output-media-tray-failure"
+msgstr ""
+
+#. TRANSLATORS: Output Media Tray Feed Error
+#: locale/ipp-strings.c:3392
+msgid "printer-state-reasons.output-media-tray-feed-error"
+msgstr ""
+
+#. TRANSLATORS: Output Media Tray Jam
+#: locale/ipp-strings.c:3394
+msgid "printer-state-reasons.output-media-tray-jam"
+msgstr ""
+
+#. TRANSLATORS: Output tray is missing
+#: locale/ipp-strings.c:3396
+msgid "printer-state-reasons.output-tray-missing"
+msgstr ""
+
+#. TRANSLATORS: Paused
+#: locale/ipp-strings.c:3398
+msgid "printer-state-reasons.paused"
+msgstr ""
+
+#. TRANSLATORS: Perforater Added
+#: locale/ipp-strings.c:3400
+msgid "printer-state-reasons.perforater-added"
+msgstr ""
+
+#. TRANSLATORS: Perforater Almost Empty
+#: locale/ipp-strings.c:3402
+msgid "printer-state-reasons.perforater-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Perforater Almost Full
+#: locale/ipp-strings.c:3404
+msgid "printer-state-reasons.perforater-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Perforater At Limit
+#: locale/ipp-strings.c:3406
+msgid "printer-state-reasons.perforater-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Perforater Closed
+#: locale/ipp-strings.c:3408
+msgid "printer-state-reasons.perforater-closed"
+msgstr ""
+
+#. TRANSLATORS: Perforater Configuration Change
+#: locale/ipp-strings.c:3410
+msgid "printer-state-reasons.perforater-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Perforater Cover Closed
+#: locale/ipp-strings.c:3412
+msgid "printer-state-reasons.perforater-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Perforater Cover Open
+#: locale/ipp-strings.c:3414
+msgid "printer-state-reasons.perforater-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Perforater Empty
+#: locale/ipp-strings.c:3416
+msgid "printer-state-reasons.perforater-empty"
+msgstr ""
+
+#. TRANSLATORS: Perforater Full
+#: locale/ipp-strings.c:3418
+msgid "printer-state-reasons.perforater-full"
+msgstr ""
+
+#. TRANSLATORS: Perforater Interlock Closed
+#: locale/ipp-strings.c:3420
+msgid "printer-state-reasons.perforater-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Perforater Interlock Open
+#: locale/ipp-strings.c:3422
+msgid "printer-state-reasons.perforater-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Perforater Jam
+#: locale/ipp-strings.c:3424
+msgid "printer-state-reasons.perforater-jam"
+msgstr ""
+
+#. TRANSLATORS: Perforater Life Almost Over
+#: locale/ipp-strings.c:3426
+msgid "printer-state-reasons.perforater-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Perforater Life Over
+#: locale/ipp-strings.c:3428
+msgid "printer-state-reasons.perforater-life-over"
+msgstr ""
+
+#. TRANSLATORS: Perforater Memory Exhausted
+#: locale/ipp-strings.c:3430
+msgid "printer-state-reasons.perforater-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Perforater Missing
+#: locale/ipp-strings.c:3432
+msgid "printer-state-reasons.perforater-missing"
+msgstr ""
+
+#. TRANSLATORS: Perforater Motor Failure
+#: locale/ipp-strings.c:3434
+msgid "printer-state-reasons.perforater-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Perforater Near Limit
+#: locale/ipp-strings.c:3436
+msgid "printer-state-reasons.perforater-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Perforater Offline
+#: locale/ipp-strings.c:3438
+msgid "printer-state-reasons.perforater-offline"
+msgstr ""
+
+#. TRANSLATORS: Perforater Opened
+#: locale/ipp-strings.c:3440
+msgid "printer-state-reasons.perforater-opened"
+msgstr ""
+
+#. TRANSLATORS: Perforater Over Temperature
+#: locale/ipp-strings.c:3442
+msgid "printer-state-reasons.perforater-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Perforater Power Saver
+#: locale/ipp-strings.c:3444
+msgid "printer-state-reasons.perforater-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Perforater Recoverable Failure
+#: locale/ipp-strings.c:3446
+msgid "printer-state-reasons.perforater-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Perforater Recoverable Storage
+#: locale/ipp-strings.c:3448
+msgid "printer-state-reasons.perforater-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Perforater Removed
+#: locale/ipp-strings.c:3450
+msgid "printer-state-reasons.perforater-removed"
+msgstr ""
+
+#. TRANSLATORS: Perforater Resource Added
+#: locale/ipp-strings.c:3452
+msgid "printer-state-reasons.perforater-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Perforater Resource Removed
+#: locale/ipp-strings.c:3454
+msgid "printer-state-reasons.perforater-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Perforater Thermistor Failure
+#: locale/ipp-strings.c:3456
+msgid "printer-state-reasons.perforater-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Perforater Timing Failure
+#: locale/ipp-strings.c:3458
+msgid "printer-state-reasons.perforater-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Perforater Turned Off
+#: locale/ipp-strings.c:3460
+msgid "printer-state-reasons.perforater-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Perforater Turned On
+#: locale/ipp-strings.c:3462
+msgid "printer-state-reasons.perforater-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Perforater Under Temperature
+#: locale/ipp-strings.c:3464
+msgid "printer-state-reasons.perforater-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Perforater Unrecoverable Failure
+#: locale/ipp-strings.c:3466
+msgid "printer-state-reasons.perforater-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Perforater Unrecoverable Storage Error
+#: locale/ipp-strings.c:3468
+msgid "printer-state-reasons.perforater-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Perforater Warming Up
+#: locale/ipp-strings.c:3470
+msgid "printer-state-reasons.perforater-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Platform Cooling
+#: locale/ipp-strings.c:3472
+msgid "printer-state-reasons.platform-cooling"
+msgstr ""
+
+#. TRANSLATORS: Platform Failure
+#: locale/ipp-strings.c:3474
+msgid "printer-state-reasons.platform-failure"
+msgstr ""
+
+#. TRANSLATORS: Platform Heating
+#: locale/ipp-strings.c:3476
+msgid "printer-state-reasons.platform-heating"
+msgstr ""
+
+#. TRANSLATORS: Platform Temperature High
+#: locale/ipp-strings.c:3478
+msgid "printer-state-reasons.platform-temperature-high"
+msgstr ""
+
+#. TRANSLATORS: Platform Temperature Low
+#: locale/ipp-strings.c:3480
+msgid "printer-state-reasons.platform-temperature-low"
+msgstr ""
+
+#. TRANSLATORS: Power Down
+#: locale/ipp-strings.c:3482
+msgid "printer-state-reasons.power-down"
+msgstr ""
+
+#. TRANSLATORS: Power Up
+#: locale/ipp-strings.c:3484
+msgid "printer-state-reasons.power-up"
+msgstr ""
+
+#. TRANSLATORS: Printer Reset Manually
+#: locale/ipp-strings.c:3486
+msgid "printer-state-reasons.printer-manual-reset"
+msgstr ""
+
+#. TRANSLATORS: Printer Reset Remotely
+#: locale/ipp-strings.c:3488
+msgid "printer-state-reasons.printer-nms-reset"
+msgstr ""
+
+#. TRANSLATORS: Printer Ready To Print
+#: locale/ipp-strings.c:3490
+msgid "printer-state-reasons.printer-ready-to-print"
+msgstr ""
+
+#. TRANSLATORS: Puncher Added
+#: locale/ipp-strings.c:3492
+msgid "printer-state-reasons.puncher-added"
+msgstr ""
+
+#. TRANSLATORS: Puncher Almost Empty
+#: locale/ipp-strings.c:3494
+msgid "printer-state-reasons.puncher-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Puncher Almost Full
+#: locale/ipp-strings.c:3496
+msgid "printer-state-reasons.puncher-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Puncher At Limit
+#: locale/ipp-strings.c:3498
+msgid "printer-state-reasons.puncher-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Puncher Closed
+#: locale/ipp-strings.c:3500
+msgid "printer-state-reasons.puncher-closed"
+msgstr ""
+
+#. TRANSLATORS: Puncher Configuration Change
+#: locale/ipp-strings.c:3502
+msgid "printer-state-reasons.puncher-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Puncher Cover Closed
+#: locale/ipp-strings.c:3504
+msgid "printer-state-reasons.puncher-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Puncher Cover Open
+#: locale/ipp-strings.c:3506
+msgid "printer-state-reasons.puncher-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Puncher Empty
+#: locale/ipp-strings.c:3508
+msgid "printer-state-reasons.puncher-empty"
+msgstr ""
+
+#. TRANSLATORS: Puncher Full
+#: locale/ipp-strings.c:3510
+msgid "printer-state-reasons.puncher-full"
+msgstr ""
+
+#. TRANSLATORS: Puncher Interlock Closed
+#: locale/ipp-strings.c:3512
+msgid "printer-state-reasons.puncher-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Puncher Interlock Open
+#: locale/ipp-strings.c:3514
+msgid "printer-state-reasons.puncher-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Puncher Jam
+#: locale/ipp-strings.c:3516
+msgid "printer-state-reasons.puncher-jam"
+msgstr ""
+
+#. TRANSLATORS: Puncher Life Almost Over
+#: locale/ipp-strings.c:3518
+msgid "printer-state-reasons.puncher-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Puncher Life Over
+#: locale/ipp-strings.c:3520
+msgid "printer-state-reasons.puncher-life-over"
+msgstr ""
+
+#. TRANSLATORS: Puncher Memory Exhausted
+#: locale/ipp-strings.c:3522
+msgid "printer-state-reasons.puncher-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Puncher Missing
+#: locale/ipp-strings.c:3524
+msgid "printer-state-reasons.puncher-missing"
+msgstr ""
+
+#. TRANSLATORS: Puncher Motor Failure
+#: locale/ipp-strings.c:3526
+msgid "printer-state-reasons.puncher-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Puncher Near Limit
+#: locale/ipp-strings.c:3528
+msgid "printer-state-reasons.puncher-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Puncher Offline
+#: locale/ipp-strings.c:3530
+msgid "printer-state-reasons.puncher-offline"
+msgstr ""
+
+#. TRANSLATORS: Puncher Opened
+#: locale/ipp-strings.c:3532
+msgid "printer-state-reasons.puncher-opened"
+msgstr ""
+
+#. TRANSLATORS: Puncher Over Temperature
+#: locale/ipp-strings.c:3534
+msgid "printer-state-reasons.puncher-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Puncher Power Saver
+#: locale/ipp-strings.c:3536
+msgid "printer-state-reasons.puncher-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Puncher Recoverable Failure
+#: locale/ipp-strings.c:3538
+msgid "printer-state-reasons.puncher-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Puncher Recoverable Storage
+#: locale/ipp-strings.c:3540
+msgid "printer-state-reasons.puncher-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Puncher Removed
+#: locale/ipp-strings.c:3542
+msgid "printer-state-reasons.puncher-removed"
+msgstr ""
+
+#. TRANSLATORS: Puncher Resource Added
+#: locale/ipp-strings.c:3544
+msgid "printer-state-reasons.puncher-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Puncher Resource Removed
+#: locale/ipp-strings.c:3546
+msgid "printer-state-reasons.puncher-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Puncher Thermistor Failure
+#: locale/ipp-strings.c:3548
+msgid "printer-state-reasons.puncher-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Puncher Timing Failure
+#: locale/ipp-strings.c:3550
+msgid "printer-state-reasons.puncher-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Puncher Turned Off
+#: locale/ipp-strings.c:3552
+msgid "printer-state-reasons.puncher-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Puncher Turned On
+#: locale/ipp-strings.c:3554
+msgid "printer-state-reasons.puncher-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Puncher Under Temperature
+#: locale/ipp-strings.c:3556
+msgid "printer-state-reasons.puncher-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Puncher Unrecoverable Failure
+#: locale/ipp-strings.c:3558
+msgid "printer-state-reasons.puncher-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Puncher Unrecoverable Storage Error
+#: locale/ipp-strings.c:3560
+msgid "printer-state-reasons.puncher-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Puncher Warming Up
+#: locale/ipp-strings.c:3562
+msgid "printer-state-reasons.puncher-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Added
+#: locale/ipp-strings.c:3564
+msgid "printer-state-reasons.separation-cutter-added"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Almost Empty
+#: locale/ipp-strings.c:3566
+msgid "printer-state-reasons.separation-cutter-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Almost Full
+#: locale/ipp-strings.c:3568
+msgid "printer-state-reasons.separation-cutter-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter At Limit
+#: locale/ipp-strings.c:3570
+msgid "printer-state-reasons.separation-cutter-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Closed
+#: locale/ipp-strings.c:3572
+msgid "printer-state-reasons.separation-cutter-closed"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Configuration Change
+#: locale/ipp-strings.c:3574
+msgid "printer-state-reasons.separation-cutter-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Cover Closed
+#: locale/ipp-strings.c:3576
+msgid "printer-state-reasons.separation-cutter-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Cover Open
+#: locale/ipp-strings.c:3578
+msgid "printer-state-reasons.separation-cutter-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Empty
+#: locale/ipp-strings.c:3580
+msgid "printer-state-reasons.separation-cutter-empty"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Full
+#: locale/ipp-strings.c:3582
+msgid "printer-state-reasons.separation-cutter-full"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Interlock Closed
+#: locale/ipp-strings.c:3584
+msgid "printer-state-reasons.separation-cutter-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Interlock Open
+#: locale/ipp-strings.c:3586
+msgid "printer-state-reasons.separation-cutter-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Jam
+#: locale/ipp-strings.c:3588
+msgid "printer-state-reasons.separation-cutter-jam"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Life Almost Over
+#: locale/ipp-strings.c:3590
+msgid "printer-state-reasons.separation-cutter-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Life Over
+#: locale/ipp-strings.c:3592
+msgid "printer-state-reasons.separation-cutter-life-over"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Memory Exhausted
+#: locale/ipp-strings.c:3594
+msgid "printer-state-reasons.separation-cutter-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Missing
+#: locale/ipp-strings.c:3596
+msgid "printer-state-reasons.separation-cutter-missing"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Motor Failure
+#: locale/ipp-strings.c:3598
+msgid "printer-state-reasons.separation-cutter-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Near Limit
+#: locale/ipp-strings.c:3600
+msgid "printer-state-reasons.separation-cutter-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Offline
+#: locale/ipp-strings.c:3602
+msgid "printer-state-reasons.separation-cutter-offline"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Opened
+#: locale/ipp-strings.c:3604
+msgid "printer-state-reasons.separation-cutter-opened"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Over Temperature
+#: locale/ipp-strings.c:3606
+msgid "printer-state-reasons.separation-cutter-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Power Saver
+#: locale/ipp-strings.c:3608
+msgid "printer-state-reasons.separation-cutter-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Recoverable Failure
+#: locale/ipp-strings.c:3610
+msgid "printer-state-reasons.separation-cutter-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Recoverable Storage
+#: locale/ipp-strings.c:3612
+msgid "printer-state-reasons.separation-cutter-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Removed
+#: locale/ipp-strings.c:3614
+msgid "printer-state-reasons.separation-cutter-removed"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Resource Added
+#: locale/ipp-strings.c:3616
+msgid "printer-state-reasons.separation-cutter-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Resource Removed
+#: locale/ipp-strings.c:3618
+msgid "printer-state-reasons.separation-cutter-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Thermistor Failure
+#: locale/ipp-strings.c:3620
+msgid "printer-state-reasons.separation-cutter-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Timing Failure
+#: locale/ipp-strings.c:3622
+msgid "printer-state-reasons.separation-cutter-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Turned Off
+#: locale/ipp-strings.c:3624
+msgid "printer-state-reasons.separation-cutter-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Turned On
+#: locale/ipp-strings.c:3626
+msgid "printer-state-reasons.separation-cutter-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Under Temperature
+#: locale/ipp-strings.c:3628
+msgid "printer-state-reasons.separation-cutter-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Unrecoverable Failure
+#: locale/ipp-strings.c:3630
+msgid "printer-state-reasons.separation-cutter-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Unrecoverable Storage Error
+#: locale/ipp-strings.c:3632
+msgid "printer-state-reasons.separation-cutter-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Separation Cutter Warming Up
+#: locale/ipp-strings.c:3634
+msgid "printer-state-reasons.separation-cutter-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Added
+#: locale/ipp-strings.c:3636
+msgid "printer-state-reasons.sheet-rotator-added"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Almost Empty
+#: locale/ipp-strings.c:3638
+msgid "printer-state-reasons.sheet-rotator-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Almost Full
+#: locale/ipp-strings.c:3640
+msgid "printer-state-reasons.sheet-rotator-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator At Limit
+#: locale/ipp-strings.c:3642
+msgid "printer-state-reasons.sheet-rotator-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Closed
+#: locale/ipp-strings.c:3644
+msgid "printer-state-reasons.sheet-rotator-closed"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Configuration Change
+#: locale/ipp-strings.c:3646
+msgid "printer-state-reasons.sheet-rotator-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Cover Closed
+#: locale/ipp-strings.c:3648
+msgid "printer-state-reasons.sheet-rotator-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Cover Open
+#: locale/ipp-strings.c:3650
+msgid "printer-state-reasons.sheet-rotator-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Empty
+#: locale/ipp-strings.c:3652
+msgid "printer-state-reasons.sheet-rotator-empty"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Full
+#: locale/ipp-strings.c:3654
+msgid "printer-state-reasons.sheet-rotator-full"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Interlock Closed
+#: locale/ipp-strings.c:3656
+msgid "printer-state-reasons.sheet-rotator-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Interlock Open
+#: locale/ipp-strings.c:3658
+msgid "printer-state-reasons.sheet-rotator-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Jam
+#: locale/ipp-strings.c:3660
+msgid "printer-state-reasons.sheet-rotator-jam"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Life Almost Over
+#: locale/ipp-strings.c:3662
+msgid "printer-state-reasons.sheet-rotator-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Life Over
+#: locale/ipp-strings.c:3664
+msgid "printer-state-reasons.sheet-rotator-life-over"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Memory Exhausted
+#: locale/ipp-strings.c:3666
+msgid "printer-state-reasons.sheet-rotator-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Missing
+#: locale/ipp-strings.c:3668
+msgid "printer-state-reasons.sheet-rotator-missing"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Motor Failure
+#: locale/ipp-strings.c:3670
+msgid "printer-state-reasons.sheet-rotator-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Near Limit
+#: locale/ipp-strings.c:3672
+msgid "printer-state-reasons.sheet-rotator-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Offline
+#: locale/ipp-strings.c:3674
+msgid "printer-state-reasons.sheet-rotator-offline"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Opened
+#: locale/ipp-strings.c:3676
+msgid "printer-state-reasons.sheet-rotator-opened"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Over Temperature
+#: locale/ipp-strings.c:3678
+msgid "printer-state-reasons.sheet-rotator-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Power Saver
+#: locale/ipp-strings.c:3680
+msgid "printer-state-reasons.sheet-rotator-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Recoverable Failure
+#: locale/ipp-strings.c:3682
+msgid "printer-state-reasons.sheet-rotator-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Recoverable Storage
+#: locale/ipp-strings.c:3684
+msgid "printer-state-reasons.sheet-rotator-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Removed
+#: locale/ipp-strings.c:3686
+msgid "printer-state-reasons.sheet-rotator-removed"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Resource Added
+#: locale/ipp-strings.c:3688
+msgid "printer-state-reasons.sheet-rotator-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Resource Removed
+#: locale/ipp-strings.c:3690
+msgid "printer-state-reasons.sheet-rotator-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Thermistor Failure
+#: locale/ipp-strings.c:3692
+msgid "printer-state-reasons.sheet-rotator-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Timing Failure
+#: locale/ipp-strings.c:3694
+msgid "printer-state-reasons.sheet-rotator-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Turned Off
+#: locale/ipp-strings.c:3696
+msgid "printer-state-reasons.sheet-rotator-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Turned On
+#: locale/ipp-strings.c:3698
+msgid "printer-state-reasons.sheet-rotator-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Under Temperature
+#: locale/ipp-strings.c:3700
+msgid "printer-state-reasons.sheet-rotator-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Unrecoverable Failure
+#: locale/ipp-strings.c:3702
+msgid "printer-state-reasons.sheet-rotator-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Unrecoverable Storage Error
+#: locale/ipp-strings.c:3704
+msgid "printer-state-reasons.sheet-rotator-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Sheet Rotator Warming Up
+#: locale/ipp-strings.c:3706
+msgid "printer-state-reasons.sheet-rotator-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Printer offline
+#: locale/ipp-strings.c:3708
+msgid "printer-state-reasons.shutdown"
+msgstr ""
+
+#. TRANSLATORS: Slitter Added
+#: locale/ipp-strings.c:3710
+msgid "printer-state-reasons.slitter-added"
+msgstr ""
+
+#. TRANSLATORS: Slitter Almost Empty
+#: locale/ipp-strings.c:3712
+msgid "printer-state-reasons.slitter-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Slitter Almost Full
+#: locale/ipp-strings.c:3714
+msgid "printer-state-reasons.slitter-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Slitter At Limit
+#: locale/ipp-strings.c:3716
+msgid "printer-state-reasons.slitter-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Slitter Closed
+#: locale/ipp-strings.c:3718
+msgid "printer-state-reasons.slitter-closed"
+msgstr ""
+
+#. TRANSLATORS: Slitter Configuration Change
+#: locale/ipp-strings.c:3720
+msgid "printer-state-reasons.slitter-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Slitter Cover Closed
+#: locale/ipp-strings.c:3722
+msgid "printer-state-reasons.slitter-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Slitter Cover Open
+#: locale/ipp-strings.c:3724
+msgid "printer-state-reasons.slitter-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Slitter Empty
+#: locale/ipp-strings.c:3726
+msgid "printer-state-reasons.slitter-empty"
+msgstr ""
+
+#. TRANSLATORS: Slitter Full
+#: locale/ipp-strings.c:3728
+msgid "printer-state-reasons.slitter-full"
+msgstr ""
+
+#. TRANSLATORS: Slitter Interlock Closed
+#: locale/ipp-strings.c:3730
+msgid "printer-state-reasons.slitter-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Slitter Interlock Open
+#: locale/ipp-strings.c:3732
+msgid "printer-state-reasons.slitter-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Slitter Jam
+#: locale/ipp-strings.c:3734
+msgid "printer-state-reasons.slitter-jam"
+msgstr ""
+
+#. TRANSLATORS: Slitter Life Almost Over
+#: locale/ipp-strings.c:3736
+msgid "printer-state-reasons.slitter-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Slitter Life Over
+#: locale/ipp-strings.c:3738
+msgid "printer-state-reasons.slitter-life-over"
+msgstr ""
+
+#. TRANSLATORS: Slitter Memory Exhausted
+#: locale/ipp-strings.c:3740
+msgid "printer-state-reasons.slitter-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Slitter Missing
+#: locale/ipp-strings.c:3742
+msgid "printer-state-reasons.slitter-missing"
+msgstr ""
+
+#. TRANSLATORS: Slitter Motor Failure
+#: locale/ipp-strings.c:3744
+msgid "printer-state-reasons.slitter-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Slitter Near Limit
+#: locale/ipp-strings.c:3746
+msgid "printer-state-reasons.slitter-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Slitter Offline
+#: locale/ipp-strings.c:3748
+msgid "printer-state-reasons.slitter-offline"
+msgstr ""
+
+#. TRANSLATORS: Slitter Opened
+#: locale/ipp-strings.c:3750
+msgid "printer-state-reasons.slitter-opened"
+msgstr ""
+
+#. TRANSLATORS: Slitter Over Temperature
+#: locale/ipp-strings.c:3752
+msgid "printer-state-reasons.slitter-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Slitter Power Saver
+#: locale/ipp-strings.c:3754
+msgid "printer-state-reasons.slitter-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Slitter Recoverable Failure
+#: locale/ipp-strings.c:3756
+msgid "printer-state-reasons.slitter-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Slitter Recoverable Storage
+#: locale/ipp-strings.c:3758
+msgid "printer-state-reasons.slitter-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Slitter Removed
+#: locale/ipp-strings.c:3760
+msgid "printer-state-reasons.slitter-removed"
+msgstr ""
+
+#. TRANSLATORS: Slitter Resource Added
+#: locale/ipp-strings.c:3762
+msgid "printer-state-reasons.slitter-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Slitter Resource Removed
+#: locale/ipp-strings.c:3764
+msgid "printer-state-reasons.slitter-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Slitter Thermistor Failure
+#: locale/ipp-strings.c:3766
+msgid "printer-state-reasons.slitter-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Slitter Timing Failure
+#: locale/ipp-strings.c:3768
+msgid "printer-state-reasons.slitter-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Slitter Turned Off
+#: locale/ipp-strings.c:3770
+msgid "printer-state-reasons.slitter-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Slitter Turned On
+#: locale/ipp-strings.c:3772
+msgid "printer-state-reasons.slitter-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Slitter Under Temperature
+#: locale/ipp-strings.c:3774
+msgid "printer-state-reasons.slitter-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Slitter Unrecoverable Failure
+#: locale/ipp-strings.c:3776
+msgid "printer-state-reasons.slitter-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Slitter Unrecoverable Storage Error
+#: locale/ipp-strings.c:3778
+msgid "printer-state-reasons.slitter-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Slitter Warming Up
+#: locale/ipp-strings.c:3780
+msgid "printer-state-reasons.slitter-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Spool Area Full
+#: locale/ipp-strings.c:3782
+msgid "printer-state-reasons.spool-area-full"
+msgstr ""
+
+#. TRANSLATORS: Stacker Added
+#: locale/ipp-strings.c:3784
+msgid "printer-state-reasons.stacker-added"
+msgstr ""
+
+#. TRANSLATORS: Stacker Almost Empty
+#: locale/ipp-strings.c:3786
+msgid "printer-state-reasons.stacker-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Stacker Almost Full
+#: locale/ipp-strings.c:3788
+msgid "printer-state-reasons.stacker-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Stacker At Limit
+#: locale/ipp-strings.c:3790
+msgid "printer-state-reasons.stacker-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Stacker Closed
+#: locale/ipp-strings.c:3792
+msgid "printer-state-reasons.stacker-closed"
+msgstr ""
+
+#. TRANSLATORS: Stacker Configuration Change
+#: locale/ipp-strings.c:3794
+msgid "printer-state-reasons.stacker-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Stacker Cover Closed
+#: locale/ipp-strings.c:3796
+msgid "printer-state-reasons.stacker-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Stacker Cover Open
+#: locale/ipp-strings.c:3798
+msgid "printer-state-reasons.stacker-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Stacker Empty
+#: locale/ipp-strings.c:3800
+msgid "printer-state-reasons.stacker-empty"
+msgstr ""
+
+#. TRANSLATORS: Stacker Full
+#: locale/ipp-strings.c:3802
+msgid "printer-state-reasons.stacker-full"
+msgstr ""
+
+#. TRANSLATORS: Stacker Interlock Closed
+#: locale/ipp-strings.c:3804
+msgid "printer-state-reasons.stacker-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Stacker Interlock Open
+#: locale/ipp-strings.c:3806
+msgid "printer-state-reasons.stacker-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Stacker Jam
+#: locale/ipp-strings.c:3808
+msgid "printer-state-reasons.stacker-jam"
+msgstr ""
+
+#. TRANSLATORS: Stacker Life Almost Over
+#: locale/ipp-strings.c:3810
+msgid "printer-state-reasons.stacker-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Stacker Life Over
+#: locale/ipp-strings.c:3812
+msgid "printer-state-reasons.stacker-life-over"
+msgstr ""
+
+#. TRANSLATORS: Stacker Memory Exhausted
+#: locale/ipp-strings.c:3814
+msgid "printer-state-reasons.stacker-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Stacker Missing
+#: locale/ipp-strings.c:3816
+msgid "printer-state-reasons.stacker-missing"
+msgstr ""
+
+#. TRANSLATORS: Stacker Motor Failure
+#: locale/ipp-strings.c:3818
+msgid "printer-state-reasons.stacker-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Stacker Near Limit
+#: locale/ipp-strings.c:3820
+msgid "printer-state-reasons.stacker-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Stacker Offline
+#: locale/ipp-strings.c:3822
+msgid "printer-state-reasons.stacker-offline"
+msgstr ""
+
+#. TRANSLATORS: Stacker Opened
+#: locale/ipp-strings.c:3824
+msgid "printer-state-reasons.stacker-opened"
+msgstr ""
+
+#. TRANSLATORS: Stacker Over Temperature
+#: locale/ipp-strings.c:3826
+msgid "printer-state-reasons.stacker-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Stacker Power Saver
+#: locale/ipp-strings.c:3828
+msgid "printer-state-reasons.stacker-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Stacker Recoverable Failure
+#: locale/ipp-strings.c:3830
+msgid "printer-state-reasons.stacker-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Stacker Recoverable Storage
+#: locale/ipp-strings.c:3832
+msgid "printer-state-reasons.stacker-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Stacker Removed
+#: locale/ipp-strings.c:3834
+msgid "printer-state-reasons.stacker-removed"
+msgstr ""
+
+#. TRANSLATORS: Stacker Resource Added
+#: locale/ipp-strings.c:3836
+msgid "printer-state-reasons.stacker-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Stacker Resource Removed
+#: locale/ipp-strings.c:3838
+msgid "printer-state-reasons.stacker-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Stacker Thermistor Failure
+#: locale/ipp-strings.c:3840
+msgid "printer-state-reasons.stacker-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Stacker Timing Failure
+#: locale/ipp-strings.c:3842
+msgid "printer-state-reasons.stacker-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Stacker Turned Off
+#: locale/ipp-strings.c:3844
+msgid "printer-state-reasons.stacker-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Stacker Turned On
+#: locale/ipp-strings.c:3846
+msgid "printer-state-reasons.stacker-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Stacker Under Temperature
+#: locale/ipp-strings.c:3848
+msgid "printer-state-reasons.stacker-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Stacker Unrecoverable Failure
+#: locale/ipp-strings.c:3850
+msgid "printer-state-reasons.stacker-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Stacker Unrecoverable Storage Error
+#: locale/ipp-strings.c:3852
+msgid "printer-state-reasons.stacker-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Stacker Warming Up
+#: locale/ipp-strings.c:3854
+msgid "printer-state-reasons.stacker-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Stapler Added
+#: locale/ipp-strings.c:3856
+msgid "printer-state-reasons.stapler-added"
+msgstr ""
+
+#. TRANSLATORS: Stapler Almost Empty
+#: locale/ipp-strings.c:3858
+msgid "printer-state-reasons.stapler-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Stapler Almost Full
+#: locale/ipp-strings.c:3860
+msgid "printer-state-reasons.stapler-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Stapler At Limit
+#: locale/ipp-strings.c:3862
+msgid "printer-state-reasons.stapler-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Stapler Closed
+#: locale/ipp-strings.c:3864
+msgid "printer-state-reasons.stapler-closed"
+msgstr ""
+
+#. TRANSLATORS: Stapler Configuration Change
+#: locale/ipp-strings.c:3866
+msgid "printer-state-reasons.stapler-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Stapler Cover Closed
+#: locale/ipp-strings.c:3868
+msgid "printer-state-reasons.stapler-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Stapler Cover Open
+#: locale/ipp-strings.c:3870
+msgid "printer-state-reasons.stapler-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Stapler Empty
+#: locale/ipp-strings.c:3872
+msgid "printer-state-reasons.stapler-empty"
+msgstr ""
+
+#. TRANSLATORS: Stapler Full
+#: locale/ipp-strings.c:3874
+msgid "printer-state-reasons.stapler-full"
+msgstr ""
+
+#. TRANSLATORS: Stapler Interlock Closed
+#: locale/ipp-strings.c:3876
+msgid "printer-state-reasons.stapler-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Stapler Interlock Open
+#: locale/ipp-strings.c:3878
+msgid "printer-state-reasons.stapler-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Stapler Jam
+#: locale/ipp-strings.c:3880
+msgid "printer-state-reasons.stapler-jam"
+msgstr ""
+
+#. TRANSLATORS: Stapler Life Almost Over
+#: locale/ipp-strings.c:3882
+msgid "printer-state-reasons.stapler-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Stapler Life Over
+#: locale/ipp-strings.c:3884
+msgid "printer-state-reasons.stapler-life-over"
+msgstr ""
+
+#. TRANSLATORS: Stapler Memory Exhausted
+#: locale/ipp-strings.c:3886
+msgid "printer-state-reasons.stapler-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Stapler Missing
+#: locale/ipp-strings.c:3888
+msgid "printer-state-reasons.stapler-missing"
+msgstr ""
+
+#. TRANSLATORS: Stapler Motor Failure
+#: locale/ipp-strings.c:3890
+msgid "printer-state-reasons.stapler-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Stapler Near Limit
+#: locale/ipp-strings.c:3892
+msgid "printer-state-reasons.stapler-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Stapler Offline
+#: locale/ipp-strings.c:3894
+msgid "printer-state-reasons.stapler-offline"
+msgstr ""
+
+#. TRANSLATORS: Stapler Opened
+#: locale/ipp-strings.c:3896
+msgid "printer-state-reasons.stapler-opened"
+msgstr ""
+
+#. TRANSLATORS: Stapler Over Temperature
+#: locale/ipp-strings.c:3898
+msgid "printer-state-reasons.stapler-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Stapler Power Saver
+#: locale/ipp-strings.c:3900
+msgid "printer-state-reasons.stapler-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Stapler Recoverable Failure
+#: locale/ipp-strings.c:3902
+msgid "printer-state-reasons.stapler-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Stapler Recoverable Storage
+#: locale/ipp-strings.c:3904
+msgid "printer-state-reasons.stapler-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Stapler Removed
+#: locale/ipp-strings.c:3906
+msgid "printer-state-reasons.stapler-removed"
+msgstr ""
+
+#. TRANSLATORS: Stapler Resource Added
+#: locale/ipp-strings.c:3908
+msgid "printer-state-reasons.stapler-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Stapler Resource Removed
+#: locale/ipp-strings.c:3910
+msgid "printer-state-reasons.stapler-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Stapler Thermistor Failure
+#: locale/ipp-strings.c:3912
+msgid "printer-state-reasons.stapler-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Stapler Timing Failure
+#: locale/ipp-strings.c:3914
+msgid "printer-state-reasons.stapler-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Stapler Turned Off
+#: locale/ipp-strings.c:3916
+msgid "printer-state-reasons.stapler-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Stapler Turned On
+#: locale/ipp-strings.c:3918
+msgid "printer-state-reasons.stapler-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Stapler Under Temperature
+#: locale/ipp-strings.c:3920
+msgid "printer-state-reasons.stapler-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Stapler Unrecoverable Failure
+#: locale/ipp-strings.c:3922
+msgid "printer-state-reasons.stapler-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Stapler Unrecoverable Storage Error
+#: locale/ipp-strings.c:3924
+msgid "printer-state-reasons.stapler-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Stapler Warming Up
+#: locale/ipp-strings.c:3926
+msgid "printer-state-reasons.stapler-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Added
+#: locale/ipp-strings.c:3928
+msgid "printer-state-reasons.stitcher-added"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Almost Empty
+#: locale/ipp-strings.c:3930
+msgid "printer-state-reasons.stitcher-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Almost Full
+#: locale/ipp-strings.c:3932
+msgid "printer-state-reasons.stitcher-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Stitcher At Limit
+#: locale/ipp-strings.c:3934
+msgid "printer-state-reasons.stitcher-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Closed
+#: locale/ipp-strings.c:3936
+msgid "printer-state-reasons.stitcher-closed"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Configuration Change
+#: locale/ipp-strings.c:3938
+msgid "printer-state-reasons.stitcher-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Cover Closed
+#: locale/ipp-strings.c:3940
+msgid "printer-state-reasons.stitcher-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Cover Open
+#: locale/ipp-strings.c:3942
+msgid "printer-state-reasons.stitcher-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Empty
+#: locale/ipp-strings.c:3944
+msgid "printer-state-reasons.stitcher-empty"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Full
+#: locale/ipp-strings.c:3946
+msgid "printer-state-reasons.stitcher-full"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Interlock Closed
+#: locale/ipp-strings.c:3948
+msgid "printer-state-reasons.stitcher-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Interlock Open
+#: locale/ipp-strings.c:3950
+msgid "printer-state-reasons.stitcher-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Jam
+#: locale/ipp-strings.c:3952
+msgid "printer-state-reasons.stitcher-jam"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Life Almost Over
+#: locale/ipp-strings.c:3954
+msgid "printer-state-reasons.stitcher-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Life Over
+#: locale/ipp-strings.c:3956
+msgid "printer-state-reasons.stitcher-life-over"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Memory Exhausted
+#: locale/ipp-strings.c:3958
+msgid "printer-state-reasons.stitcher-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Missing
+#: locale/ipp-strings.c:3960
+msgid "printer-state-reasons.stitcher-missing"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Motor Failure
+#: locale/ipp-strings.c:3962
+msgid "printer-state-reasons.stitcher-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Near Limit
+#: locale/ipp-strings.c:3964
+msgid "printer-state-reasons.stitcher-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Offline
+#: locale/ipp-strings.c:3966
+msgid "printer-state-reasons.stitcher-offline"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Opened
+#: locale/ipp-strings.c:3968
+msgid "printer-state-reasons.stitcher-opened"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Over Temperature
+#: locale/ipp-strings.c:3970
+msgid "printer-state-reasons.stitcher-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Power Saver
+#: locale/ipp-strings.c:3972
+msgid "printer-state-reasons.stitcher-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Recoverable Failure
+#: locale/ipp-strings.c:3974
+msgid "printer-state-reasons.stitcher-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Recoverable Storage
+#: locale/ipp-strings.c:3976
+msgid "printer-state-reasons.stitcher-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Removed
+#: locale/ipp-strings.c:3978
+msgid "printer-state-reasons.stitcher-removed"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Resource Added
+#: locale/ipp-strings.c:3980
+msgid "printer-state-reasons.stitcher-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Resource Removed
+#: locale/ipp-strings.c:3982
+msgid "printer-state-reasons.stitcher-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Thermistor Failure
+#: locale/ipp-strings.c:3984
+msgid "printer-state-reasons.stitcher-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Timing Failure
+#: locale/ipp-strings.c:3986
+msgid "printer-state-reasons.stitcher-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Turned Off
+#: locale/ipp-strings.c:3988
+msgid "printer-state-reasons.stitcher-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Turned On
+#: locale/ipp-strings.c:3990
+msgid "printer-state-reasons.stitcher-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Under Temperature
+#: locale/ipp-strings.c:3992
+msgid "printer-state-reasons.stitcher-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Unrecoverable Failure
+#: locale/ipp-strings.c:3994
+msgid "printer-state-reasons.stitcher-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Unrecoverable Storage Error
+#: locale/ipp-strings.c:3996
+msgid "printer-state-reasons.stitcher-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Stitcher Warming Up
+#: locale/ipp-strings.c:3998
+msgid "printer-state-reasons.stitcher-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Partially stopped
+#: locale/ipp-strings.c:4000
+msgid "printer-state-reasons.stopped-partly"
+msgstr ""
+
+#. TRANSLATORS: Stopping
+#: locale/ipp-strings.c:4002
+msgid "printer-state-reasons.stopping"
+msgstr ""
+
+#. TRANSLATORS: Subunit Added
+#: locale/ipp-strings.c:4004
+msgid "printer-state-reasons.subunit-added"
+msgstr ""
+
+#. TRANSLATORS: Subunit Almost Empty
+#: locale/ipp-strings.c:4006
+msgid "printer-state-reasons.subunit-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Subunit Almost Full
+#: locale/ipp-strings.c:4008
+msgid "printer-state-reasons.subunit-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Subunit At Limit
+#: locale/ipp-strings.c:4010
+msgid "printer-state-reasons.subunit-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Subunit Closed
+#: locale/ipp-strings.c:4012
+msgid "printer-state-reasons.subunit-closed"
+msgstr ""
+
+#. TRANSLATORS: Subunit Cooling Down
+#: locale/ipp-strings.c:4014
+msgid "printer-state-reasons.subunit-cooling-down"
+msgstr ""
+
+#. TRANSLATORS: Subunit Empty
+#: locale/ipp-strings.c:4016
+msgid "printer-state-reasons.subunit-empty"
+msgstr ""
+
+#. TRANSLATORS: Subunit Full
+#: locale/ipp-strings.c:4018
+msgid "printer-state-reasons.subunit-full"
+msgstr ""
+
+#. TRANSLATORS: Subunit Life Almost Over
+#: locale/ipp-strings.c:4020
+msgid "printer-state-reasons.subunit-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Subunit Life Over
+#: locale/ipp-strings.c:4022
+msgid "printer-state-reasons.subunit-life-over"
+msgstr ""
+
+#. TRANSLATORS: Subunit Memory Exhausted
+#: locale/ipp-strings.c:4024
+msgid "printer-state-reasons.subunit-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Subunit Missing
+#: locale/ipp-strings.c:4026
+msgid "printer-state-reasons.subunit-missing"
+msgstr ""
+
+#. TRANSLATORS: Subunit Motor Failure
+#: locale/ipp-strings.c:4028
+msgid "printer-state-reasons.subunit-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Subunit Near Limit
+#: locale/ipp-strings.c:4030
+msgid "printer-state-reasons.subunit-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Subunit Offline
+#: locale/ipp-strings.c:4032
+msgid "printer-state-reasons.subunit-offline"
+msgstr ""
+
+#. TRANSLATORS: Subunit Opened
+#: locale/ipp-strings.c:4034
+msgid "printer-state-reasons.subunit-opened"
+msgstr ""
+
+#. TRANSLATORS: Subunit Over Temperature
+#: locale/ipp-strings.c:4036
+msgid "printer-state-reasons.subunit-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Subunit Power Saver
+#: locale/ipp-strings.c:4038
+msgid "printer-state-reasons.subunit-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Subunit Recoverable Failure
+#: locale/ipp-strings.c:4040
+msgid "printer-state-reasons.subunit-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Subunit Recoverable Storage
+#: locale/ipp-strings.c:4042
+msgid "printer-state-reasons.subunit-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Subunit Removed
+#: locale/ipp-strings.c:4044
+msgid "printer-state-reasons.subunit-removed"
+msgstr ""
+
+#. TRANSLATORS: Subunit Resource Added
+#: locale/ipp-strings.c:4046
+msgid "printer-state-reasons.subunit-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Subunit Resource Removed
+#: locale/ipp-strings.c:4048
+msgid "printer-state-reasons.subunit-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Subunit Thermistor Failure
+#: locale/ipp-strings.c:4050
+msgid "printer-state-reasons.subunit-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Subunit Timing Failure
+#: locale/ipp-strings.c:4052
+msgid "printer-state-reasons.subunit-timing-Failure"
+msgstr ""
+
+#. TRANSLATORS: Subunit Turned Off
+#: locale/ipp-strings.c:4054
+msgid "printer-state-reasons.subunit-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Subunit Turned On
+#: locale/ipp-strings.c:4056
+msgid "printer-state-reasons.subunit-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Subunit Under Temperature
+#: locale/ipp-strings.c:4058
+msgid "printer-state-reasons.subunit-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Subunit Unrecoverable Failure
+#: locale/ipp-strings.c:4060
+msgid "printer-state-reasons.subunit-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Subunit Unrecoverable Storage
+#: locale/ipp-strings.c:4062
+msgid "printer-state-reasons.subunit-unrecoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Subunit Warming Up
+#: locale/ipp-strings.c:4064
+msgid "printer-state-reasons.subunit-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Printer stopped responding
+#: locale/ipp-strings.c:4066
+msgid "printer-state-reasons.timed-out"
+msgstr ""
+
+#. TRANSLATORS: Out of toner
+#: locale/ipp-strings.c:4068
+msgid "printer-state-reasons.toner-empty"
+msgstr ""
+
+#. TRANSLATORS: Toner low
+#: locale/ipp-strings.c:4070
+msgid "printer-state-reasons.toner-low"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Added
+#: locale/ipp-strings.c:4072
+msgid "printer-state-reasons.trimmer-added"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Almost Empty
+#: locale/ipp-strings.c:4074
+msgid "printer-state-reasons.trimmer-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Almost Full
+#: locale/ipp-strings.c:4076
+msgid "printer-state-reasons.trimmer-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Trimmer At Limit
+#: locale/ipp-strings.c:4078
+msgid "printer-state-reasons.trimmer-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Closed
+#: locale/ipp-strings.c:4080
+msgid "printer-state-reasons.trimmer-closed"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Configuration Change
+#: locale/ipp-strings.c:4082
+msgid "printer-state-reasons.trimmer-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Cover Closed
+#: locale/ipp-strings.c:4084
+msgid "printer-state-reasons.trimmer-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Cover Open
+#: locale/ipp-strings.c:4086
+msgid "printer-state-reasons.trimmer-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Empty
+#: locale/ipp-strings.c:4088
+msgid "printer-state-reasons.trimmer-empty"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Full
+#: locale/ipp-strings.c:4090
+msgid "printer-state-reasons.trimmer-full"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Interlock Closed
+#: locale/ipp-strings.c:4092
+msgid "printer-state-reasons.trimmer-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Interlock Open
+#: locale/ipp-strings.c:4094
+msgid "printer-state-reasons.trimmer-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Jam
+#: locale/ipp-strings.c:4096
+msgid "printer-state-reasons.trimmer-jam"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Life Almost Over
+#: locale/ipp-strings.c:4098
+msgid "printer-state-reasons.trimmer-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Life Over
+#: locale/ipp-strings.c:4100
+msgid "printer-state-reasons.trimmer-life-over"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Memory Exhausted
+#: locale/ipp-strings.c:4102
+msgid "printer-state-reasons.trimmer-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Missing
+#: locale/ipp-strings.c:4104
+msgid "printer-state-reasons.trimmer-missing"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Motor Failure
+#: locale/ipp-strings.c:4106
+msgid "printer-state-reasons.trimmer-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Near Limit
+#: locale/ipp-strings.c:4108
+msgid "printer-state-reasons.trimmer-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Offline
+#: locale/ipp-strings.c:4110
+msgid "printer-state-reasons.trimmer-offline"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Opened
+#: locale/ipp-strings.c:4112
+msgid "printer-state-reasons.trimmer-opened"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Over Temperature
+#: locale/ipp-strings.c:4114
+msgid "printer-state-reasons.trimmer-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Power Saver
+#: locale/ipp-strings.c:4116
+msgid "printer-state-reasons.trimmer-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Recoverable Failure
+#: locale/ipp-strings.c:4118
+msgid "printer-state-reasons.trimmer-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Recoverable Storage
+#: locale/ipp-strings.c:4120
+msgid "printer-state-reasons.trimmer-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Removed
+#: locale/ipp-strings.c:4122
+msgid "printer-state-reasons.trimmer-removed"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Resource Added
+#: locale/ipp-strings.c:4124
+msgid "printer-state-reasons.trimmer-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Resource Removed
+#: locale/ipp-strings.c:4126
+msgid "printer-state-reasons.trimmer-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Thermistor Failure
+#: locale/ipp-strings.c:4128
+msgid "printer-state-reasons.trimmer-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Timing Failure
+#: locale/ipp-strings.c:4130
+msgid "printer-state-reasons.trimmer-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Turned Off
+#: locale/ipp-strings.c:4132
+msgid "printer-state-reasons.trimmer-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Turned On
+#: locale/ipp-strings.c:4134
+msgid "printer-state-reasons.trimmer-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Under Temperature
+#: locale/ipp-strings.c:4136
+msgid "printer-state-reasons.trimmer-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Unrecoverable Failure
+#: locale/ipp-strings.c:4138
+msgid "printer-state-reasons.trimmer-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Unrecoverable Storage Error
+#: locale/ipp-strings.c:4140
+msgid "printer-state-reasons.trimmer-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Trimmer Warming Up
+#: locale/ipp-strings.c:4142
+msgid "printer-state-reasons.trimmer-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Unknown
+#: locale/ipp-strings.c:4144
+msgid "printer-state-reasons.unknown"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Added
+#: locale/ipp-strings.c:4146
+msgid "printer-state-reasons.wrapper-added"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Almost Empty
+#: locale/ipp-strings.c:4148
+msgid "printer-state-reasons.wrapper-almost-empty"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Almost Full
+#: locale/ipp-strings.c:4150
+msgid "printer-state-reasons.wrapper-almost-full"
+msgstr ""
+
+#. TRANSLATORS: Wrapper At Limit
+#: locale/ipp-strings.c:4152
+msgid "printer-state-reasons.wrapper-at-limit"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Closed
+#: locale/ipp-strings.c:4154
+msgid "printer-state-reasons.wrapper-closed"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Configuration Change
+#: locale/ipp-strings.c:4156
+msgid "printer-state-reasons.wrapper-configuration-change"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Cover Closed
+#: locale/ipp-strings.c:4158
+msgid "printer-state-reasons.wrapper-cover-closed"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Cover Open
+#: locale/ipp-strings.c:4160
+msgid "printer-state-reasons.wrapper-cover-open"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Empty
+#: locale/ipp-strings.c:4162
+msgid "printer-state-reasons.wrapper-empty"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Full
+#: locale/ipp-strings.c:4164
+msgid "printer-state-reasons.wrapper-full"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Interlock Closed
+#: locale/ipp-strings.c:4166
+msgid "printer-state-reasons.wrapper-interlock-closed"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Interlock Open
+#: locale/ipp-strings.c:4168
+msgid "printer-state-reasons.wrapper-interlock-open"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Jam
+#: locale/ipp-strings.c:4170
+msgid "printer-state-reasons.wrapper-jam"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Life Almost Over
+#: locale/ipp-strings.c:4172
+msgid "printer-state-reasons.wrapper-life-almost-over"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Life Over
+#: locale/ipp-strings.c:4174
+msgid "printer-state-reasons.wrapper-life-over"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Memory Exhausted
+#: locale/ipp-strings.c:4176
+msgid "printer-state-reasons.wrapper-memory-exhausted"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Missing
+#: locale/ipp-strings.c:4178
+msgid "printer-state-reasons.wrapper-missing"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Motor Failure
+#: locale/ipp-strings.c:4180
+msgid "printer-state-reasons.wrapper-motor-failure"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Near Limit
+#: locale/ipp-strings.c:4182
+msgid "printer-state-reasons.wrapper-near-limit"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Offline
+#: locale/ipp-strings.c:4184
+msgid "printer-state-reasons.wrapper-offline"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Opened
+#: locale/ipp-strings.c:4186
+msgid "printer-state-reasons.wrapper-opened"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Over Temperature
+#: locale/ipp-strings.c:4188
+msgid "printer-state-reasons.wrapper-over-temperature"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Power Saver
+#: locale/ipp-strings.c:4190
+msgid "printer-state-reasons.wrapper-power-saver"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Recoverable Failure
+#: locale/ipp-strings.c:4192
+msgid "printer-state-reasons.wrapper-recoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Recoverable Storage
+#: locale/ipp-strings.c:4194
+msgid "printer-state-reasons.wrapper-recoverable-storage"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Removed
+#: locale/ipp-strings.c:4196
+msgid "printer-state-reasons.wrapper-removed"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Resource Added
+#: locale/ipp-strings.c:4198
+msgid "printer-state-reasons.wrapper-resource-added"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Resource Removed
+#: locale/ipp-strings.c:4200
+msgid "printer-state-reasons.wrapper-resource-removed"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Thermistor Failure
+#: locale/ipp-strings.c:4202
+msgid "printer-state-reasons.wrapper-thermistor-failure"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Timing Failure
+#: locale/ipp-strings.c:4204
+msgid "printer-state-reasons.wrapper-timing-failure"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Turned Off
+#: locale/ipp-strings.c:4206
+msgid "printer-state-reasons.wrapper-turned-off"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Turned On
+#: locale/ipp-strings.c:4208
+msgid "printer-state-reasons.wrapper-turned-on"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Under Temperature
+#: locale/ipp-strings.c:4210
+msgid "printer-state-reasons.wrapper-under-temperature"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Unrecoverable Failure
+#: locale/ipp-strings.c:4212
+msgid "printer-state-reasons.wrapper-unrecoverable-failure"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Unrecoverable Storage Error
+#: locale/ipp-strings.c:4214
+msgid "printer-state-reasons.wrapper-unrecoverable-storage-error"
+msgstr ""
+
+#. TRANSLATORS: Wrapper Warming Up
+#: locale/ipp-strings.c:4216
+msgid "printer-state-reasons.wrapper-warming-up"
+msgstr ""
+
+#. TRANSLATORS: Idle
+#: locale/ipp-strings.c:4218
+msgid "printer-state.3"
+msgstr ""
+
+#. TRANSLATORS: Processing
+#: locale/ipp-strings.c:4220
+msgid "printer-state.4"
+msgstr ""
+
+#. TRANSLATORS: Stopped
+#: locale/ipp-strings.c:4222
+msgid "printer-state.5"
+msgstr ""
+
+#. TRANSLATORS: Printer Uptime
+#: locale/ipp-strings.c:4224
+msgid "printer-up-time"
+msgstr ""
+
+#: cups/notify.c:80 cups/notify.c:121
+msgid "processing"
+msgstr ""
+
+#. TRANSLATORS: Proof Print
+#: locale/ipp-strings.c:4226
+msgid "proof-print"
+msgstr ""
+
+#. TRANSLATORS: Proof Print Copies
+#: locale/ipp-strings.c:4228
+msgid "proof-print-copies"
+msgstr ""
+
+#. TRANSLATORS: Punching
+#: locale/ipp-strings.c:4230
+msgid "punching"
+msgstr ""
+
+#. TRANSLATORS: Punching Locations
+#: locale/ipp-strings.c:4232
+msgid "punching-locations"
+msgstr ""
+
+#. TRANSLATORS: Punching Offset
+#: locale/ipp-strings.c:4234
+msgid "punching-offset"
+msgstr ""
+
+#. TRANSLATORS: Punch Edge
+#: locale/ipp-strings.c:4236
+msgid "punching-reference-edge"
+msgstr ""
+
+#. TRANSLATORS: Bottom
+#: locale/ipp-strings.c:4238
+msgid "punching-reference-edge.bottom"
+msgstr ""
+
+#. TRANSLATORS: Left
+#: locale/ipp-strings.c:4240
+msgid "punching-reference-edge.left"
+msgstr ""
+
+#. TRANSLATORS: Right
+#: locale/ipp-strings.c:4242
+msgid "punching-reference-edge.right"
+msgstr ""
+
+#. TRANSLATORS: Top
+#: locale/ipp-strings.c:4244
+msgid "punching-reference-edge.top"
+msgstr ""
+
+#: systemv/lp.c:642
+#, c-format
+msgid "request id is %s-%d (%d file(s))"
+msgstr ""
+
+#: cups/snmp.c:974
+msgid "request-id uses indefinite length"
+msgstr ""
+
+#. TRANSLATORS: Requested Attributes
+#: locale/ipp-strings.c:4246
+msgid "requested-attributes"
+msgstr ""
+
+#. TRANSLATORS: Retry Interval
+#: locale/ipp-strings.c:4248
+msgid "retry-interval"
+msgstr ""
+
+#. TRANSLATORS: Retry Timeout
+#: locale/ipp-strings.c:4250
+msgid "retry-time-out"
+msgstr ""
+
+#. TRANSLATORS: Save Disposition
+#: locale/ipp-strings.c:4252
+msgid "save-disposition"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:4254
+msgid "save-disposition.none"
+msgstr ""
+
+#. TRANSLATORS: Print and Save
+#: locale/ipp-strings.c:4256
+msgid "save-disposition.print-save"
+msgstr ""
+
+#. TRANSLATORS: Save Only
+#: locale/ipp-strings.c:4258
+msgid "save-disposition.save-only"
+msgstr ""
+
+#. TRANSLATORS: Save Document Format
+#: locale/ipp-strings.c:4260
+msgid "save-document-format"
+msgstr ""
+
+#. TRANSLATORS: Save Info
+#: locale/ipp-strings.c:4262
+msgid "save-info"
+msgstr ""
+
+#. TRANSLATORS: Save Location
+#: locale/ipp-strings.c:4264
+msgid "save-location"
+msgstr ""
+
+#. TRANSLATORS: Save Name
+#: locale/ipp-strings.c:4266
+msgid "save-name"
+msgstr ""
+
+#: systemv/lpstat.c:2032
+msgid "scheduler is not running"
+msgstr ""
+
+#: systemv/lpstat.c:2028
+msgid "scheduler is running"
+msgstr ""
+
+#. TRANSLATORS: Separator Sheets
+#: locale/ipp-strings.c:4268
+msgid "separator-sheets"
+msgstr ""
+
+#. TRANSLATORS: Type of Separator Sheets
+#: locale/ipp-strings.c:4270
+msgid "separator-sheets-type"
+msgstr ""
+
+#. TRANSLATORS: Start and End Sheets
+#: locale/ipp-strings.c:4272
+msgid "separator-sheets-type.both-sheets"
+msgstr ""
+
+#. TRANSLATORS: End Sheet
+#: locale/ipp-strings.c:4274
+msgid "separator-sheets-type.end-sheet"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:4276
+msgid "separator-sheets-type.none"
+msgstr ""
+
+#. TRANSLATORS: Slip Sheets
+#: locale/ipp-strings.c:4278
+msgid "separator-sheets-type.slip-sheets"
+msgstr ""
+
+#. TRANSLATORS: Start Sheet
+#: locale/ipp-strings.c:4280
+msgid "separator-sheets-type.start-sheet"
+msgstr ""
+
+#. TRANSLATORS: 2-Sided Printing
+#: locale/ipp-strings.c:4282
+msgid "sides"
+msgstr ""
+
+#. TRANSLATORS: Off
+#: locale/ipp-strings.c:4284
+msgid "sides.one-sided"
+msgstr ""
+
+#. TRANSLATORS: On (Portrait)
+#: locale/ipp-strings.c:4286
+msgid "sides.two-sided-long-edge"
+msgstr ""
+
+#. TRANSLATORS: On (Landscape)
+#: locale/ipp-strings.c:4288
+msgid "sides.two-sided-short-edge"
+msgstr ""
+
+#: cups/adminutil.c:1384
+#, c-format
+msgid "stat of %s failed: %s"
+msgstr ""
+
+#: berkeley/lpc.c:197
+msgid "status\t\tShow status of daemon and queue."
+msgstr ""
+
+#. TRANSLATORS: Status Message
+#: locale/ipp-strings.c:4290
+msgid "status-message"
+msgstr ""
+
+#. TRANSLATORS: Staple
+#: locale/ipp-strings.c:4292
+msgid "stitching"
+msgstr ""
+
+#. TRANSLATORS: Stitching Angle
+#: locale/ipp-strings.c:4294
+msgid "stitching-angle"
+msgstr ""
+
+#. TRANSLATORS: Stitching Locations
+#: locale/ipp-strings.c:4296
+msgid "stitching-locations"
+msgstr ""
+
+#. TRANSLATORS: Staple Method
+#: locale/ipp-strings.c:4298
+msgid "stitching-method"
+msgstr ""
+
+#. TRANSLATORS: Automatic
+#: locale/ipp-strings.c:4300
+msgid "stitching-method.auto"
+msgstr ""
+
+#. TRANSLATORS: Crimp
+#: locale/ipp-strings.c:4302
+msgid "stitching-method.crimp"
+msgstr ""
+
+#. TRANSLATORS: Wire
+#: locale/ipp-strings.c:4304
+msgid "stitching-method.wire"
+msgstr ""
+
+#. TRANSLATORS: Stitching Offset
+#: locale/ipp-strings.c:4306
+msgid "stitching-offset"
+msgstr ""
+
+#. TRANSLATORS: Staple Edge
+#: locale/ipp-strings.c:4308
+msgid "stitching-reference-edge"
+msgstr ""
+
+#. TRANSLATORS: Bottom
+#: locale/ipp-strings.c:4310
+msgid "stitching-reference-edge.bottom"
+msgstr ""
+
+#. TRANSLATORS: Left
+#: locale/ipp-strings.c:4312
+msgid "stitching-reference-edge.left"
+msgstr ""
+
+#. TRANSLATORS: Right
+#: locale/ipp-strings.c:4314
+msgid "stitching-reference-edge.right"
+msgstr ""
+
+#. TRANSLATORS: Top
+#: locale/ipp-strings.c:4316
+msgid "stitching-reference-edge.top"
+msgstr ""
+
+#: cups/notify.c:83 cups/notify.c:124
+msgid "stopped"
+msgstr ""
+
+#. TRANSLATORS: Subject
+#: locale/ipp-strings.c:4318
+msgid "subject"
+msgstr ""
+
+#. TRANSLATORS: Subscription Privacy Attributes
+#: locale/ipp-strings.c:4320
+msgid "subscription-privacy-attributes"
+msgstr ""
+
+#. TRANSLATORS: All
+#: locale/ipp-strings.c:4322
+msgid "subscription-privacy-attributes.all"
+msgstr ""
+
+#. TRANSLATORS: Default
+#: locale/ipp-strings.c:4324
+msgid "subscription-privacy-attributes.default"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:4326
+msgid "subscription-privacy-attributes.none"
+msgstr ""
+
+#. TRANSLATORS: Subscription Description
+#: locale/ipp-strings.c:4328
+msgid "subscription-privacy-attributes.subscription-description"
+msgstr ""
+
+#. TRANSLATORS: Subscription Template
+#: locale/ipp-strings.c:4330
+msgid "subscription-privacy-attributes.subscription-template"
+msgstr ""
+
+#. TRANSLATORS: Subscription Privacy Scope
+#: locale/ipp-strings.c:4332
+msgid "subscription-privacy-scope"
+msgstr ""
+
+#. TRANSLATORS: All
+#: locale/ipp-strings.c:4334
+msgid "subscription-privacy-scope.all"
+msgstr ""
+
+#. TRANSLATORS: Default
+#: locale/ipp-strings.c:4336
+msgid "subscription-privacy-scope.default"
+msgstr ""
+
+#. TRANSLATORS: None
+#: locale/ipp-strings.c:4338
+msgid "subscription-privacy-scope.none"
+msgstr ""
+
+#. TRANSLATORS: Owner
+#: locale/ipp-strings.c:4340
+msgid "subscription-privacy-scope.owner"
+msgstr ""
+
+#: systemv/lpstat.c:1077
+#, c-format
+msgid "system default destination: %s"
+msgstr ""
+
+#: systemv/lpstat.c:1074
+#, c-format
+msgid "system default destination: %s/%s"
+msgstr ""
+
+#. TRANSLATORS: T33 Subaddress
+#: locale/ipp-strings.c:4342
+msgid "t33-subaddress"
+msgstr ""
+
+#. TRANSLATORS: To Name
+#: locale/ipp-strings.c:4344
+msgid "to-name"
+msgstr ""
+
+#. TRANSLATORS: Transmission Status
+#: locale/ipp-strings.c:4346
+msgid "transmission-status"
+msgstr ""
+
+#. TRANSLATORS: Pending
+#: locale/ipp-strings.c:4348
+msgid "transmission-status.3"
+msgstr ""
+
+#. TRANSLATORS: Pending Retry
+#: locale/ipp-strings.c:4350
+msgid "transmission-status.4"
+msgstr ""
+
+#. TRANSLATORS: Processing
+#: locale/ipp-strings.c:4352
+msgid "transmission-status.5"
+msgstr ""
+
+#. TRANSLATORS: Canceled
+#: locale/ipp-strings.c:4354
+msgid "transmission-status.7"
+msgstr ""
+
+#. TRANSLATORS: Aborted
+#: locale/ipp-strings.c:4356
+msgid "transmission-status.8"
+msgstr ""
+
+#. TRANSLATORS: Completed
+#: locale/ipp-strings.c:4358
+msgid "transmission-status.9"
+msgstr ""
+
+#. TRANSLATORS: Cut
+#: locale/ipp-strings.c:4360
+msgid "trimming"
+msgstr ""
+
+#. TRANSLATORS: Cut Position
+#: locale/ipp-strings.c:4362
+msgid "trimming-offset"
+msgstr ""
+
+#. TRANSLATORS: Cut Edge
+#: locale/ipp-strings.c:4364
+msgid "trimming-reference-edge"
+msgstr ""
+
+#. TRANSLATORS: Bottom
+#: locale/ipp-strings.c:4366
+msgid "trimming-reference-edge.bottom"
+msgstr ""
+
+#. TRANSLATORS: Left
+#: locale/ipp-strings.c:4368
+msgid "trimming-reference-edge.left"
+msgstr ""
+
+#. TRANSLATORS: Right
+#: locale/ipp-strings.c:4370
+msgid "trimming-reference-edge.right"
+msgstr ""
+
+#. TRANSLATORS: Top
+#: locale/ipp-strings.c:4372
+msgid "trimming-reference-edge.top"
+msgstr ""
+
+#. TRANSLATORS: Type of Cut
+#: locale/ipp-strings.c:4374
+msgid "trimming-type"
+msgstr ""
+
+#. TRANSLATORS: Draw Line
+#: locale/ipp-strings.c:4376
+msgid "trimming-type.draw-line"
+msgstr ""
+
+#. TRANSLATORS: Full
+#: locale/ipp-strings.c:4378
+msgid "trimming-type.full"
+msgstr ""
+
+#. TRANSLATORS: Partial
+#: locale/ipp-strings.c:4380
+msgid "trimming-type.partial"
+msgstr ""
+
+#. TRANSLATORS: Perforate
+#: locale/ipp-strings.c:4382
+msgid "trimming-type.perforate"
+msgstr ""
+
+#. TRANSLATORS: Score
+#: locale/ipp-strings.c:4384
+msgid "trimming-type.score"
+msgstr ""
+
+#. TRANSLATORS: Tab
+#: locale/ipp-strings.c:4386
+msgid "trimming-type.tab"
+msgstr ""
+
+#. TRANSLATORS: Cut After
+#: locale/ipp-strings.c:4388
+msgid "trimming-when"
+msgstr ""
+
+#. TRANSLATORS: Every Document
+#: locale/ipp-strings.c:4390
+msgid "trimming-when.after-documents"
+msgstr ""
+
+#. TRANSLATORS: Job
+#: locale/ipp-strings.c:4392
+msgid "trimming-when.after-job"
+msgstr ""
+
+#. TRANSLATORS: Every Set
+#: locale/ipp-strings.c:4394
+msgid "trimming-when.after-sets"
+msgstr ""
+
+#. TRANSLATORS: Every Page
+#: locale/ipp-strings.c:4396
+msgid "trimming-when.after-sheets"
+msgstr ""
+
+#: cups/notify.c:95 cups/notify.c:127
+msgid "unknown"
+msgstr ""
+
+#: cups/notify.c:104
+msgid "untitled"
+msgstr ""
+
+#: cups/snmp.c:999
+msgid "variable-bindings uses indefinite length"
+msgstr ""
+
+#. TRANSLATORS: X Accuracy
+#: locale/ipp-strings.c:4398
+msgid "x-accuracy"
+msgstr ""
+
+#. TRANSLATORS: X Dimension
+#: locale/ipp-strings.c:4400
+msgid "x-dimension"
+msgstr ""
+
+#. TRANSLATORS: X Offset
+#: locale/ipp-strings.c:4402
+msgid "x-offset"
+msgstr ""
+
+#. TRANSLATORS: X Origin
+#: locale/ipp-strings.c:4404
+msgid "x-origin"
+msgstr ""
+
+#. TRANSLATORS: Y Accuracy
+#: locale/ipp-strings.c:4406
+msgid "y-accuracy"
+msgstr ""
+
+#. TRANSLATORS: Y Dimension
+#: locale/ipp-strings.c:4408
+msgid "y-dimension"
+msgstr ""
+
+#. TRANSLATORS: Y Offset
+#: locale/ipp-strings.c:4410
+msgid "y-offset"
+msgstr ""
+
+#. TRANSLATORS: Y Origin
+#: locale/ipp-strings.c:4412
+msgid "y-origin"
+msgstr ""
+
+#. TRANSLATORS: Z Accuracy
+#: locale/ipp-strings.c:4414
+msgid "z-accuracy"
+msgstr ""
+
+#. TRANSLATORS: Z Dimension
+#: locale/ipp-strings.c:4416
+msgid "z-dimension"
+msgstr ""
+
+#. TRANSLATORS: Z Offset
+#: locale/ipp-strings.c:4418
+msgid "z-offset"
+msgstr ""
+
+#: tools/ippfind.c:2814
+msgid "{service_domain}        Domain name"
+msgstr ""
+
+#: tools/ippfind.c:2815
+msgid "{service_hostname}      Fully-qualified domain name"
+msgstr ""
+
+#: tools/ippfind.c:2816
+msgid "{service_name}          Service instance name"
+msgstr ""
+
+#: tools/ippfind.c:2817
+msgid "{service_port}          Port number"
+msgstr ""
+
+#: tools/ippfind.c:2818
+msgid "{service_regtype}       DNS-SD registration type"
+msgstr ""
+
+#: tools/ippfind.c:2819
+msgid "{service_scheme}        URI scheme"
+msgstr ""
+
+#: tools/ippfind.c:2820
+msgid "{service_uri}           URI"
+msgstr ""
+
+#: tools/ippfind.c:2821
+msgid "{txt_*}                 Value of TXT record key"
+msgstr ""
+
+#: tools/ippfind.c:2813
+msgid "{}                      URI"
+msgstr ""
+
+#: cups/dest.c:1864
+msgid "~/.cups/lpoptions file names default destination that does not exist."
+msgstr ""


### PR DESCRIPTION
It seems Debian currently only includes the other translated files (like templates) if this file exists.
So i create this untranslated cups.da.po file and hope Debian will include danish translation in their CUPS packages.