### PR TITLE
Do not check for verbose when outputting critical error

### DIFF
--- a/scheduler/cups-driverd.cxx
+++ b/scheduler/cups-driverd.cxx
@@ -2621,8 +2621,7 @@ load_ppds_dat(char   *filename,		/* I - Filename buffer */
       {
 	if ((ppd = (ppd_info_t *)calloc(1, sizeof(ppd_info_t))) == NULL)
 	{
-	  if (verbose)
-	    fputs("ERROR: [cups-driverd] Unable to allocate memory for PPD!\n",
+	  fputs("ERROR: [cups-driverd] Unable to allocate memory for PPD!\n",
 		  stderr);
 	  exit(1);
 	}


### PR DESCRIPTION
This isn't really a cleanup. This is the only case where an allocation error does not get printed UNLESS it is verbose, which doesn't align with the other behavior. Let's output this error whenever we get an allocation error regardless of verbosity.