### PR TITLE
Fix path to libcupsimage.so.2 in EPM packaging

### DIFF
--- a/packaging/cups.list.in
+++ b/packaging/cups.list.in
@@ -346,12 +346,12 @@ l 0755 root sys /usr/bsd/lprm $BINDIR/lprm
 %system darwin
 f 0555 root sys $LIBDIR/libcups.2.dylib cups/libcups.2.dylib nostrip()
 l 0755 root sys $LIBDIR/libcups.dylib libcups.2.dylib
-f 0555 root sys $LIBDIR/libcupsimage.2.dylib filter/libcupsimage.2.dylib nostrip()
+f 0555 root sys $LIBDIR/libcupsimage.2.dylib cups/libcupsimage.2.dylib nostrip()
 l 0755 root sys $LIBDIR/libcupsimage.dylib libcupsimage.2.dylib
 %system !darwin
 f 0555 root sys $LIBDIR/libcups.so.2 cups/libcups.so.2 nostrip()
 l 0755 root sys $LIBDIR/libcups.so libcups.so.2
-f 0555 root sys $LIBDIR/libcupsimage.so.2 filter/libcupsimage.so.2 nostrip()
+f 0555 root sys $LIBDIR/libcupsimage.so.2 cups/libcupsimage.so.2 nostrip()
 l 0755 root sys $LIBDIR/libcupsimage.so libcupsimage.so.2
 %system all
 %subpackage


### PR DESCRIPTION
Cherry picked from OpenPrinting CUPS