### PR TITLE
treewide: Replace bzero with memset

### DIFF
--- a/backend/usb-darwin.c
+++ b/backend/usb-darwin.c
@@ -1596,7 +1596,7 @@ static CFStringRef copy_printer_interface_deviceid(printer_interface_t printer, 
 		/* This request takes the 0 based configuration index. IOKit returns a 1 based configuration index */
 		configurationIndex -= 1;
 
-		bzero(&request, sizeof(request));
+		memset(&request, 0, sizeof(request));
 
 		request.bmRequestType		= USBmakebmRequestType(kUSBIn, kUSBClass, kUSBInterface);
 		request.bRequest			= kUSBPrintClassGetDeviceID;
@@ -1638,7 +1638,7 @@ static CFStringRef copy_printer_interface_deviceid(printer_interface_t printer, 
 		IOUSBDevRequestTO		request;
 		IOUSBDeviceDescriptor	desc;
 
-		bzero(&request, sizeof(request));
+		memset(&request, 0, sizeof(request));
 
 		request.bmRequestType = USBmakebmRequestType( kUSBIn,  kUSBStandard, kUSBDevice );
 		request.bRequest = kUSBRqGetDescriptor;
@@ -1728,7 +1728,7 @@ static CFStringRef copy_printer_interface_indexed_description(printer_interface_
 	UInt8 description[256]; // Max possible descriptor length
 	IOUSBDevRequestTO	request;
 
-	bzero(description, 2);
+	memset(description, 0, 2);
 
 	request.bmRequestType = USBmakebmRequestType(kUSBIn, kUSBStandard, kUSBDevice);
 	request.bRequest = kUSBRqGetDescriptor;
@@ -1742,7 +1742,7 @@ static CFStringRef copy_printer_interface_indexed_description(printer_interface_
 	err = (*printer)->ControlRequestTO(printer, 0, &request);
 	if (err != kIOReturnSuccess && err != kIOReturnOverrun)
 	{
-		bzero(description, request.wLength);
+		memset(description, 0, request.wLength);
 
 		// Let's try again full length. Here's why:
 		//      On USB 2.0 controllers, we will not get an overrun error.  We just get a "babble" error
@@ -1775,7 +1775,7 @@ static CFStringRef copy_printer_interface_indexed_description(printer_interface_
 	request.wValue = (kUSBStringDesc << 8) | index;
 	request.wIndex = language;
 
-	bzero(description, length);
+	memset(description, 0, length);
 	request.wLength = (UInt16)length;
 	request.pData = &description;
 	request.completionTimeout = 0;

--- a/scheduler/sysman.c
+++ b/scheduler/sysman.c
@@ -425,7 +425,7 @@ sysEventThreadEntry(void)
   * Register for power state change notifications
   */
 
-  bzero(&threadData, sizeof(threadData));
+  memset(&threadData, 0, sizeof(threadData));
 
   threadData.sysevent.powerKernelPort =
       IORegisterForSystemPower(&threadData, &powerNotifierPort,
@@ -441,7 +441,7 @@ sysEventThreadEntry(void)
   * Register for system configuration change notifications
   */
 
-  bzero(&storeContext, sizeof(storeContext));
+  memset(&storeContext, 0, sizeof(storeContext));
   storeContext.info = &threadData;
 
   store = SCDynamicStoreCreate(kCFAllocatorDefault, CFSTR("cupsd"),
@@ -536,7 +536,7 @@ sysEventThreadEntry(void)
   * this later.
   */
 
-  bzero(&timerContext, sizeof(timerContext));
+  memset(&timerContext, 0, sizeof(timerContext));
   timerContext.info = &threadData;
 
   threadData.timerRef =


### PR DESCRIPTION
bzero has been deprecated by POSIX 2008. It recommends the use of memset
instead.