### PR TITLE
fix wide roll printing: In rastertopwg.c, don't core dump if map.pwg is NULL

### DIFF
--- a/filter/rastertopwg.c
+++ b/filter/rastertopwg.c
@@ -260,7 +260,8 @@ main(int  argc,				/* I - Number of command-line args */
     }
 
     if (inheader.cupsPageSizeName[0] &&
-        (pwg_size = _ppdCacheGetSize(cache, inheader.cupsPageSizeName)) != NULL)
+        (pwg_size = _ppdCacheGetSize(cache, inheader.cupsPageSizeName)) != NULL &&
+        pwg_size->map.pwg)
     {
       strlcpy(outheader.cupsPageSizeName, pwg_size->map.pwg,
 	      sizeof(outheader.cupsPageSizeName));


### PR DESCRIPTION
I don't have any understanding of the big picture, but after I recently updated my ubuntu system, I could no longer print to my HP T120 wide format roll printer.  I tracked it down to a core dump from rastertopwg caused by an attempt to reference pwg_size->map.pwg when it was NULL.  With this change in place, I can print to my T120 again.