### PR TITLE
job.c: remove the repeated getting time-at-creation in function cupsdLoadJob

### DIFF
--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -1698,7 +1698,7 @@ cupsdLoadJob(cupsd_job_t *job)		/* I - Job */
   * Copy attribute data to the job object...
   */
 
-  if (!ippFindAttribute(job->attrs, "time-at-creation", IPP_TAG_INTEGER))
+  if ((attr = ippFindAttribute(job->attrs, "time-at-creation", IPP_TAG_INTEGER)) == NULL)
   {
     cupsdLogJob(job, CUPSD_LOG_ERROR,
 		"Missing or bad time-at-creation attribute in control file.");
@@ -1716,9 +1716,7 @@ cupsdLoadJob(cupsd_job_t *job)		/* I - Job */
   job->state_value  = (ipp_jstate_t)job->state->values[0].integer;
   job->file_time    = 0;
   job->history_time = 0;
-
-  if ((attr = ippFindAttribute(job->attrs, "time-at-creation", IPP_TAG_INTEGER)) != NULL)
-    job->creation_time = attr->values[0].integer;
+  job->creation_time = attr->values[0].integer;
 
   if (job->state_value >= IPP_JOB_CANCELED && (attr = ippFindAttribute(job->attrs, "time-at-completed", IPP_TAG_INTEGER)) != NULL)
   {


### PR DESCRIPTION
Fixes: #6212 

Signed-off-by: YiLin.Li <YiLin.Li@linux.alibaba.com>