### PR TITLE
HP Laserjet 1010 delay required

### DIFF
--- a/backend/org.cups.usb-quirks
+++ b/backend/org.cups.usb-quirks
@@ -242,6 +242,9 @@
 # All Intermec devices (Issue #4553)
 0x067e no-reattach
 
+# HP LaserJet 1010
+0x03f0 0x0c17 delay-close
+
 # HP LaserJet 1015 (Issue #5617)
 0x03f0 0x0e17 delay-close
 


### PR DESCRIPTION
HP Laserjet suffers the same problem as the 1150 and 1015. The last page isn't printed until the job times out.