### PR TITLE
Change strncmp parameter

### DIFF
--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -3822,7 +3822,7 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
 
 	PRINTF_COLOROPTION("Gray16", _("Deep Gray"), CUPS_CSPACE_SW, 16)
       }
-      else if (!strcasecmp(keyword, "srgb_8") || !strncmp(keyword, "SRGB24", 7) || !strcmp(keyword, "color"))
+      else if (!strcasecmp(keyword, "srgb_8") || !strncmp(keyword, "SRGB24", 6) || !strcmp(keyword, "color"))
       {
 	PRINTF_COLORMODEL
 


### PR DESCRIPTION
Otherwise we are just comparing the entire string, which is pointless, since the "urf-supported" keyword potentially might contain "SRGB24" or "SRGB24-48"