### PR TITLE
backend/Makefile: Don't use libtool.

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -118,7 +118,7 @@ install-exec:	$(INSTALLXPC)
 	echo Installing backends in $(SERVERBIN)/backend
 	$(INSTALL_DIR) -m 755 $(SERVERBIN)/backend
 	for file in $(RBACKENDS); do \
-		$(LIBTOOL) $(INSTALL_BIN) -m 700 $$file $(SERVERBIN)/backend; \
+		$(INSTALL_BIN) -m 700 $$file $(SERVERBIN)/backend; \
 	done
 	for file in $(UBACKENDS); do \
 		$(INSTALL_BIN) $$file $(SERVERBIN)/backend; \
@@ -142,7 +142,7 @@ install-exec:	$(INSTALLXPC)
 install-xpc:	ipp
 	echo Installing XPC backends in $(SERVERBIN)/apple
 	$(INSTALL_DIR) -m 755 $(SERVERBIN)/apple
-	$(LIBTOOL) $(INSTALL_BIN) ipp $(SERVERBIN)/apple
+	$(INSTALL_BIN) ipp $(SERVERBIN)/apple
 	for file in $(IPPALIASES); do \
 		$(RM) $(SERVERBIN)/apple/$$file; \
 		$(LN) ipp $(SERVERBIN)/apple/$$file; \


### PR DESCRIPTION
This is not needed and causes problems with more strict implementations of libtool.

With slibtool it fails.
```
Installing backends in /tmp/package-cups/usr/lib64/cups/backend
rdlibtool: error: --mode must be specified.
rdlibtool: error: --mode must be specified.
make[1]: *** [Makefile:120: install-exec] Error 2
make: *** [Makefile:198: install-exec] Error 1
```
https://git.foss21.org/slibtool