### PR TITLE
Fix various typos

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -16,7 +16,7 @@ to thank the following individuals for their contributions:
                                      fixes.
     Bjoern Jacke                   - I18N stuff.
     Wang Jian                      - CUPS RPM corrections.
-    Roderick Johnstone             - Beta tester of the millenium.
+    Roderick Johnstone             - Beta tester of the millennium.
     Till Kamppeter                 - Bug fixes, beta testing, evangelism.
     Tomohiro Kato                  - Japanese localization.
     Kiko                           - Bug fixes.

--- a/backend/ipp.c
+++ b/backend/ipp.c
@@ -3285,7 +3285,7 @@ run_as_user(char       *argv[],		/* I - Command-line arguments */
 				         fprintf(stderr, "DEBUG: Connection invalid for service %s.\n",
 					         xpc_connection_get_name(conn));
 				       else
-				         fprintf(stderr, "DEBUG: Unxpected error for service %s: %s\n",
+				         fprintf(stderr, "DEBUG: Unexpected error for service %s: %s\n",
 					         xpc_connection_get_name(conn),
 						 xpc_dictionary_get_string(event, XPC_ERROR_KEY_DESCRIPTION));
 				     }

--- a/backend/lpd.c
+++ b/backend/lpd.c
@@ -61,7 +61,7 @@ static int	abort_job = 0;		/* Non-zero if we get SIGTERM */
  * What to reserve...
  */
 
-#define RESERVE_NONE		0	/* Don't reserve a priviledged port */
+#define RESERVE_NONE		0	/* Don't reserve a privileged port */
 #define RESERVE_RFC1179		1	/* Reserve port 721-731 */
 #define RESERVE_ANY		2	/* Reserve port 1-1023 */
 
@@ -114,7 +114,7 @@ main(int  argc,				/* I - Number of command-line arguments (6 or 7) */
   int		banner;			/* Print banner page? */
   int		format;			/* Print format */
   int		order;			/* Order of control/data files */
-  int		reserve;		/* Reserve priviledged port? */
+  int		reserve;		/* Reserve privileged port? */
   int		sanitize_title;		/* Sanitize title string? */
   int		manual_copies,		/* Do manual copies? */
 		timeout,		/* Timeout */
@@ -768,7 +768,7 @@ lpd_queue(const char      *hostname,	/* I - Host to connect to */
         return (CUPS_BACKEND_FAILED);
 
      /*
-      * Choose the next priviledged port...
+      * Choose the next privileged port...
       */
 
       if (!addr)
@@ -805,7 +805,7 @@ lpd_queue(const char      *hostname,	/* I - Host to connect to */
       {
        /*
 	* We're running as root and want to comply with RFC 1179.  Reserve a
-	* priviledged lport between 721 and 731...
+	* privileged lport between 721 and 731...
 	*/
 
 	if ((fd = cups_rresvport(&lport, addr->addr.addr.sa_family)) < 0)

--- a/backend/testbackend.c
+++ b/backend/testbackend.c
@@ -503,7 +503,7 @@ main(int  argc,				/* I - Number of command-line args */
   if (do_side_tests)
   {
     int			length;		/* Length of buffer */
-    char		buffer[2049];	/* Buffer for reponse */
+    char		buffer[2049];	/* Buffer for response */
     cups_sc_status_t	scstatus;	/* Status of side-channel command */
     static const char * const statuses[] =
     {

--- a/backend/usb-darwin.c
+++ b/backend/usb-darwin.c
@@ -955,7 +955,7 @@ static void *read_thread(void *reference)
       fputs("DEBUG: Got USB return aborted during read\n", stderr);
 
    /*
-    * Make sure this loop executes no more than once every 250 miliseconds...
+    * Make sure this loop executes no more than once every 250 milliseconds...
     */
 
     if ((readstatus != kIOReturnSuccess || rbytes == 0) && (g.wait_eof || !g.read_thread_stop))
@@ -978,7 +978,7 @@ static void *read_thread(void *reference)
          if (readstatus == kIOReturnSuccess && rbytes > 0 && readbuffer[rbytes-1] == 0x4)
            break;
 
-         /* Make sure this loop executes no more than once every 250 miliseconds... */
+         /* Make sure this loop executes no more than once every 250 milliseconds... */
          mach_wait_until(start + delay);
        }
      }
@@ -2347,7 +2347,7 @@ static void parse_pserror(char *sockBuffer,
 
       if ((logstrlen = snprintf(logstr, sizeof(logstr), "%s: %s\n", logLevel, pCommentBegin)) >= sizeof(logstr))
       {
-	/* If the string was trucnated make sure it has a linefeed before the nul */
+	/* If the string was truncated make sure it has a linefeed before the nul */
 	logstrlen = sizeof(logstr) - 1;
 	logstr[logstrlen - 1] = '\n';
       }

--- a/backend/usb-libusb.c
+++ b/backend/usb-libusb.c
@@ -1739,7 +1739,7 @@ static void *read_thread(void *reference)
       fputs("DEBUG: Got USB return aborted during read.\n", stderr);
 
    /*
-    * Make sure this loop executes no more than once every 250 miliseconds...
+    * Make sure this loop executes no more than once every 250 milliseconds...
     */
 
     if ((g.wait_eof || !g.read_thread_stop))

--- a/cgi-bin/template.c
+++ b/cgi-bin/template.c
@@ -432,7 +432,7 @@ cgi_copy(FILE *out,			/* I - Output file */
       if (ch == '?')
       {
        /*
-        * Test for existance...
+        * Test for existence...
 	*/
 
         if (name[0] == '?')

--- a/cups/array.c
+++ b/cups/array.c
@@ -1098,7 +1098,7 @@ cups_array_add(cups_array_t *a,		/* I - Array */
     else if (!diff)
     {
      /*
-      * Compared equal, make sure we add to the begining or end of
+      * Compared equal, make sure we add to the beginning or end of
       * the current run of equal elements...
       */
 
@@ -1240,7 +1240,7 @@ cups_array_find(cups_array_t *a,	/* I - Array */
       else
       {
        /*
-        * Start wih previous on left side...
+        * Start with previous on left side...
 	*/
 
         left  = prev;

--- a/cups/dest-localization.c
+++ b/cups/dest-localization.c
@@ -324,7 +324,7 @@ cupsLocalizeDestValue(
 static void
 cups_create_localizations(
     http_t       *http,			/* I - Connection to destination */
-    cups_dinfo_t *dinfo)		/* I - Destination informations */
+    cups_dinfo_t *dinfo)		/* I - Destination information */
 {
   http_t		*http2;		/* Connection for strings file */
   http_status_t		status;		/* Request status */

--- a/cups/dest.c
+++ b/cups/dest.c
@@ -3965,7 +3965,7 @@ cups_find_dest(const char  *name,	/* I - Destination name */
     else
     {
      /*
-      * Start wih previous on left side...
+      * Start with previous on left side...
       */
 
       left  = prev;

--- a/cups/ipp.c
+++ b/cups/ipp.c
@@ -1929,7 +1929,7 @@ ippFindNextAttribute(ipp_t      *ipp,	/* I - IPP message */
                      const char *name,	/* I - Name of attribute */
 		     ipp_tag_t  type)	/* I - Type of attribute */
 {
-  ipp_attribute_t	*attr,		/* Current atttribute */
+  ipp_attribute_t	*attr,		/* Current attribute */
 			*childattr;	/* Child attribute */
   ipp_tag_t		value_tag;	/* Value tag */
   char			parent[1024],	/* Parent attribute name */

--- a/cups/options.c
+++ b/cups/options.c
@@ -684,7 +684,7 @@ cups_find_option(
     else
     {
      /*
-      * Start wih previous on left side...
+      * Start with previous on left side...
       */
 
       left  = prev;

--- a/cups/ppd.c
+++ b/cups/ppd.c
@@ -3379,7 +3379,7 @@ ppd_read(cups_file_t    *fp,		/* I - File to read from */
     if (*lineptr == ':')
     {
      /*
-      * Get string after triming leading and trailing whitespace...
+      * Get string after trimming leading and trailing whitespace...
       */
 
       lineptr ++;

--- a/cups/raster-interpret.c
+++ b/cups/raster-interpret.c
@@ -54,7 +54,7 @@ typedef struct
     char	name[64];		/* Name value */
     double	number;			/* Number value */
     char	other[64];		/* Other operator */
-    char	string[64];		/* Sring value */
+    char	string[64];		/* String value */
   }			value;		/* Value */
 } _cups_ps_obj_t;
 
@@ -129,7 +129,7 @@ _cupsRasterInterpretPPD(
     cups_option_t       *options,	/* I - Options */
     cups_interpret_cb_t func)		/* I - Optional page header callback (@code NULL@ for none) */
 {
-  int		status;			/* Cummulative status */
+  int		status;			/* Cumulative status */
   char		*code;			/* Code to run */
   const char	*val;			/* Option value */
   ppd_size_t	*size;			/* Current size */

--- a/cups/raster.h
+++ b/cups/raster.h
@@ -335,7 +335,7 @@ typedef struct cups_page_header2_s	/**** Version 2 page header @since CUPS 1.2/m
   unsigned	cupsRowStep;		/* Spacing between lines */
 
   /**** Version 2 Dictionary Values ****/
-  unsigned	cupsNumColors;		/* Number of color compoents @since CUPS 1.2/macOS 10.5@ */
+  unsigned	cupsNumColors;		/* Number of color components @since CUPS 1.2/macOS 10.5@ */
   float		cupsBorderlessScalingFactor;
 					/* Scaling that was applied to page data @since CUPS 1.2/macOS 10.5@ */
   float		cupsPageSize[2];	/* Floating point PageSize (scaling *

--- a/cups/tls-sspi.c
+++ b/cups/tls-sspi.c
@@ -1755,7 +1755,7 @@ http_sspi_find_credentials(
   }
 
  /*
-  * Set supported protocols (can also be overriden in the registry...)
+  * Set supported protocols (can also be overridden in the registry...)
   */
 
 #ifdef SP_PROT_TLS1_2_SERVER

--- a/cups/versioning.h
+++ b/cups/versioning.h
@@ -71,7 +71,7 @@
 
 
 /*
- * Define _CUPS_INTERNAL, _CUPS_PRIVATE, and _CUPS_PUBLIC visibilty macros for
+ * Define _CUPS_INTERNAL, _CUPS_PRIVATE, and _CUPS_PUBLIC visibility macros for
  * internal/private/public functions...
  */
 

--- a/doc/help/api-raster.html
+++ b/doc/help/api-raster.html
@@ -1115,7 +1115,7 @@ bottom, right, top) </td></tr>
 <tr><th>cupsMediaType </th>
         <td class="description">Media type code</td></tr>
 <tr><th>cupsNumColors <span class="info">&#160;CUPS 1.2/macOS 10.5&#160;</span></th>
-        <td class="description">Number of color compoents </td></tr>
+        <td class="description">Number of color components </td></tr>
 <tr><th>cupsPageSizeName[64] <span class="info">&#160;CUPS 1.2/macOS 10.5&#160;</span></th>
         <td class="description">PageSize name </td></tr>
 <tr><th>cupsPageSize[2] <span class="info">&#160;CUPS 1.2/macOS 10.5&#160;</span></th>

--- a/doc/help/spec-ipp.html
+++ b/doc/help/spec-ipp.html
@@ -1497,7 +1497,7 @@ CUPS-Get-PPDs Response:
 
 <h4><a name="auth-info">auth-info (1setOf text(MAX))</a><span class="info">CUPS 1.3/macOS 10.5</span></h4>
 
-<p>The "auth-info" attribute specifies the authentication information to use when printing to a remote device. The order and content of each text value is specifed by the <a href="#auth-info-required">auth-info-required</a> printer attribute.
+<p>The "auth-info" attribute specifies the authentication information to use when printing to a remote device. The order and content of each text value is specified by the <a href="#auth-info-required">auth-info-required</a> printer attribute.
 
 <h4><a name="job-cancel-after">job-cancel-after (integer(1:MAX))</a><span class='info'>CUPS 2.0</span></h4>
 

--- a/filter/common.c
+++ b/filter/common.c
@@ -206,7 +206,7 @@ UpdatePageVars(void)
 
   switch (Orientation & 3)
   {
-    case 0 : /* Portait */
+    case 0 : /* Portrait */
         break;
 
     case 1 : /* Landscape */

--- a/ppdc/ppdc-constraint.cxx
+++ b/ppdc/ppdc-constraint.cxx
@@ -1,5 +1,5 @@
 //
-// Contraint class for the CUPS PPD Compiler.
+// Constraint class for the CUPS PPD Compiler.
 //
 // Copyright 2007-2009 by Apple Inc.
 // Copyright 2002-2005 by Easy Software Products.

--- a/ppdc/ppdc-source.cxx
+++ b/ppdc/ppdc-source.cxx
@@ -3480,7 +3480,7 @@ ppdcSource::write_file(const char *f)	// I - File to write
                    d->model_name->value);
     cupsFilePuts(fp, "{\n");
 
-    // Write the copyright stings...
+    // Write the copyright strings...
     for (st = (ppdcString *)d->copyright->first();
          st;
 	 st = (ppdcString *)d->copyright->next())

--- a/ppdc/ppdc.h
+++ b/ppdc/ppdc.h
@@ -467,7 +467,7 @@ class ppdcSource			//// Source File
 		*po_files,		// Message catalogs
 		*sizes,			// Predefined media sizes
 		*vars;			// Defined variables
-  int		cond_state,		// Cummulative conditional state
+  int		cond_state,		// Cumulative conditional state
 		*cond_current,		// Current #if state
 		cond_stack[101];	// #if state stack
 

--- a/scheduler/env.c
+++ b/scheduler/env.c
@@ -100,7 +100,7 @@ void
 cupsdSetEnv(const char *name,		/* I - Name of variable */
             const char *value)		/* I - Value of variable */
 {
-  int	i;				/* Index into environent array */
+  int	i;				/* Index into environment array */
 
 
  /*

--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -10080,7 +10080,7 @@ send_ipp_status(cupsd_client_t *con,	/* I - Client connection */
 	        ...)			/* I - Additional args as needed */
 {
   va_list	ap;			/* Pointer to additional args */
-  char		formatted[1024];	/* Formatted errror message */
+  char		formatted[1024];	/* Formatted error message */
 
 
   va_start(ap, message);

--- a/scheduler/listen.c
+++ b/scheduler/listen.c
@@ -120,7 +120,7 @@ cupsdStartListening(void)
 {
   int			p;		/* Port number */
   cupsd_listener_t	*lis;		/* Current listening socket */
-  char			s[256];		/* String addresss */
+  char			s[256];		/* String address */
   const char		*have_domain;	/* Have a domain socket? */
   static const char * const encryptions[] =
 		{			/* Encryption values */

--- a/scheduler/main.c
+++ b/scheduler/main.c
@@ -1847,7 +1847,7 @@ service_add_listener(int fd,		/* I - Socket file descriptor */
   cupsd_listener_t	*lis;		/* Listeners array */
   http_addr_t		addr;		/* Address variable */
   socklen_t		addrlen;	/* Length of address */
-  char			s[256];		/* String addresss */
+  char			s[256];		/* String address */
 
 
   addrlen = sizeof(addr);

--- a/scheduler/sysman.c
+++ b/scheduler/sysman.c
@@ -258,9 +258,9 @@ static CFStringRef	ComputerNameKey = NULL,
 			HostNamesKey = NULL,
 					/* Host name key */
 			NetworkInterfaceKeyIPv4 = NULL,
-					/* Netowrk interface key */
+					/* Network interface key */
 			NetworkInterfaceKeyIPv6 = NULL;
-					/* Netowrk interface key */
+					/* Network interface key */
 static cupsd_sysevent_t	LastSysEvent;	/* Last system event (for delayed sleep) */
 static int		NameChanged = 0;/* Did we get a 'name changed' event during sleep? */
 static int		PSToken = 0;	/* Power source notifications */

--- a/systemv/cupstestppd.c
+++ b/systemv/cupstestppd.c
@@ -3241,7 +3241,7 @@ check_sizes(ppd_file_t *ppd,		/* I - PPD file */
 
    /*
     * Verify that the size name is Adobe standard name if it's a standard size
-    * and the dimentional name if it's not a standard size.  Suffix should be
+    * and the dimensional name if it's not a standard size.  Suffix should be
     * .Fullbleed, etc., or numeric, e.g., Letter, Letter.Fullbleed,
     * Letter.Transverse, Letter1, Letter2, 4x8, 55x91mm, 55x91mm.Fullbleed, etc.
     */

--- a/tools/ippeveprinter.c
+++ b/tools/ippeveprinter.c
@@ -5844,7 +5844,7 @@ process_client(ippeve_client_t *client)	/* I - Client */
   }
 
  /*
-  * Close the conection to the client and return...
+  * Close the connection to the client and return...
   */
 
   delete_client(client);
@@ -7613,7 +7613,7 @@ respond_ipp(ippeve_client_t *client,	/* I - Client */
 static void
 respond_unsupported(
     ippeve_client_t   *client,		/* I - Client */
-    ipp_attribute_t *attr)		/* I - Atribute */
+    ipp_attribute_t *attr)		/* I - Attribute */
 {
   ipp_attribute_t	*temp;		/* Copy of attribute */
 

--- a/tools/ippeveps.c
+++ b/tools/ippeveps.c
@@ -297,7 +297,7 @@ dsc_header(int num_pages)		/* I - Number of pages or 0 if not known */
  */
 
 static void
-dsc_page(int page)			/* I - Page numebr (1-based) */
+dsc_page(int page)			/* I - Page number (1-based) */
 {
   printf("%%%%Page: (%d) %d\n", page, page);
 
@@ -541,7 +541,7 @@ jpeg_to_ps(const char    *filename,	/* I - Filename */
   float		page_left,		/* Left margin */
 		page_top,		/* Top margin */
 		page_width,		/* Page width in points */
-		page_height,		/* Page heigth in points */
+		page_height,		/* Page height in points */
 		x_factor,		/* X image scaling factor */
 		y_factor,		/* Y image scaling factor */
 		page_scaling;		/* Image scaling factor */

--- a/vcnet/dns_sd.h
+++ b/vcnet/dns_sd.h
@@ -1055,7 +1055,7 @@ DNSServiceErrorType DNSSD_API DNSServiceRegister
  *
  * sdRef:           A DNSServiceRef initialized by DNSServiceRegister().
  *
- * RecordRef:       A pointer to an uninitialized DNSRecordRef. Upon succesfull completion of this
+ * RecordRef:       A pointer to an uninitialized DNSRecordRef. Upon successful completion of this
  *                  call, this ref may be passed to DNSServiceUpdateRecord() or DNSServiceRemoveRecord().
  *                  If the above DNSServiceRef is passed to DNSServiceRefDeallocate(), RecordRef is also
  *                  invalidated and may not be used further.
@@ -1684,7 +1684,7 @@ DNSServiceErrorType DNSSD_API DNSServiceCreateConnection(DNSServiceRef *sdRef);
  *
  * sdRef:           A DNSServiceRef initialized by DNSServiceCreateConnection().
  *
- * RecordRef:       A pointer to an uninitialized DNSRecordRef. Upon succesfull completion of this
+ * RecordRef:       A pointer to an uninitialized DNSRecordRef. Upon successful completion of this
  *                  call, this ref may be passed to DNSServiceUpdateRecord() or DNSServiceRemoveRecord().
  *                  (To deregister ALL records registered on a single connected DNSServiceRef
  *                  and deallocate each of their corresponding DNSServiceRecordRefs, call
@@ -2419,7 +2419,7 @@ DNSServiceErrorType DNSSD_API DNSServiceSetDispatchQueue
  * and report errors at compile-time if anything is wrong. The usual way to do this would
  * be to use a run-time "if" statement or the conventional run-time "assert" mechanism, but
  * then you don't find out what's wrong until you run the software. This way, if the assertion
- * condition is false, the array size is negative, and the complier complains immediately.
+ * condition is false, the array size is negative, and the compiler complains immediately.
  */
 
 struct CompileTimeAssertionChecks_DNS_SD

--- a/vcnet/regex/regcomp.c
+++ b/vcnet/regex/regcomp.c
@@ -448,7 +448,7 @@ int starordinary;		/* is a leading * an ordinary character? */
 	register sopno subno;
 #	define	BACKSL	(1<<CHAR_BIT)
 
-	pos = HERE();		/* repetion op, if any, covers from here */
+	pos = HERE();		/* repetition op, if any, covers from here */
 
 	assert(MORE());		/* caller should have ensured this */
 	c = GETNEXT();


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.ps,./templates/da,./templates/pt_BR,./templates/de,./templates/es,./templates/fr,./doc/pt_BR,./doc/da,./doc/de,./doc/es -L bale,dashs,flate,numer,stil,varius`