### PR TITLE
Fix for #5805 -  number of copies

### DIFF
--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -3228,7 +3228,7 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
         cupsFilePuts(fp, "*cupsFilter2: \"application/vnd.cups-pdf application/pdf 10 -\"\n");
     }
     else
-      cupsFilePuts(fp, "*cupsManualCopies: true\n");
+      cupsFilePuts(fp, "*cupsManualCopies: True\n");
     if (is_apple)
       cupsFilePuts(fp, "*cupsFilter2: \"image/urf image/urf 100 -\"\n");
     if (is_pwg)


### PR DESCRIPTION
With that fix, the ppd file that is created by installing a ippeverywhere printer contains correctly "True" and the number of copies is correctly printed. Without that fix, that bool value in the ppd is "true" and as a result the number of copies is ignored and it always prints a single copy.