### PR TITLE
Fix jumbotron margin

### DIFF
--- a/css/cups.css
+++ b/css/cups.css
@@ -132,7 +132,7 @@ DIV.jumbotron {
   background: #444;
   border-radius: 0;
   color: white;
-  margin: -3px -20px 20px;
+  margin: -3px -0.75rem 20px;
   padding: 20px 30px 20px;
 }
 


### PR DESCRIPTION
Fixes the jumbotron creating a horizontal scrollbar on the website

`0.75rem` is the padding applied to the container so we have to negate that hence the `-0.75rem`