### PR TITLE
Fix permissions of ipp Backend for legacy driverless printing support

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -13,7 +13,8 @@ include ../Makedefs
 # Object files...
 #
 
-# RBACKENDS are installed mode 0700 so cupsd will run them as root...
+# RBACKENDS are installed mode 0755.
+# Cups-filters 1.26.0+ assumes 0755 for the driverless printing fallback logic.
 #
 # UBACKENDS and ULBACKENDS are installed mode 0755 so cupsd will run them as
 # an unprivileged user...
@@ -118,7 +119,7 @@ install-exec:	$(INSTALLXPC)
 	echo Installing backends in $(SERVERBIN)/backend
 	$(INSTALL_DIR) -m 755 $(SERVERBIN)/backend
 	for file in $(RBACKENDS); do \
-		$(LIBTOOL) $(INSTALL_BIN) -m 700 $$file $(SERVERBIN)/backend; \
+		$(LIBTOOL) $(INSTALL_BIN) -m 755 $$file $(SERVERBIN)/backend; \
 	done
 	for file in $(UBACKENDS); do \
 		$(INSTALL_BIN) $$file $(SERVERBIN)/backend; \


### PR DESCRIPTION
Cups-filters 1.26.0+ assumes 755 for the driverless printing fallback logic.
Ubuntu 19.10 already applies a distro specific patch to cups for this.

The issue was brought up here
https://github.com/OpenPrinting/cups-filters/issues/163.