### PR TITLE
Fix infinite loop waiting for usb printer to be available

### DIFF
--- a/backend/usb-libusb.c
+++ b/backend/usb-libusb.c
@@ -32,7 +32,7 @@
 #define WAIT_EOF_DELAY			7
 #define WAIT_SIDE_DELAY			3
 #define DEFAULT_TIMEOUT			5000L
-
+#define FIND_TRIES      6
 
 /*
  * Local types...
@@ -214,11 +214,15 @@ print_device(const char *uri,		/* I - Device URI */
   */
 
   fprintf(stderr, "DEBUG: Printing on printer with URI: %s\n", uri);
-  while ((g.printer = find_device(print_cb, uri)) == NULL)
+  for (int find_attempt = 0; ((g.printer = find_device(print_cb, uri)) == NULL) && (find_attempt < FIND_TRIES); ++find_attempt)
   {
-    _cupsLangPrintFilter(stderr, "INFO",
-			 _("Waiting for printer to become available."));
+    _cupsLangPrintFilter(stderr, "INFO", _("Waiting for printer to become available."));
     sleep(5);
+  }
+
+  if (g.printer == NULL) {
+    _cupsLangPrintFilter(stderr, "ERROR", _("Printer is not available."));
+    return (CUPS_BACKEND_FAILED);
   }
 
   g.print_fd = print_fd;


### PR DESCRIPTION
Waiting forever for the USB device to be available is not a reliable solution. Sometimes it is not possible to impose a policy of maximum waiting time for the job to be completed in the scheduler, without knowing if the process is actually being carried out correctly or not. Because of this, a maximum number of tries is introduced to make sure the backend process ends in a failure condition if the USB device is connected.

This solves #5817