### PR TITLE
Fix drowning of minor_status code when accepting GSSAPI security context

### DIFF
--- a/scheduler/auth.c
+++ b/scheduler/auth.c
@@ -717,7 +717,8 @@ cupsdAuthorize(cupsd_client_t *con)	/* I - Client connection */
     int			len;		/* Length of authorization string */
     gss_ctx_id_t	context;	/* Authorization context */
     OM_uint32		major_status,	/* Major status code */
-			minor_status;	/* Minor status code */
+			minor_status,	/* Minor status code */
+			tmp_status;	/* Temporary status code */
     gss_buffer_desc	input_token = GSS_C_EMPTY_BUFFER,
 					/* Input token from string */
 			output_token = GSS_C_EMPTY_BUFFER;
@@ -781,7 +782,7 @@ cupsdAuthorize(cupsd_client_t *con)	/* I - Client connection */
 					  NULL);
 
     if (output_token.length > 0)
-      gss_release_buffer(&minor_status, &output_token);
+      gss_release_buffer(&tmp_status, &output_token);
 
     if (GSS_ERROR(major_status))
     {


### PR DESCRIPTION
Fix drowing out of the GSSAPI minor_status code when accepting GSSAPI security context. This fixes the issue during GSSAPI (Kerbos) negotation in case the server is misconfigured. Without the patch, cupsd reports
```
  Error accepting GSSAPI security context.: Unspecified GSS failure.  Minor code may provide more information, Unknown error 
```
With the patch, the true GSSAPI error is printed:
```
  Error accepting GSSAPI security context.: Unspecified GSS failure.  Minor code may provide more information, Request ticket server host/host.example.nl@EXAMPLE.COM kvno 6 not found in keytab; keytab is likely out of date
```





Signed-off-by: Jan Just Keijser <jan.just.keijser@gmail.com>