### PR TITLE
[Mistake Bug-Fix]: Fix cupsfilter by setting both array elements to -1

### DIFF
--- a/scheduler/cupsfilter.c
+++ b/scheduler/cupsfilter.c
@@ -1126,7 +1126,7 @@ exec_filters(mime_type_t   *srctype,	/* I - Source type */
       close(filterfds[1 - current][1]);
 
       filterfds[1 - current][0] = -1;
-      filterfds[1 - current][0] = -1;
+      filterfds[1 - current][1] = -1;
     }
 
     if (next)


### PR DESCRIPTION
Right now, we set filterfds[1 - current][0] = -1; twice, when we should set filterfds[1 - current][1] to -1 as well