### PR TITLE
Fix FTBFS with recent GCC 9

### DIFF
--- a/backend/ipp.c
+++ b/backend/ipp.c
@@ -233,7 +233,6 @@ main(int  argc,				/* I - Number of command-line args */
   int		waitjob,			/* Wait for job complete? */
 		waitjob_tries = 0,	/* Number of times we've waited */
 		waitprinter;		/* Wait for printer ready? */
-  time_t	waittime;		/* Wait time for held jobs */
   _cups_monitor_t monitor;		/* Monitoring data */
   ipp_attribute_t *job_id_attr;		/* job-id attribute */
   int		job_id;			/* job-id value */
@@ -2009,7 +2008,7 @@ main(int  argc,				/* I - Number of command-line args */
 
     _cupsLangPrintFilter(stderr, "INFO", _("Waiting for job to complete."));
 
-    for (delay = _cupsNextDelay(0, &prev_delay), waittime = time(NULL) + 30; !job_canceled;)
+    for (delay = _cupsNextDelay(0, &prev_delay); !job_canceled;)
     {
      /*
       * Check for side-channel requests...

--- a/backend/lpd.c
+++ b/backend/lpd.c
@@ -1046,7 +1046,7 @@ lpd_queue(const char      *hostname,	/* I - Host to connect to */
       * Send the control file...
       */
 
-      if (lpd_command(fd, "\002%d cfA%03.3d%.15s\n", (int)strlen(control),
+      if (lpd_command(fd, "\002%d cfA%3.3d%.15s\n", (int)strlen(control),
                       (int)getpid() % 1000, localhost))
       {
 	close(fd);
@@ -1096,7 +1096,7 @@ lpd_queue(const char      *hostname,	/* I - Host to connect to */
       * Send the print file...
       */
 
-      if (lpd_command(fd, "\003" CUPS_LLFMT " dfA%03.3d%.15s\n",
+      if (lpd_command(fd, "\003" CUPS_LLFMT " dfA%3.3d%.15s\n",
                       CUPS_LLCAST filestats.st_size, (int)getpid() % 1000,
 		      localhost))
       {
@@ -1179,7 +1179,7 @@ lpd_queue(const char      *hostname,	/* I - Host to connect to */
       * Send control file...
       */
 
-      if (lpd_command(fd, "\002%d cfA%03.3d%.15s\n", (int)strlen(control),
+      if (lpd_command(fd, "\002%d cfA%3.3d%.15s\n", (int)strlen(control),
                       (int)getpid() % 1000, localhost))
       {
 	close(fd);


### PR DESCRIPTION
`master` currently doesn't build on Debian unstable; see Travis-CI log: https://travis-ci.org/OdyX/cups/jobs/620941340

First "error: variable 'waittime' set but not used [-Werror=unused-but-set-variable]"
```
Compiling ipp.c...
ipp.c: In function 'main':
ipp.c:236:10: error: variable 'waittime' set but not used [-Werror=unused-but-set-variable]
  236 |   time_t waittime;  /* Wait time for held jobs */
      |          ^~~~~~~~
```

With this fixed; then "error: '0' flag ignored with precision and '%d' gnu_printf format [-Werror=format=]"
```
Compiling lpd.c...
lpd.c: In function 'lpd_queue':
lpd.c:1049:27: error: '0' flag ignored with precision and '%d' gnu_printf format [-Werror=format=]
 1049 |       if (lpd_command(fd, "\002%d cfA%03.3d%.15s\n", (int)strlen(control),
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~
lpd.c:1099:27: error: '0' flag ignored with precision and '%d' gnu_printf format [-Werror=format=]
 1099 |       if (lpd_command(fd, "\003" CUPS_LLFMT " dfA%03.3d%.15s\n",
      |                           ^~~~~~
lpd.c:1182:27: error: '0' flag ignored with precision and '%d' gnu_printf format [-Werror=format=]
 1182 |       if (lpd_command(fd, "\002%d cfA%03.3d%.15s\n", (int)strlen(control),
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~
```