### PR TITLE
Ignore HTTP-date values with invalid year field

### DIFF
--- a/cups/http-support.c
+++ b/cups/http-support.c
@@ -841,6 +841,12 @@ httpGetDateTime(const char *s)		/* I - Date/time string */
                 "min=%d, sec=%d", day, mon, year, hour, min, sec));
 
  /*
+  * Check for invalid year (RFC 7231 says it's 4DIGIT)
+  */
+  if (year > 9999)
+    return (0);
+
+ /*
   * Convert the month name to a number from 0 to 11.
   */
 


### PR DESCRIPTION
Some clients request PPD files with a random value (e.g.., 25 Nov 4461684 22:08:41) in the `If-Modified-Since` header (see Issue #5511).
Ignore this by rejecting invalid (RFC 7231 says the year field is `4DIGIT`) years in `httpGetDateTime()`.