### PR TITLE
Add the Canon PIXMA MP240 to the USB quirk list

### DIFF
--- a/backend/org.cups.usb-quirks
+++ b/backend/org.cups.usb-quirks
@@ -77,6 +77,9 @@
 # Canon, Inc. MP210 (https://bugzilla.redhat.com/show_bug.cgi?id=847923#c53)
 0x04a9 0x1721 unidir
 
+# Canon, Inc. MP240 Printer (https://github.com/agalakhov/captdriver/issues/7#issuecomment-890380405)
+0x04a9 0x1732 unidir
+
 # Canon, Inc. MP500 Printer (https://bugs.launchpad.net/bugs/1032456)
 0x04a9 0x170c unidir
 


### PR DESCRIPTION
Without it the printer gets stuck waiting for some kind of USB response from the computer 3/4 into the page. Right at the end of the job. Sometimes it moves the printing head once every few minutes, if we wait for 20-30 minutes it often finishes correctly. Which is unacceptable.

Using `no-reattach unidir` instead of only `unidir` seems to also work fine, but it seemed superfluous in my case, so try that if things are still wonky. Disconnecting the USB cable makes it stop the job instantly, spitting the rest of the page.

The same setup works on Windows just fine. Maybe adding the other MP2XX models into the list should be considered. In my case, until a few months ago printing via CUPS without any kinds of quirks seemed to work fine, so it seems like some kind of regression.

The credit goes to @mounaiban for the original solution:
https://github.com/agalakhov/captdriver/issues/7#issuecomment-602004919

More information here:
https://github.com/agalakhov/captdriver/issues/7#issuecomment-890380405