### PR TITLE
Printer list

### DIFF
--- a/scheduler/auth.c
+++ b/scheduler/auth.c
@@ -717,7 +717,8 @@ cupsdAuthorize(cupsd_client_t *con)	/* I - Client connection */
     int			len;		/* Length of authorization string */
     gss_ctx_id_t	context;	/* Authorization context */
     OM_uint32		major_status,	/* Major status code */
-			minor_status;	/* Minor status code */
+			minor_status,	/* Minor status code */
+			tmp_status;	/* Temporary status code */
     gss_buffer_desc	input_token = GSS_C_EMPTY_BUFFER,
 					/* Input token from string */
 			output_token = GSS_C_EMPTY_BUFFER;
@@ -781,7 +782,7 @@ cupsdAuthorize(cupsd_client_t *con)	/* I - Client connection */
 					  NULL);
 
     if (output_token.length > 0)
-      gss_release_buffer(&minor_status, &output_token);
+      gss_release_buffer(&tmp_status, &output_token);
 
     if (GSS_ERROR(major_status))
     {


### PR DESCRIPTION
## Add support for filtering the list of printers on the client side

When a cups server has hundreds of printers defined, each client-side operation becomes very slow, as the full list of printers is queried from the server for almost **every** operation. Also, the list of printers presented to the user becomes far too long, e.g. in GUI-based programs such as LibreOffice.

With this patch, a user can list a set of printers that {s}he wants to queried. This list can be specified using either an environment variable
`` export CUPS_PRINTER_LIST="printer1, printer2, printer3"
``
or by adding a line to the `~/.cups/lpoptions` file
``
  printer-list  printer1, printer2, printer3
``

Please note that the list of printers can either be comma-separated or space-separated.
