### PR TITLE
Fix up final bitwise operation

### DIFF
--- a/backend/ieee1284.c
+++ b/backend/ieee1284.c
@@ -157,7 +157,7 @@ backendGetDeviceID(
       * bytes.  The 1284 spec says the length is stored MSB first...
       */
 
-      length = (int)((((unsigned)device_id[0] & 255) << 8) + ((unsigned)device_id[1] & 255));
+      length = (int)((((unsigned)device_id[0] & 255) << 8) | ((unsigned)device_id[1] & 255));
 
      /*
       * Check to see if the length is larger than our buffer; first
@@ -166,7 +166,7 @@ backendGetDeviceID(
       */
 
       if (length > device_id_size || length < 14)
-	length = (int)((((unsigned)device_id[1] & 255) << 8) + ((unsigned)device_id[0] & 255));
+	length = (int)((((unsigned)device_id[1] & 255) << 8) | ((unsigned)device_id[0] & 255));
 
       if (length > device_id_size)
 	length = device_id_size;

--- a/cups/dest-options.c
+++ b/cups/dest-options.c
@@ -1620,7 +1620,7 @@ cups_collection_string(
 		  const ipp_uchar_t *date = ippGetDate(member, j);
 					/* Date value */
 
-		  year = ((unsigned)date[0] << 8) + (unsigned)date[1];
+		  year = ((unsigned)date[0] << 8) | (unsigned)date[1];
 
 		  if (date[9] == 0 && date[10] == 0)
 		    snprintf(temp, sizeof(temp), "%04u-%02u-%02uT%02u:%02u:%02uZ", year, date[2], date[3], date[4], date[5], date[6]);

--- a/cups/ipp-support.c
+++ b/cups/ipp-support.c
@@ -742,7 +742,7 @@ ippAttributeString(
           {
             unsigned year;		/* Year */
 
-            year = ((unsigned)val->date[0] << 8) + (unsigned)val->date[1];
+            year = ((unsigned)val->date[0] << 8) | (unsigned)val->date[1];
 
 	    if (val->date[9] == 0 && val->date[10] == 0)
 	      snprintf(temp, sizeof(temp), "%04u-%02u-%02uT%02u:%02u:%02uZ",

--- a/cups/md5.c
+++ b/cups/md5.c
@@ -131,8 +131,8 @@ _cups_md5_process(_cups_md5_state_t *pms, const unsigned char *data /*[64]*/)
     int i;
 
     for (i = 0; i < 16; ++i, xp += 4)
-	X[i] = (unsigned)xp[0] + ((unsigned)xp[1] << 8) +
-	       ((unsigned)xp[2] << 16) + ((unsigned)xp[3] << 24);
+	X[i] = (unsigned)xp[0] | ((unsigned)xp[1] << 8) |
+	       ((unsigned)xp[2] << 16) | ((unsigned)xp[3] << 24);
 
 #  else  /* !ARCH_IS_BIG_ENDIAN */
 

--- a/scheduler/cert.c
+++ b/scheduler/cert.c
@@ -434,9 +434,12 @@ ctcompare(const char *a,		/* I - First string */
     b ++;
   }
 
-  // either both *a and *b == '\0', or one points inside a string,
-  // so factor that in.
-  result |= (*a ^ *b);
+  /*
+  * The while loop finishes when *a == '\0' or *b == '\0'
+  * so after the while loop either both *a and *b == '\0',
+  * or one points inside a string, so when we apply bitwise OR on *a,
+  * *b and result, we get a non-zero return value if the compared strings don't match.
+  */
 
-  return (result);
+  return (result | *a | *b);
 }


### PR DESCRIPTION
The final operation should be a bitwise OR, not bitwise XOR, because this matches the current CUPS, and is slightly faster too.