### PR TITLE
Build ippfind in dnssd case, not just avahi and darwin cases.

### DIFF
--- a/config-scripts/cups-dnssd.m4
+++ b/config-scripts/cups-dnssd.m4
@@ -60,9 +60,9 @@ if test "x$DNSSD_BACKEND" = x -a x$enable_dnssd != xno; then
 					AC_MSG_RESULT(yes)
 					AC_DEFINE(HAVE_DNSSD)
 					DNSSDLIBS="-ldns_sd"
-					DNSSD_BACKEND="dnssd",
+					DNSSD_BACKEND="dnssd"
 					IPPFIND_BIN="ippfind"
-					IPPFIND_MAN="ippfind.1"
+					IPPFIND_MAN="ippfind.1",
 					AC_MSG_RESULT(no))
 				LIBS="$SAVELIBS"
 				;;


### PR DESCRIPTION
This seems to be the intention of cups commit 766a822, but a comma
got in the way.