### PR TITLE
Pessimize PPD choice allocation

### DIFF
--- a/cups/ppd.h
+++ b/cups/ppd.h
@@ -167,6 +167,7 @@ struct ppd_option_s			/**** Options @deprecated@ ****/
   ppd_section_t	section;		/* Section for command */
   float		order;			/* Order number */
   int		num_choices;		/* Number of option choices */
+  int           choices_capacity;       /* Holdable choices without realloc */
   ppd_choice_t	*choices;		/* Option choices */
 };
 


### PR DESCRIPTION
We noticed that our Clusterfuzz instance occasionally [had trouble allocating `ppd_choice_t`s once the test cases got huge](https://bugs.chromium.org/p/chromium/issues/detail?id=992067). This change aims to address that by allocating memory a little more greedily.