### PR TITLE
Do not check for ppd, since that is done at the start

### DIFF
--- a/ppdc/ppdc-import.cxx
+++ b/ppdc/ppdc-import.cxx
@@ -323,8 +323,7 @@ ppdcSource::import_ppd(const char *f)	// I - Filename
     }
   }
 
-  if (ppd)
-    ppdClose(ppd);
+  ppdClose(ppd);
 
   return (1);
 }


### PR DESCRIPTION
The entire point of the function is to open a file to import it, and then close it.

The function will not run if ppd is NULL and it shouldn't be set to NULL at all. It is best for the function to remove that one check only.

If you consider this a "cleanup", please make this the one exception, as I won't be making this type of change anymore.