### PR TITLE
Add USB quirk rule for Citizen CT-S4000 printer

### DIFF
--- a/backend/org.cups.usb-quirks
+++ b/backend/org.cups.usb-quirks
@@ -302,3 +302,6 @@
 
 # Dymo 450 Turbo (Issue #5521)
 0x0922 0x0021 unidir
+
+# Citizen CT-S4000
+0x2730 0x2008 unidir delay-close


### PR DESCRIPTION
- Fix 8 seconds pause between print jobs.
- Fix (sometimes) fail to cut the receipt at the end.